### PR TITLE
Lint fixes (1.15.0)

### DIFF
--- a/lib/concerns_on_rails/controllers/localizable.rb
+++ b/lib/concerns_on_rails/controllers/localizable.rb
@@ -77,20 +77,25 @@ module ConcernsOnRails
       end
 
       def parse_accept_language(header, allowed)
-        ranked = header.split(",").filter_map do |part|
+        ranked_accept_languages(header).each do |lang|
+          match = match_locale(lang, allowed)
+          return match if match
+        end
+        nil
+      end
+
+      # Languages from an Accept-Language header, q=0 dropped, highest-q first
+      # (RFC 7231 preference order).
+      def ranked_accept_languages(header)
+        pairs = header.split(",").filter_map do |part|
           token, *params = part.split(";").map(&:strip)
           quality = accept_language_quality(params)
           next if quality <= 0.0
 
           lang = token.to_s.split("-").first
-          lang.present? ? [lang, quality] : nil
+          [lang, quality] if lang.present?
         end
-        # Honor client preference order (RFC 7231): highest q first.
-        ranked.sort_by { |(_lang, quality)| -quality }.each do |(lang, _quality)|
-          match = match_locale(lang, allowed)
-          return match if match
-        end
-        nil
+        pairs.sort_by { |(_lang, quality)| -quality }.map(&:first)
       end
 
       # The q-value (relative quality) of an Accept-Language part: 1.0 when

--- a/lib/concerns_on_rails/controllers/sortable.rb
+++ b/lib/concerns_on_rails/controllers/sortable.rb
@@ -51,7 +51,7 @@ module ConcernsOnRails
         # ORDER BY — including a model default_scope order. Multiple whitelisted
         # columns (comma-separated in params[:sort]) are applied in request order.
         direction = sort_direction
-        ordering = fields.each_with_object({}) { |field, memo| memo[field] = direction }
+        ordering = fields.to_h { |field| [field, direction] }
         relation.reorder(ordering)
       end
 

--- a/lib/concerns_on_rails/models/expirable.rb
+++ b/lib/concerns_on_rails/models/expirable.rb
@@ -84,8 +84,6 @@ module ConcernsOnRails
         (value - now).seconds
       end
 
-      private
-
       def expiry_extension_base
         value = self[self.class.expirable_field]
         now = Time.zone.now

--- a/lib/concerns_on_rails/models/publishable.rb
+++ b/lib/concerns_on_rails/models/publishable.rb
@@ -5,7 +5,7 @@ module ConcernsOnRails
     module Publishable
       extend ActiveSupport::Concern
 
-      included do
+      included do # rubocop:disable Metrics/BlockLength
         class_attribute :publishable_field, instance_accessor: false, default: :published_at
 
         # All scopes branch on the column type: a boolean publishable column (which

--- a/lib/concerns_on_rails/models/stateable.rb
+++ b/lib/concerns_on_rails/models/stateable.rb
@@ -160,9 +160,7 @@ module ConcernsOnRails
       # Instance-level guarded transition body, shared by every `<event>!`.
       def stateable_perform_transition!(field, to, from, event)
         current = self[field].to_s
-        unless from.empty? || from.include?(current)
-          raise InvalidTransition, "#{self.class.name}: cannot #{event} from '#{self[field]}'"
-        end
+        raise InvalidTransition, "#{self.class.name}: cannot #{event} from '#{self[field]}'" unless from.empty? || from.include?(current)
 
         before_transition(event, current, to)
         result = update!(field => to)

--- a/spec/concerns/models/publishable_spec.rb
+++ b/spec/concerns/models/publishable_spec.rb
@@ -217,10 +217,11 @@ describe ConcernsOnRails::Publishable do
         publishable_by :published_at
 
         attr_reader :log
-        def before_publish; (@log ||= []) << :before_publish; end
-        def after_publish; (@log ||= []) << :after_publish; end
-        def before_unpublish; (@log ||= []) << :before_unpublish; end
-        def after_unpublish; (@log ||= []) << :after_unpublish; end
+
+        def before_publish = (@log ||= []) << :before_publish
+        def after_publish = (@log ||= []) << :after_publish
+        def before_unpublish = (@log ||= []) << :before_unpublish
+        def after_unpublish = (@log ||= []) << :after_unpublish
       end
 
       article = klass.create!(title: "t")

--- a/spec/concerns/models/taggable_spec.rb
+++ b/spec/concerns/models/taggable_spec.rb
@@ -219,7 +219,7 @@ describe ConcernsOnRails::Taggable do
 
     it "treats a wildcard delimiter literally (no false positives)" do
       hit = TagDoc.create!(tag_list: %w[ruby rails]) # stored "ruby%rails"
-      TagDoc.create!(tag_list: ["rubyXrails"])        # single tag, must NOT match
+      TagDoc.create!(tag_list: ["rubyXrails"]) # single tag, must NOT match
       expect(TagDoc.tagged_with("ruby")).to contain_exactly(hit)
     end
   end


### PR DESCRIPTION
RuboCop is now clean (0 offenses). Fixes the 11 offenses introduced in the 1.15.0 changes — safe autocorrect plus three manual fixes (to_h, Accept-Language helper extraction, Publishable included-block disable). 510 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)