### PR TITLE
1.27.0: scope affixing + batch operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,72 @@
 <!-- CHANGELOG.md -->
 
+## 1.27.0 (2026-08-29)
+
+Scope-name collisions finally have an escape hatch on every concern that
+generates scopes, and the 1.22 batch-operation contract reaches five more
+concerns. No new columns, migrations or dependencies. 1245 examples, 0
+failures.
+
+### Added
+- **Models::Publishable / SoftDeletable / Schedulable**: `prefix:`/`suffix:` on
+  `publishable_by` / `soft_deletable_by` / `schedulable_by` rename the generated
+  scopes, so a model can include SoftDeletable (`.active`) alongside Activatable
+  or Expirable (also `.active`) without one silently clobbering the other. With
+  no affix passed the scope names, default scopes and emitted SQL are unchanged.
+  `prefix: true` (use the configured field name), previously honoured only by
+  Stateable, now works on every affixing concern.
+- **Models::Publishable**: `publish_all` / `unpublish_all`. `publish_all` targets
+  every not-currently-published row — *including scheduled ones*, whose future
+  timestamp it overwrites; chain the draft scope (`Post.draft.publish_all`) to
+  narrow it. Both respect the relation, return an Integer count, and run in a
+  transaction.
+- **Models::Expirable**: `expire_all(time = Time.zone.now)`.
+- **Models::Activatable**: `activate_all` / `deactivate_all`.
+- **Models::Lockable**: `unlock_expired` — clears `locked_at` and zeroes the
+  attempts counter on every row whose `unlock_in` window has elapsed, mirroring
+  `unlock_access!`. Returns 0 without querying when `unlock_in` is nil.
+- **Models::Stateable**: `transition_all(event)` — runs one declared transition
+  across the relation, skipping (not failing) records the guard rejects.
+  Deliberately has no single-UPDATE fast path: the per-record path runs
+  validations through `update!` and a bulk UPDATE would skip them.
+
+### Notes
+Validation semantics of the new batch verbs (`publish_all`, `unpublish_all`,
+`expire_all`, `activate_all`, `deactivate_all`, `unlock_expired`): each
+collapses to a **single `UPDATE`** — one SQL statement for the whole batch —
+only when the host model declares **no validations** (and has overridden
+none of the concern's hooks/bang methods; see the per-concern docs for the
+exact method list). `unlock_expired` is exempt from the validators check
+because `unlock_access!` writes via `update_columns`, which always skips
+validations, so its two paths are already equivalent. On a model with
+`validates`, every one of these verbs instead streams the relation
+record-by-record inside a transaction, calling the same guarded bang/update
+method a single record would use; a record that fails to save raises
+`ActiveRecord::RecordNotSaved` and rolls the **entire batch** back — nothing
+partially commits. `transition_all` always takes the per-record path,
+regardless of validators, for the same reason. One residual, deliberate
+divergence survives on the fast path: like every `*_all` method in Rails,
+the single-UPDATE path does not fire host-defined `before_save`/`after_save`
+callbacks (only the concern's own `before_*`/`after_*` lifecycle hooks are
+checked when deciding whether the fast path applies at all). If your model
+relies on `before_save`/`after_save` for side effects, either add a
+validation (forcing the slow, per-record path) or call the bang method in a
+loop.
+
+### Internal
+- New `Support::Affix` (affixed-name computation, `prefix: true` normalization,
+  and the guarded scope capture/retirement used by the three newly affixable
+  concerns) replaces six duplicated implementations across Activatable,
+  Expirable, Lockable, Anonymizable, Stateable and Storable.
+- New `Support::BatchOps` (hook-ownership fast-path predicate + the
+  transactional `find_each` runner); SoftDeletable's `soft_delete_all` /
+  `restore_all` now route through it, so the contract has one definition.
+- Retiring a default-named scope is guarded three ways — the name must have been
+  recorded by the concern, be owned by the class's own singleton, and still be
+  the exact method captured — so a model's own override survives and a parent's
+  scopes are never removed from a subclass (that case raises with a pointer to
+  the parent).
+
 ## 1.26.0 (2026-08-24)
 
 A fixes-and-performance round from a full audit of the 25 model concerns: one privacy bug (Anonymizable left Encryptable blind-index fingerprints queryable after erasure), four silent-misbehavior fixes, five query-count reductions, and three hardening changes. No new concerns. 1173 examples, 0 failures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ exact method list). "No validations" means neither `validates` /
 `validates_with` **nor** a custom `validate :method` / `validate do … end` —
 the latter registers only a validate callback and leaves `validators` empty,
 so it is detected through `_validate_callbacks` rather than `validators`.
+It also means **no association carrying the default autosave validation**: a
+bare `has_many`/`has_one` registers a `validate_associated_records_*` callback,
+so in practice most models with associations take the streaming per-record
+path. That is deliberate — the gate errs toward the path that honours the
+rollback contract — but it means the single-`UPDATE` optimisation applies to
+simple models, not to every model that merely omits `validates`.
 `unlock_expired` is exempt from the validations check because
 `unlock_access!` writes via `update_columns`, which always skips validations,
 so its two paths are already equivalent. On a model that declares any

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Scope-name collisions finally have an escape hatch on the eight concerns whose
 generated scope names can collide (Activatable, Expirable, Lockable, Stateable
 and Anonymizable already had it; Publishable, SoftDeletable and Schedulable
 join them here), and the 1.22 batch-operation contract reaches five more
-concerns. No new columns, migrations or dependencies. 1245 examples, 0
+concerns. No new columns, migrations or dependencies. 1257 examples, 0
 failures.
 
 ### Added
@@ -20,7 +20,12 @@ failures.
 - **Models::Publishable**: `publish_all` / `unpublish_all`. `publish_all` targets
   every not-currently-published row — *including scheduled ones*, whose future
   timestamp it overwrites; chain the draft scope (`Post.draft.publish_all`) to
-  narrow it. Both respect the relation, return an Integer count, and run in a
+  narrow it, which composes because the predicate is built against the current
+  relation rather than routed through the field-unscoping `unpublished` scope.
+  The flip side: on a model with `default_scope: true` the relation is already
+  narrowed to published rows, so a bare `Post.publish_all` matches nothing —
+  chain `.draft` or `.unpublished` (both unscope the column themselves). Both
+  verbs respect the relation, return an Integer count, and run in a
   transaction.
 - **Models::Expirable**: `expire_all(time = Time.zone.now)`.
 - **Models::Activatable**: `activate_all` / `deactivate_all`.
@@ -38,15 +43,26 @@ Validation semantics of the new batch verbs (`publish_all`, `unpublish_all`,
 collapses to a **single `UPDATE`** — one SQL statement for the whole batch —
 only when the host model declares **no validations** (and has overridden
 none of the concern's hooks/bang methods; see the per-concern docs for the
-exact method list). `unlock_expired` is exempt from the validators check
-because `unlock_access!` writes via `update_columns`, which always skips
-validations, so its two paths are already equivalent. On a model with
-`validates`, five of these verbs (`publish_all`, `unpublish_all`, `expire_all`,
+exact method list). "No validations" means neither `validates` /
+`validates_with` **nor** a custom `validate :method` / `validate do … end` —
+the latter registers only a validate callback and leaves `validators` empty,
+so it is detected through `_validate_callbacks` rather than `validators`.
+`unlock_expired` is exempt from the validations check because
+`unlock_access!` writes via `update_columns`, which always skips validations,
+so its two paths are already equivalent. On a model that declares any
+validation, five of these verbs (`publish_all`, `unpublish_all`, `expire_all`,
 `activate_all`, `deactivate_all`) instead stream the relation record-by-record
 inside a transaction, calling the same guarded bang/update method a single
 record would use; a record that fails to save raises
 `ActiveRecord::RecordNotSaved` and rolls the **entire batch** back — nothing
 partially commits.
+
+The single-`UPDATE` path writes `updated_at` (`updated_on` too, when present)
+alongside the concern's own column whenever the model has that column and
+`record_timestamps` is on, so the fast and slow paths agree — the same thing
+Rails' `touch_all` and `update_counters(touch:)` do. `unlock_expired` is
+exempt here as well: it mirrors `unlock_access!`, which writes via
+`update_columns` and deliberately does not touch timestamps.
 
 `transition_all` also always takes the per-record path, regardless of
 validators — for the same underlying reason (validations must run) — but its
@@ -71,8 +87,13 @@ or call the bang method in a loop.
   and the guarded scope capture/retirement used by the three newly affixable
   concerns) replaces six duplicated implementations across Activatable,
   Expirable, Lockable, Anonymizable, Stateable and Storable.
-- New `Support::BatchOps` (hook-ownership fast-path predicate + the
-  transactional `find_each` runner); SoftDeletable's `soft_delete_all` /
+- New `Support::BatchOps`: the whole fast-path safety decision
+  (`fast_path?` = hooks/bang methods unoverridden AND no declared validations,
+  detected through both `validators` and `_validate_callbacks`), the
+  ownership-only half (`unoverridden?`, for the two concerns whose per-record
+  path writes via `update_column(s)` and so needs no validations gate), the
+  `updated_at`/`updated_on` bulk-write payload helper (`with_timestamps`), and
+  the transactional `find_each` runner. SoftDeletable's `soft_delete_all` /
   `restore_all` now route through it, so the contract has one definition.
 - Retiring a default-named scope is guarded three ways — the name must have been
   recorded by the concern, be owned by the class's own singleton, and still be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## 1.27.0 (2026-08-29)
 
-Scope-name collisions finally have an escape hatch on every concern that
-generates scopes, and the 1.22 batch-operation contract reaches five more
+Scope-name collisions finally have an escape hatch on the eight concerns whose
+generated scope names can collide (Activatable, Expirable, Lockable, Stateable
+and Anonymizable already had it; Publishable, SoftDeletable and Schedulable
+join them here), and the 1.22 batch-operation contract reaches five more
 concerns. No new columns, migrations or dependencies. 1245 examples, 0
 failures.
 
@@ -39,19 +41,30 @@ none of the concern's hooks/bang methods; see the per-concern docs for the
 exact method list). `unlock_expired` is exempt from the validators check
 because `unlock_access!` writes via `update_columns`, which always skips
 validations, so its two paths are already equivalent. On a model with
-`validates`, every one of these verbs instead streams the relation
-record-by-record inside a transaction, calling the same guarded bang/update
-method a single record would use; a record that fails to save raises
+`validates`, five of these verbs (`publish_all`, `unpublish_all`, `expire_all`,
+`activate_all`, `deactivate_all`) instead stream the relation record-by-record
+inside a transaction, calling the same guarded bang/update method a single
+record would use; a record that fails to save raises
 `ActiveRecord::RecordNotSaved` and rolls the **entire batch** back — nothing
-partially commits. `transition_all` always takes the per-record path,
-regardless of validators, for the same reason. One residual, deliberate
-divergence survives on the fast path: like every `*_all` method in Rails,
-the single-UPDATE path does not fire host-defined `before_save`/`after_save`
-callbacks (only the concern's own `before_*`/`after_*` lifecycle hooks are
-checked when deciding whether the fast path applies at all). If your model
-relies on `before_save`/`after_save` for side effects, either add a
-validation (forcing the slow, per-record path) or call the bang method in a
-loop.
+partially commits.
+
+`transition_all` also always takes the per-record path, regardless of
+validators — for the same underlying reason (validations must run) — but its
+failure mode is different, not the same: the per-record path calls the
+guarded `<event>!`, which calls `update!`, and `update!` raises
+`ActiveRecord::RecordInvalid` **directly** on a validation failure. That
+exception propagates straight out of the batch loop, never reaching the
+`RecordNotSaved` branch the other five verbs use. Code that rescues
+`RecordNotSaved` around a `transition_all` call will not catch a failed row —
+rescue `RecordInvalid` there instead.
+
+One residual, deliberate divergence survives on the fast path: like every
+`*_all` method in Rails, the single-UPDATE path does not fire host-defined
+`before_save`/`after_save` callbacks (only the concern's own
+`before_*`/`after_*` lifecycle hooks are checked when deciding whether the
+fast path applies at all). If your model relies on `before_save`/`after_save`
+for side effects, either add a validation (forcing the slow, per-record path)
+or call the bang method in a loop.
 
 ### Internal
 - New `Support::Affix` (affixed-name computation, `prefix: true` normalization,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,12 +57,16 @@ and may be called multiple times, rather than the `<concern>_by` form.)
   field/direction. `sortable_by :position` / `position: :desc`; `scope:`, `add_new_at:`,
   `use_acts_as_list: false`.
 - **`Publishable`** — timestamp (default `published_at`) **or** boolean column; scopes
-  `.published/.unpublished/.scheduled/.draft` branch on the column type. `default_scope: true`
-  hides unpublished. Lifecycle hooks: `before/after_publish`, `before/after_unpublish`.
+  `.published/.unpublished/.scheduled/.draft` (affixable via `prefix:`/`suffix:`) branch on
+  the column type. `default_scope: true` hides unpublished. Lifecycle hooks:
+  `before/after_publish`, `before/after_unpublish`. Batch `publish_all`/`unpublish_all`
+  (atomic; single-UPDATE fast path when the hooks/bang methods are unoverridden AND the
+  model has no validators — `update` in the per-record path runs them, `update_all` doesn't).
 - **`SoftDeletable`** — timestamp (default `deleted_at`) + `default_scope` hiding deleted
-  rows (opt out with `default_scope: false`). `soft_delete!`/`restore!`, batch
-  `soft_delete_all`/`restore_all` (atomic), `really_destroy_all`/`really_delete!` for hard
-  deletes. Hooks: `before/after_soft_delete`, `before/after_restore`.
+  rows (opt out with `default_scope: false`); scopes affixable via `prefix:`/`suffix:`.
+  `soft_delete!`/`restore!`, batch `soft_delete_all`/`restore_all` (atomic, routed through
+  `Support::BatchOps`), `really_destroy_all`/`really_delete!` for hard deletes. Hooks:
+  `before/after_soft_delete`, `before/after_restore`.
 - **`Hashable`** — one random identifier column. `type:` `:hex`/`:uuid`/`:integer`/`:custom`,
   `length:`, `alphabet:`, `unique:` (retry on collision).
 - **`Tokenizable`** — multiple security-token columns. `type:` `:urlsafe`/`:hex`/
@@ -70,14 +74,17 @@ and may be called multiple times, rather than the `<concern>_by` form.)
 - **`Sequenceable`** — ordered reference numbers (invoice/order numbers). `into:`, `prefix:`,
   `padding:`, `scope:`, `reset:` (`:year`/`:month`/`:day`), `template:`.
 - **`Schedulable`** — start/end window (`starts_at`/`ends_at`); `current`/`upcoming`/`expired`
-  scopes + predicates.
+  scopes (affixable via `prefix:`/`suffix:`) + predicates.
 - **`Expirable`** — single expiry column (default `expires_at`); `active`/`expired`/
-  `expiring_within` scopes (affixable via `prefix:`/`suffix:`).
+  `expiring_within` scopes (affixable via `prefix:`/`suffix:`). Batch `expire_all` (single-
+  UPDATE fast path when `expire!` is unoverridden AND the model has no validators).
 - **`Activatable`** — boolean active flag (default `active`); `active`/`inactive` scopes
-  (affixable via `prefix:`/`suffix:`), `activate!`/`deactivate!`/`toggle_active!`.
+  (affixable via `prefix:`/`suffix:`), `activate!`/`deactivate!`/`toggle_active!`. Batch
+  `activate_all`/`deactivate_all` (same validators-gated fast path as Publishable/Expirable).
 - **`Stateable`** — lightweight string-backed state machine: states, `default:`,
   `transitions:`, `prefix:`/`suffix:`; guarded `<event>!` + `may_<event>?`,
-  `before/after_transition` hooks.
+  `before/after_transition` hooks. Batch `transition_all(event)` — deliberately NO fast path,
+  since the per-record path runs validations via `update!` and `update_all` would skip them.
 - **`Searchable`** — LIKE search across columns via Arel `matches`. `mode:` `:any`/`:all`,
   `match:` `:contains`/`:prefix`/`:exact`, `case_sensitive:` (Postgres only).
 - **`Normalizable`** — `before_validation` normalization. Presets (`:email`, `:phone`,
@@ -98,7 +105,9 @@ and may be called multiple times, rather than the `<concern>_by` form.)
   `lockable_by attempts:, locked_at:, max_attempts:, unlock_in:, prefix:/suffix:`;
   `register_failed_attempt!` (atomic SQL increment), `access_locked?` (lazy expiry),
   `lock_access!`/`unlock_access!` (update_columns + before/after hooks),
-  `reset_failed_attempts!`; expiry-aware `.locked`/`.unlocked` scopes.
+  `reset_failed_attempts!`; expiry-aware `.locked`/`.unlocked` scopes. Batch
+  `unlock_expired` (mirrors `unlock_access!`; no validators gate needed since
+  `update_columns` already skips them; returns 0 without a query when `unlock_in` is nil).
 - **`Aliasable`** — full association aliasing: `alias_association :new, :old`
   (alias_method argument order, repeatable, declared after the source). Read/write/
   build_/create_/ids delegators + a renamed reflection copy so joins/includes/
@@ -224,7 +233,17 @@ query-param coercion shared by the paginators/Filterable), `UniqueRetry` (bounde
 renderer used by seven controller concerns), `FilterParameterRegistry` (live
 filter_parameters registry consulted by the proc `ConcernsOnRails::Railtie` appends at
 boot), `Encryptor` (AES-256-GCM codec with a bounded PBKDF2 key cache), `RandomValue`,
-`SequenceCalculator`, `HtmlSanitizers`, `Masker`, `Money`, `AddressData`.
+`SequenceCalculator`, `HtmlSanitizers`, `Masker`, `Money`, `AddressData`, `Affix` (affixed
+scope/accessor-name computation + `prefix: true` normalization, shared by Activatable,
+Expirable, Lockable, Anonymizable, Stateable, Storable, Publishable, SoftDeletable and
+Schedulable; the latter three additionally use its guarded scope capture/retirement — a
+captured default-named scope is only retired when it's still recorded, still owned by the
+class's own singleton, and still the exact method captured, so an overridden scope survives
+and a subclass never rips a scope out from under its parent), `BatchOps` (the hook-ownership
+fast-path predicate — every named instance method still owned by the concern, i.e.
+unoverridden — plus the transactional `find_each` batch runner shared by every `*_all` verb:
+Integer count, DB-side filtering for idempotency, rollback via `ActiveRecord::RecordNotSaved`
+on a failed record).
 `lib/concerns_on_rails/railtie.rb` loads only when `Rails::Railtie` is defined.
 
 ### Test structure

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    concerns_on_rails (1.26.0)
+    concerns_on_rails (1.27.0)
       actionpack (>= 5.0, < 9)
       activerecord (>= 5.0, < 9)
       activesupport (>= 5.0, < 9)

--- a/README.md
+++ b/README.md
@@ -368,11 +368,18 @@ Post.published.unpublish_all # unpublishes every currently-published post; retur
 Both respect the current relation, return an Integer count, and run in a transaction — a
 record that fails to save raises `ActiveRecord::RecordNotSaved` and rolls the whole batch
 back. With no overridden `before_publish`/`after_publish`/`before_unpublish`/`after_unpublish`/
-`publish!`/`unpublish!` and no `validates` on the model, both collapse to a single `UPDATE`;
-otherwise they stream per record through `publish!`/`unpublish!` so validations still run.
-`publish_all` targets every not-currently-published row — **including scheduled ones**,
-whose future `published_at` it overwrites — so chain `.draft` (`Post.draft.publish_all`) to
-exclude them.
+`publish!`/`unpublish!` and no validations on the model — neither `validates`/`validates_with`
+nor a custom `validate :method` — both collapse to a single `UPDATE`, which bumps `updated_at`
+exactly as the per-record path does; otherwise they stream per record through
+`publish!`/`unpublish!` so validations still run.
+
+`publish_all` targets every not-currently-published row — **including scheduled ones**, whose
+future `published_at` it overwrites — so chain `.draft` (`Post.draft.publish_all`) to exclude
+them. Its predicate composes with your own constraint on the publish column, so that chain
+really does leave scheduled rows alone. The flip side of composing: with `default_scope: true`
+the relation is already narrowed to published rows, so a bare `Post.publish_all` matches
+nothing — chain `.draft` or `.unpublished` first (both unscope the column themselves, so the
+chain resolves to the rows you mean).
 
 **Scope-name collisions**
 
@@ -629,10 +636,11 @@ ApiToken.expiring_within(1.day).expire_all   # => 12
 ```
 
 `expire_all(time = Time.zone.now)` expires every currently-active record in the relation and
-returns the Integer count, in a transaction. With `expire!` unoverridden and no `validates` on
-the model it collapses to a single `UPDATE`; otherwise it streams per record through `expire!`
-so validations still run, and a record that fails to save raises `ActiveRecord::RecordNotSaved`
-and rolls the whole batch back.
+returns the Integer count, in a transaction. With `expire!` unoverridden and no validations on
+the model — neither `validates`/`validates_with` nor a custom `validate :method` — it collapses
+to a single `UPDATE`, which bumps `updated_at` exactly as the per-record path does; otherwise it
+streams per record through `expire!` so validations still run, and a record that fails to save
+raises `ActiveRecord::RecordNotSaved` and rolls the whole batch back.
 
 **Custom field name**
 
@@ -749,10 +757,12 @@ Subscription.active.deactivate_all     # => 3
 ```
 
 Both target the relation, return an Integer count, and run in a transaction. With
-`activate!`/`deactivate!` unoverridden and no `validates` on the model they collapse to a
-single `UPDATE`; otherwise they stream per record so validations still run, and a record that
-fails to save raises `ActiveRecord::RecordNotSaved` and rolls the whole batch back.
-`toggle_active!`'s row lock has no batch analogue.
+`activate!`/`deactivate!` unoverridden and no validations on the model — neither
+`validates`/`validates_with` nor a custom `validate :method` — they collapse to a single
+`UPDATE`, which bumps `updated_at` exactly as the per-record path does; otherwise they stream
+per record so validations still run, and a record that fails to save raises
+`ActiveRecord::RecordNotSaved` and rolls the whole batch back. `toggle_active!`'s row lock has
+no batch analogue.
 
 **Notes**
 - `NULL` is treated as inactive (same convention as most apps' "unset = off").

--- a/README.md
+++ b/README.md
@@ -358,6 +358,49 @@ publishable_by :published_at, default_scope: true
 # Article.unscoped reaches everything
 ```
 
+**Bulk operations**
+
+```ruby
+Post.draft.publish_all       # publishes every not-currently-published post; returns the count
+Post.published.unpublish_all # unpublishes every currently-published post; returns the count
+```
+
+Both respect the current relation, return an Integer count, and run in a transaction — a
+record that fails to save raises `ActiveRecord::RecordNotSaved` and rolls the whole batch
+back. With no overridden `before_publish`/`after_publish`/`before_unpublish`/`after_unpublish`/
+`publish!`/`unpublish!` and no `validates` on the model, both collapse to a single `UPDATE`;
+otherwise they stream per record through `publish!`/`unpublish!` so validations still run.
+`publish_all` targets every not-currently-published row — **including scheduled ones**,
+whose future `published_at` it overwrites — so chain `.draft` (`Post.draft.publish_all`) to
+exclude them.
+
+**Scope-name collisions**
+
+```ruby
+publishable_by :published_at, prefix: :article   # => Article.article_published / .article_draft
+publishable_by :published_at, suffix: :posts     # => Article.published_posts / .draft_posts
+publishable_by :published_at, prefix: true       # => Article.published_at_published / ...
+```
+
+`prefix:`/`suffix:` rename every scope `publishable_by` generates, so a model can include
+Publishable alongside another concern that would otherwise generate a same-named scope
+(SoftDeletable and Activatable also define `.active`, for instance) without one clobbering
+the other. With no affix passed, scope names, the optional default scope, and the emitted
+SQL are all unchanged.
+
+`prefix:`/`suffix:` mean three different things across the gem, depending on the concern:
+- **Scope-name affix** (renames generated scopes) — Activatable, Expirable, Lockable,
+  Stateable, Anonymizable, Publishable, SoftDeletable, Schedulable.
+- **Accessor-name affix** (renames generated reader/writer methods) — Storable.
+- **A literal string prepended to the generated value itself** — Sequenceable's `prefix:`
+  (e.g. `"INV-"`), unrelated to scope/method naming.
+
+Passing `true` for a scope- or accessor-name affix means "use the configured field name"
+(`publishable_by :published_at, prefix: true` → `published_at_published`/`published_at_draft`).
+
+Unrelated to all three: Searchable's `match: :prefix` is a LIKE-match mode (`term%`), not a
+naming affix.
+
 **Notes**
 - "Published" means `published_at` is set **and** in the past — so future-dated posts stay unpublished until their time arrives.
 - No `default_scope` is added by default; chain `.published` explicitly (or opt in with `default_scope: true`).
@@ -411,6 +454,21 @@ batch back. With `touch: false` and no overridden hooks, `soft_delete_all` / `re
 collapse to a single `UPDATE`. Note that `really_destroy_all` peels the soft-delete
 predicate off the relation, so `only_deleted.really_destroy_all` widens to the whole
 relation — purge trash with `User.soft_deleted.delete_all` instead.
+
+**Scope-name collisions**
+
+```ruby
+soft_deletable_by :deleted_at, prefix: :account   # => .account_active / .account_soft_deleted / ...
+soft_deletable_by :deleted_at, suffix: :records    # => .active_records / .soft_deleted_records / ...
+soft_deletable_by :deleted_at, prefix: true        # => .deleted_at_active / ...
+```
+
+`prefix:`/`suffix:` rename every scope `soft_deletable_by` generates (`active`,
+`without_deleted`, `soft_deleted`, `only_deleted`, `with_deleted`, `deleted_within`), so a
+model can combine SoftDeletable with another concern that also defines `.active` (Activatable,
+Expirable) without a collision. `prefix: true` uses the configured field name. With no affix
+passed, scope names, the default scope, and the emitted SQL are unchanged. See the
+Publishable section above for how `prefix:`/`suffix:` differ across the gem.
 
 **Lifecycle hooks** — override these methods on the model:
 
@@ -512,6 +570,18 @@ promo.reschedule!(starts_at: 1.day.from_now,
                   ends_at:   2.days.from_now)
 ```
 
+**Scope-name collisions**
+
+```ruby
+schedulable_by prefix: :promo    # => .promo_current / .promo_upcoming / .promo_expired / .promo_active_at
+schedulable_by suffix: :window   # => .current_window / .upcoming_window / .expired_window / .active_at_window
+schedulable_by prefix: true      # => .starts_at_current / ... (the configured starts_at/ends_at field)
+```
+
+`prefix:`/`suffix:` rename every scope `schedulable_by` generates (`active_at`, `current`,
+`upcoming`, `expired`). With no affix passed, scope names and the emitted SQL are unchanged.
+See the Publishable section above for how `prefix:`/`suffix:` differ across the gem.
+
 **Notes**
 - Boundary semantics: **inclusive start, exclusive end** — active at exactly `starts_at`, not at exactly `ends_at`.
 - A `nil` end means "never expires"; a `nil` start means "not yet started".
@@ -551,6 +621,18 @@ token.extend_expiry!(by: 1.day)     # pushes expiry forward
 `extend_expiry!` is smart about the base:
 - If `expires_at` is `nil` or in the past → new value is `now + by`
 - If `expires_at` is still in the future → `by` is added to the existing value
+
+**Bulk operations**
+
+```ruby
+ApiToken.expiring_within(1.day).expire_all   # => 12
+```
+
+`expire_all(time = Time.zone.now)` expires every currently-active record in the relation and
+returns the Integer count, in a transaction. With `expire!` unoverridden and no `validates` on
+the model it collapses to a single `UPDATE`; otherwise it streams per record through `expire!`
+so validations still run, and a record that fails to save raises `ActiveRecord::RecordNotSaved`
+and rolls the whole batch back.
 
 **Custom field name**
 
@@ -658,6 +740,19 @@ sub.toggle_active!     # flips back to true
 Subscription.active     # WHERE active = TRUE
 Subscription.inactive   # WHERE active = FALSE OR active IS NULL
 ```
+
+**Bulk operations**
+
+```ruby
+Subscription.inactive.activate_all     # => 12
+Subscription.active.deactivate_all     # => 3
+```
+
+Both target the relation, return an Integer count, and run in a transaction. With
+`activate!`/`deactivate!` unoverridden and no `validates` on the model they collapse to a
+single `UPDATE`; otherwise they stream per record so validations still run, and a record that
+fails to save raises `ActiveRecord::RecordNotSaved` and rolls the whole batch back.
+`toggle_active!`'s row lock has no batch analogue.
 
 **Notes**
 - `NULL` is treated as inactive (same convention as most apps' "unset = off").
@@ -804,6 +899,18 @@ article.may_publish?           # => true  (guard check without raising)
 
 article.transition_to!(:archived)  # generic move to any declared state
 ```
+
+**Bulk operations**
+
+```ruby
+Article.draft.transition_all(:publish)   # => 12 — runs :publish across every eligible row
+```
+
+Returns the Integer count of records transitioned, running in a transaction; records the
+guard rejects are skipped (not errors). Unlike every other batch verb in this gem,
+`transition_all` has **no single-UPDATE fast path** — it always streams per record through
+the guarded `<event>!` method, because that path runs validations via `update!` while a bulk
+`update_all` would silently skip them.
 
 **Prefix / suffix** — avoid clashes when the state names overlap with other concerns or scopes:
 
@@ -1094,9 +1201,20 @@ user.reset_failed_attempts!     # call on successful login
 user.lock_access!               # manual lock     (hooks: before/after_lock)
 user.unlock_access!             # manual unlock   (hooks: before/after_unlock)
 User.locked / User.unlocked     # expiry-aware scopes
+
+User.unlock_expired              # => 3 — unlocks every row whose unlock_in window has elapsed
 ```
 
 **Options**: `attempts:` (`:failed_attempts`, must be an integer column), `locked_at:` (`:locked_at`, datetime column), `max_attempts:` (`5`; `nil` = count but never auto-lock), `unlock_in:` (`nil` = locked until manual unlock; a duration makes the lock lapse by itself), `prefix:` / `suffix:` (affix the scope names).
+
+**Bulk operations**
+
+`unlock_expired` clears `locked_at` and zeroes the attempts counter on every row whose
+`locked_at + unlock_in` has passed, exactly as `unlock_access!` does — returns the Integer
+count, runs in a transaction. Returns `0` without querying when `unlock_in` is `nil` (manual
+unlock only). Because `unlock_access!` persists via `update_columns` (which already skips
+validations), the single-`UPDATE` fast path and the per-record path are equivalent here —
+unlike Publishable/Expirable/Activatable, this one has no validators gate.
 
 **Notes**
 - The increment is SQL-side (`COALESCE(attempts, 0) + 1` via `update_counters`), so concurrent failures never lose updates and a NULL counter needs no column default; a locked account stops counting.

--- a/README.md
+++ b/README.md
@@ -2070,9 +2070,9 @@ Point your agent at `llms.txt` for an overview, or paste a single concern's `.md
 
 ```sh
 bundle install                                  # install dev dependencies
-bundle exec rspec                               # run the test suite (1,173 examples)
+bundle exec rspec                               # run the test suite (1,245 examples)
 gem build concerns_on_rails.gemspec             # build the gem
-gem install ./concerns_on_rails-1.26.0.gem      # install locally
+gem install ./concerns_on_rails-1.27.0.gem      # install locally
 
 # Preview the docs site locally (GitHub Pages serves docs/ as-is):
 cd docs && python3 -m http.server 8000          # → http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -368,8 +368,10 @@ Post.published.unpublish_all # unpublishes every currently-published post; retur
 Both respect the current relation, return an Integer count, and run in a transaction — a
 record that fails to save raises `ActiveRecord::RecordNotSaved` and rolls the whole batch
 back. With no overridden `before_publish`/`after_publish`/`before_unpublish`/`after_unpublish`/
-`publish!`/`unpublish!` and no validations on the model — neither `validates`/`validates_with`
-nor a custom `validate :method` — both collapse to a single `UPDATE`, which bumps `updated_at`
+`publish!`/`unpublish!` and no validations on the model — neither `validates`/`validates_with`,
+a custom `validate :method`, nor an association's autosave validation (a bare `has_many`
+registers one, so most models with associations take the streaming path) — both collapse to a
+single `UPDATE`, which bumps `updated_at`
 exactly as the per-record path does; otherwise they stream per record through
 `publish!`/`unpublish!` so validations still run.
 
@@ -637,7 +639,9 @@ ApiToken.expiring_within(1.day).expire_all   # => 12
 
 `expire_all(time = Time.zone.now)` expires every currently-active record in the relation and
 returns the Integer count, in a transaction. With `expire!` unoverridden and no validations on
-the model — neither `validates`/`validates_with` nor a custom `validate :method` — it collapses
+the model — neither `validates`/`validates_with`, a custom `validate :method`, nor an
+association's autosave validation (a bare `has_many` registers one, so most models with
+associations take the streaming path) — it collapses
 to a single `UPDATE`, which bumps `updated_at` exactly as the per-record path does; otherwise it
 streams per record through `expire!` so validations still run, and a record that fails to save
 raises `ActiveRecord::RecordNotSaved` and rolls the whole batch back.
@@ -758,7 +762,9 @@ Subscription.active.deactivate_all     # => 3
 
 Both target the relation, return an Integer count, and run in a transaction. With
 `activate!`/`deactivate!` unoverridden and no validations on the model — neither
-`validates`/`validates_with` nor a custom `validate :method` — they collapse to a single
+`validates`/`validates_with`, a custom `validate :method`, nor an association's autosave
+validation (a bare `has_many` registers one, so most models with associations take the
+streaming path) — they collapse to a single
 `UPDATE`, which bumps `updated_at` exactly as the per-record path does; otherwise they stream
 per record so validations still run, and a record that fails to save raises
 `ActiveRecord::RecordNotSaved` and rolls the whole batch back. `toggle_active!`'s row lock has

--- a/docs/assets/js/concerns.js
+++ b/docs/assets/js/concerns.js
@@ -1,7 +1,7 @@
 /* Concern manifest — drives the sidebar nav, home cards, search, and source links.
    `tags` are refined from the doc-generation workflow; everything else is static metadata. */
 window.COR_META = {
-  version: "1.26.0",
+  version: "1.27.0",
   repo: "https://github.com/VSN2015/concerns_on_rails",
   branch: "master",
   rubygems: "https://rubygems.org/gems/concerns_on_rails"

--- a/docs/superpowers/plans/2026-08-29-affixing-and-batch-ops.md
+++ b/docs/superpowers/plans/2026-08-29-affixing-and-batch-ops.md
@@ -1,0 +1,2255 @@
+# Scope Affixing + Batch Operations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give Publishable, SoftDeletable and Schedulable the `prefix:`/`suffix:` scope-name escape hatch the other scope-generating concerns already have, and extend the existing batch-operation contract to Publishable, Expirable, Activatable, Lockable and Stateable.
+
+**Architecture:** Two new autoloaded support modules absorb duplication that already exists. `Support::Affix` computes affixed names, normalizes `prefix: true`, and owns the scope capture/retire machinery. `Support::BatchOps` owns the hook-ownership fast-path predicate and the transactional streaming loop. Every scope-generating concern gains a `<concern>_scope_names` class_attribute mapping base name => actual name, so scope bodies and batch verbs reference scopes through the map instead of hard-coded symbols.
+
+**Tech Stack:** Ruby >= 3.2, ActiveRecord/ActiveSupport >= 5.0 < 9, RSpec, in-memory SQLite, RuboCop.
+
+**Spec:** `docs/superpowers/specs/2026-08-29-affixing-and-batch-ops-design.md`
+
+## Global Constraints
+
+- Ruby floor `>= 3.2.0`; Rails component gems `>= 5.0, < 9`. No syntax or API newer than that floor.
+- Run tests with `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec` — plain `bundle exec rspec` picks the wrong Ruby.
+- **No new columns, migrations, dependencies or gemspec changes** in this release.
+- **Fully backward compatible:** with no affix passed, every scope name, default scope and emitted query must be byte-identical to 1.26.0.
+- Batch verbs take **no bang**. `anonymize_all!` keeps its existing name and is not renamed.
+- Every concern's error messages are prefixed with its full label, e.g. `ConcernsOnRails::Models::Publishable: ...`.
+- Never run `rubocop -A` on files containing lambda literals — its `lambda(&:sym)` autocorrection is broken and has produced invalid code in this repo before.
+- Target version **1.27.0**. Do not tag or release; the final task only prepares the files.
+
+---
+
+### Task 1: `Support::Affix` — name and normalize
+
+**Files:**
+- Create: `lib/concerns_on_rails/support/affix.rb`
+- Modify: `lib/concerns_on_rails.rb` (Support autoload block, after `:Encryptor`)
+- Test: `spec/concerns/support/affix_spec.rb`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `ConcernsOnRails::Support::Affix.name(base, prefix: nil, suffix: nil) -> Symbol`
+  - `ConcernsOnRails::Support::Affix.normalize(option, default:) -> String | nil`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `spec/concerns/support/affix_spec.rb`:
+
+```ruby
+require "spec_helper"
+
+describe ConcernsOnRails::Support::Affix do
+  describe ".name" do
+    it "returns the bare base as a Symbol when neither affix is given" do
+      expect(described_class.name(:active)).to eq(:active)
+    end
+
+    it "prepends the prefix" do
+      expect(described_class.name(:active, prefix: "subscription")).to eq(:subscription_active)
+    end
+
+    it "appends the suffix" do
+      expect(described_class.name(:active, suffix: "window")).to eq(:active_window)
+    end
+
+    it "applies both" do
+      expect(described_class.name(:active, prefix: "sub", suffix: "window")).to eq(:sub_active_window)
+    end
+
+    it "accepts a String base" do
+      expect(described_class.name("active", prefix: "sub")).to eq(:sub_active)
+    end
+  end
+
+  describe ".normalize" do
+    it "returns nil for nil" do
+      expect(described_class.normalize(nil, default: :status)).to be_nil
+    end
+
+    it "returns nil for false" do
+      expect(described_class.normalize(false, default: :status)).to be_nil
+    end
+
+    it "returns the default as a String for true" do
+      expect(described_class.normalize(true, default: :status)).to eq("status")
+    end
+
+    it "returns a Symbol option as a String" do
+      expect(described_class.normalize(:archived, default: :status)).to eq("archived")
+    end
+
+    it "returns a String option unchanged" do
+      expect(described_class.normalize("archived", default: :status)).to eq("archived")
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec spec/concerns/support/affix_spec.rb`
+Expected: FAIL — `uninitialized constant ConcernsOnRails::Support::Affix`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `lib/concerns_on_rails/support/affix.rb`:
+
+```ruby
+module ConcernsOnRails
+  module Support
+    # Shared naming for concerns that generate affixable scopes or accessors.
+    #
+    # Two concerns that each define `.active` (SoftDeletable, Activatable,
+    # Expirable) can coexist on one model only if their generated names can be
+    # renamed, so every such concern takes `prefix:`/`suffix:` and routes the
+    # name through here rather than re-implementing the join.
+    module Affix
+      module_function
+
+      # `[prefix, base, suffix]`, underscore-joined, as a Symbol.
+      def name(base, prefix: nil, suffix: nil)
+        [prefix, base, suffix].compact.join("_").to_sym
+      end
+
+      # Normalize an affix option: `true` means "use the configured field
+      # name" (Stateable's semantics, generalized to every affixing concern),
+      # a String/Symbol is used literally, and nil/false means no affix.
+      def normalize(option, default:)
+        return nil unless option
+
+        option == true ? default.to_s : option.to_s
+      end
+    end
+  end
+end
+```
+
+Add to the `module Support` autoload block in `lib/concerns_on_rails.rb`, immediately after the `:Encryptor` line:
+
+```ruby
+    autoload :Affix,                   "concerns_on_rails/support/affix"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec spec/concerns/support/affix_spec.rb`
+Expected: PASS (10 examples, 0 failures)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/concerns_on_rails/support/affix.rb lib/concerns_on_rails.rb spec/concerns/support/affix_spec.rb
+git commit -m "Add Support::Affix — shared affixed-name computation"
+```
+
+---
+
+### Task 2: `Support::Affix` — scope capture and retirement
+
+This is the machinery that lets an affixed macro call remove the default-named scopes the concern defined at include time. It is the riskiest code in the plan; the three guards exist so it can never remove a name it did not create, a scope inherited from a parent, or a scope the model redefined itself.
+
+**Files:**
+- Modify: `lib/concerns_on_rails/support/affix.rb`
+- Test: `spec/concerns/support/affix_spec.rb`
+
+**Interfaces:**
+- Consumes: `Affix.name` from Task 1.
+- Produces:
+  - `Affix.capture(klass, names) -> Hash{Symbol => UnboundMethod}`
+  - `Affix.retire!(klass, captured, label:) -> Array<Symbol>` (the names actually removed; raises `ArgumentError` on the STI case)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `spec/concerns/support/affix_spec.rb`, inside the top-level `describe`:
+
+```ruby
+  describe ".capture and .retire!" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :affix_posts, force: true do |t|
+          t.datetime :published_at
+        end
+      end
+
+      stub_const("AffixPost", Class.new(TestModel) do
+        self.table_name = "affix_posts"
+        scope :published, -> { where.not(published_at: nil) }
+      end)
+    end
+
+    after(:each) do
+      ActiveRecord::Base.connection.tables.each do |table|
+        next if table == "schema_migrations"
+
+        ActiveRecord::Base.connection.drop_table(table)
+      end
+    end
+
+    it "captures the named scopes as UnboundMethods" do
+      captured = described_class.capture(AffixPost, %i[published])
+      expect(captured.keys).to eq([:published])
+      expect(captured[:published]).to be_a(UnboundMethod)
+    end
+
+    it "ignores names that are not defined" do
+      captured = described_class.capture(AffixPost, %i[published nope])
+      expect(captured.keys).to eq([:published])
+    end
+
+    it "removes a captured scope that is untouched" do
+      captured = described_class.capture(AffixPost, %i[published])
+      removed = described_class.retire!(AffixPost, captured, label: "Test")
+
+      expect(removed).to eq([:published])
+      expect(AffixPost.respond_to?(:published)).to be false
+    end
+
+    it "leaves a scope the model redefined itself" do
+      captured = described_class.capture(AffixPost, %i[published])
+      AffixPost.singleton_class.send(:define_method, :published) { :mine }
+
+      removed = described_class.retire!(AffixPost, captured, label: "Test")
+
+      expect(removed).to be_empty
+      expect(AffixPost.published).to eq(:mine)
+    end
+
+    it "raises when the scope is owned by a parent class" do
+      captured = described_class.capture(AffixPost, %i[published])
+      subclass = stub_const("AffixSpecialPost", Class.new(AffixPost))
+
+      expect do
+        described_class.retire!(subclass, captured, label: "ConcernsOnRails::Models::Publishable")
+      end.to raise_error(ArgumentError, /AffixPost/)
+    end
+  end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec spec/concerns/support/affix_spec.rb -e "capture and .retire!"`
+Expected: FAIL — `undefined method 'capture' for ConcernsOnRails::Support::Affix`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `lib/concerns_on_rails/support/affix.rb`, inside `module Affix` after `normalize`:
+
+```ruby
+      # Snapshot the scopes a concern just defined on `klass`: a
+      # name => UnboundMethod map, captured immediately after definition.
+      # Names that aren't defined are skipped (a concern may generate a scope
+      # only under some configurations).
+      def capture(klass, names)
+        singleton = klass.singleton_class
+        names.each_with_object({}) do |base, acc|
+          name = base.to_sym
+          next unless singleton.method_defined?(name)
+
+          acc[name] = singleton.instance_method(name)
+        end
+      end
+
+      # Remove the default-named scopes recorded by `capture` so their affixed
+      # replacements are the only ones left. Returns the names removed.
+      #
+      # Three guards, all of which must pass before a name is removed:
+      #   1. it is in the captured map (never a name the concern did not create);
+      #   2. it is owned by THIS class's own singleton (never inherited);
+      #   3. it is still the exact method captured (never a model's override).
+      #
+      # Guard 2 failing means the concern was configured on a parent and the
+      # affix is being declared on a subclass — retiring nothing would hand
+      # back an escape hatch that doesn't work, because the parent's colliding
+      # scopes would survive. That raises instead.
+      def retire!(klass, captured, label:)
+        singleton = klass.singleton_class
+        captured.each_with_object([]) do |(name, recorded), removed|
+          next unless singleton.method_defined?(name)
+
+          current = singleton.instance_method(name)
+          retire_guard_owner!(current, singleton, klass, name, label)
+          next unless current == recorded
+
+          singleton.send(:remove_method, name)
+          removed << name
+        end
+      end
+
+      # Postfix private: keeps the public module_function methods above
+      # callable as `Affix.foo` while hiding the helper.
+      def retire_guard_owner!(current, singleton, klass, name, label)
+        return if current.owner == singleton
+
+        owner = current.owner.attached_object
+        raise ArgumentError,
+              "#{label}: cannot affix scopes on #{klass} because '#{name}' is defined on #{owner}. " \
+              "Declare the prefix:/suffix: option on #{owner} itself — affixing here would leave " \
+              "#{owner}'s unaffixed scopes in place and the collision unresolved."
+      end
+      private_class_method :retire_guard_owner!
+```
+
+Note: `Module#attached_object` is Ruby 3.2+, which is this gem's floor.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec spec/concerns/support/affix_spec.rb`
+Expected: PASS (15 examples, 0 failures)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/concerns_on_rails/support/affix.rb spec/concerns/support/affix_spec.rb
+git commit -m "Add Support::Affix scope capture + guarded retirement"
+```
+
+---
+
+### Task 3: Route the existing affixing concerns through `Support::Affix`
+
+Behaviour-preserving refactor of the six duplicated call sites, plus a `<concern>_scope_names` map on the three scope-generating ones so later tasks can reference their scopes by base name. The concerns' current specs are the regression guard — no new specs, and none of them may change.
+
+**Files:**
+- Modify: `lib/concerns_on_rails/models/activatable.rb`
+- Modify: `lib/concerns_on_rails/models/expirable.rb`
+- Modify: `lib/concerns_on_rails/models/lockable.rb`
+- Modify: `lib/concerns_on_rails/models/anonymizable.rb`
+- Modify: `lib/concerns_on_rails/models/stateable.rb`
+- Modify: `lib/concerns_on_rails/models/storable.rb`
+- Test: existing specs only
+
+**Interfaces:**
+- Consumes: `Affix.name`, `Affix.normalize`.
+- Produces:
+  - `activatable_scope_names -> {active: Symbol, inactive: Symbol}`
+  - `expirable_scope_names -> {active:, expired:, expiring_within:}`
+  - `lockable_scope_names -> {locked:, unlocked:}`
+
+- [ ] **Step 1: Run the existing specs to establish the green baseline**
+
+Run: `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec spec/concerns/models/activatable_spec.rb spec/concerns/models/expirable_spec.rb spec/concerns/models/lockable_spec.rb spec/concerns/models/anonymizable_spec.rb spec/concerns/models/stateable_spec.rb spec/concerns/models/storable_spec.rb`
+Expected: PASS. Record the example count — it must not change by the end of this task.
+
+- [ ] **Step 2: Refactor Activatable**
+
+In `lib/concerns_on_rails/models/activatable.rb`, add the require and the map, and drop the private helper.
+
+Add after the existing `require`:
+
+```ruby
+require "concerns_on_rails/support/affix"
+```
+
+In `included do`, add below the existing `class_attribute`:
+
+```ruby
+        class_attribute :activatable_scope_names, instance_accessor: false,
+                                                  default: { active: :active, inactive: :inactive }.freeze
+```
+
+Replace the body of `activatable_by` and delete `activatable_scope_name`:
+
+```ruby
+        def activatable_by(field = DEFAULT_FIELD, prefix: nil, suffix: nil)
+          self.activatable_field = field.to_sym
+          ensure_columns!("ConcernsOnRails::Models::Activatable", activatable_field, types: :boolean)
+
+          prefix = ConcernsOnRails::Support::Affix.normalize(prefix, default: activatable_field)
+          suffix = ConcernsOnRails::Support::Affix.normalize(suffix, default: activatable_field)
+          self.activatable_scope_names = {
+            active: ConcernsOnRails::Support::Affix.name(:active, prefix: prefix, suffix: suffix),
+            inactive: ConcernsOnRails::Support::Affix.name(:inactive, prefix: prefix, suffix: suffix)
+          }.freeze
+
+          # Affix the scope names so two concerns that each define `.active`
+          # (e.g. SoftDeletable / Expirable) can coexist on one model.
+          scope activatable_scope_names[:active],   -> { where(activatable_field => true) }
+          scope activatable_scope_names[:inactive], -> { where(activatable_field => [false, nil]) }
+        end
+```
+
+- [ ] **Step 3: Refactor Expirable**
+
+In `lib/concerns_on_rails/models/expirable.rb`, add `require "concerns_on_rails/support/affix"`, add to `included do`:
+
+```ruby
+        class_attribute :expirable_scope_names, instance_accessor: false,
+                                                default: { active: :active, expired: :expired,
+                                                           expiring_within: :expiring_within }.freeze
+```
+
+Replace `define_expirable_scopes` and delete `expirable_scope_name`:
+
+```ruby
+        def define_expirable_scopes(prefix, suffix)
+          prefix = ConcernsOnRails::Support::Affix.normalize(prefix, default: expirable_field)
+          suffix = ConcernsOnRails::Support::Affix.normalize(suffix, default: expirable_field)
+          self.expirable_scope_names = %i[active expired expiring_within].to_h do |base|
+            [base, ConcernsOnRails::Support::Affix.name(base, prefix: prefix, suffix: suffix)]
+          end.freeze
+
+          scope expirable_scope_names[:active], lambda {
+            column = arel_table[expirable_field]
+            where(column.eq(nil).or(column.gt(Time.zone.now)))
+          }
+          scope expirable_scope_names[:expired], lambda {
+            where(arel_table[expirable_field].lteq(Time.zone.now))
+          }
+          scope expirable_scope_names[:expiring_within], lambda { |duration|
+            column = arel_table[expirable_field]
+            now = Time.zone.now
+            where(column.gt(now)).where(column.lteq(now + duration))
+          }
+        end
+```
+
+- [ ] **Step 4: Refactor Lockable**
+
+In `lib/concerns_on_rails/models/lockable.rb`, add `require "concerns_on_rails/support/affix"`, add to `included do`:
+
+```ruby
+        class_attribute :lockable_scope_names, instance_accessor: false,
+                                               default: { locked: :locked, unlocked: :unlocked }.freeze
+```
+
+At the top of `define_lockable_scopes`, replace the name computation and delete `lockable_scope_name`:
+
+```ruby
+        def define_lockable_scopes(prefix, suffix)
+          prefix = ConcernsOnRails::Support::Affix.normalize(prefix, default: lockable_locked_at_field)
+          suffix = ConcernsOnRails::Support::Affix.normalize(suffix, default: lockable_locked_at_field)
+          self.lockable_scope_names = {
+            locked: ConcernsOnRails::Support::Affix.name(:locked, prefix: prefix, suffix: suffix),
+            unlocked: ConcernsOnRails::Support::Affix.name(:unlocked, prefix: prefix, suffix: suffix)
+          }.freeze
+
+          scope lockable_scope_names[:locked], lambda {
+```
+
+(the two scope bodies are unchanged; only the two name expressions change, and
+`scope lockable_scope_name(:unlocked, prefix, suffix)` becomes
+`scope lockable_scope_names[:unlocked]`)
+
+- [ ] **Step 5: Refactor Anonymizable, Stateable and Storable**
+
+`lib/concerns_on_rails/models/anonymizable.rb` — replace the `affixed` lambda in `anonymizable_define_scopes`:
+
+```ruby
+          prefix = ConcernsOnRails::Support::Affix.normalize(prefix, default: anonymizable_stamp)
+          suffix = ConcernsOnRails::Support::Affix.normalize(suffix, default: anonymizable_stamp)
+          scope ConcernsOnRails::Support::Affix.name(:anonymized, prefix: prefix, suffix: suffix),
+                -> { where.not(anonymizable_stamp => nil) }
+          scope ConcernsOnRails::Support::Affix.name(:not_anonymized, prefix: prefix, suffix: suffix),
+                -> { where(anonymizable_stamp => nil) }
+```
+
+`lib/concerns_on_rails/models/stateable.rb` — delete `stateable_affix` and `stateable_method_name` bodies, delegating:
+
+```ruby
+        def stateable_affix(option)
+          ConcernsOnRails::Support::Affix.normalize(option, default: stateable_field)
+        end
+
+        def stateable_method_name(base)
+          ConcernsOnRails::Support::Affix.name(base, prefix: stateable_prefix, suffix: stateable_suffix).to_s
+        end
+```
+
+Note `stateable_method_name` must keep returning a **String** — it is interpolated into `"#{name}?"` and `"#{name}!"`.
+
+`lib/concerns_on_rails/models/storable.rb` — in `storable_normalize_spec`, replace the inline join:
+
+```ruby
+            accessor: ConcernsOnRails::Support::Affix.name(key, prefix: prefix, suffix: suffix) }
+```
+
+Add `require "concerns_on_rails/support/affix"` to anonymizable.rb, stateable.rb and storable.rb.
+
+- [ ] **Step 6: Run the same specs and confirm an identical green result**
+
+Run: `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec spec/concerns/models/activatable_spec.rb spec/concerns/models/expirable_spec.rb spec/concerns/models/lockable_spec.rb spec/concerns/models/anonymizable_spec.rb spec/concerns/models/stateable_spec.rb spec/concerns/models/storable_spec.rb`
+Expected: PASS with the same example count as Step 1. Any change in count or a single failure means the refactor was not behaviour-preserving — fix before committing.
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec`
+Expected: PASS, 1173 examples, 0 failures.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/concerns_on_rails/models/
+git commit -m "Route the six existing affix call sites through Support::Affix"
+```
+
+---
+
+### Task 4: Affix Publishable
+
+**Files:**
+- Modify: `lib/concerns_on_rails/models/publishable.rb`
+- Test: `spec/concerns/models/publishable_spec.rb`
+
+**Interfaces:**
+- Consumes: `Affix.name`, `Affix.normalize`, `Affix.capture`, `Affix.retire!`.
+- Produces: `publishable_scope_names -> {published:, unpublished:, scheduled:, draft:}`; `publishable_by(field = nil, default_scope: false, prefix: nil, suffix: nil)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `spec/concerns/models/publishable_spec.rb`:
+
+```ruby
+  describe "scope affixing" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :affixed_articles, force: true do |t|
+          t.datetime :published_at
+        end
+      end
+    end
+
+    it "keeps the default scope names when no affix is given" do
+      klass = Class.new(TestModel) do
+        self.table_name = "affixed_articles"
+        include ConcernsOnRails::Publishable
+        publishable_by
+      end
+
+      expect(klass).to respond_to(:published)
+      expect(klass).to respond_to(:draft)
+    end
+
+    it "keeps the default scope names when the macro is never called" do
+      klass = Class.new(TestModel) do
+        self.table_name = "affixed_articles"
+        include ConcernsOnRails::Publishable
+      end
+
+      expect(klass).to respond_to(:published)
+    end
+
+    it "defines affixed names and removes the defaults" do
+      klass = Class.new(TestModel) do
+        self.table_name = "affixed_articles"
+        include ConcernsOnRails::Publishable
+        publishable_by :published_at, prefix: :article
+      end
+
+      expect(klass).to respond_to(:article_published)
+      expect(klass).to respond_to(:article_draft)
+      expect(klass).not_to respond_to(:published)
+      expect(klass).not_to respond_to(:draft)
+    end
+
+    it "accepts prefix: true, meaning the field name" do
+      klass = Class.new(TestModel) do
+        self.table_name = "affixed_articles"
+        include ConcernsOnRails::Publishable
+        publishable_by :published_at, prefix: true
+      end
+
+      expect(klass).to respond_to(:published_at_published)
+    end
+
+    it "returns the right rows through the affixed scopes" do
+      klass = Class.new(TestModel) do
+        self.table_name = "affixed_articles"
+        include ConcernsOnRails::Publishable
+        publishable_by :published_at, suffix: :posts
+      end
+      live = klass.create!(published_at: 1.day.ago)
+      klass.create!(published_at: nil)
+
+      expect(klass.published_posts.pluck(:id)).to eq([live.id])
+      expect(klass.draft_posts.count).to eq(1)
+    end
+
+    it "keeps default_scope: true working under an affix" do
+      klass = Class.new(TestModel) do
+        self.table_name = "affixed_articles"
+        include ConcernsOnRails::Publishable
+        publishable_by :published_at, prefix: :article, default_scope: true
+      end
+      live = klass.create!(published_at: 1.day.ago)
+      klass.create!(published_at: nil)
+
+      expect(klass.all.pluck(:id)).to eq([live.id])
+      expect(klass.article_draft.count).to eq(1)
+    end
+
+    it "raises when affixing on a subclass whose parent owns the scopes" do
+      parent = Class.new(TestModel) do
+        self.table_name = "affixed_articles"
+        include ConcernsOnRails::Publishable
+        publishable_by
+      end
+      stub_const("AffixedParentArticle", parent)
+
+      expect do
+        Class.new(parent) { publishable_by :published_at, prefix: :child }
+      end.to raise_error(ArgumentError, /AffixedParentArticle/)
+    end
+  end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec spec/concerns/models/publishable_spec.rb -e "scope affixing"`
+Expected: FAIL — `unknown keyword: :prefix`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `lib/concerns_on_rails/models/publishable.rb`, add `require "concerns_on_rails/support/affix"`.
+
+Replace the whole `included do` block with:
+
+```ruby
+      SCOPE_BASES = %i[published unpublished scheduled draft].freeze
+
+      included do
+        class_attribute :publishable_field, instance_accessor: false, default: :published_at
+        class_attribute :publishable_scope_names, instance_accessor: false,
+                                                  default: SCOPE_BASES.to_h { |b| [b, b] }.freeze
+        class_attribute :publishable_captured_scopes, instance_accessor: false, default: {}.freeze
+
+        define_publishable_scopes(nil, nil)
+        self.publishable_captured_scopes =
+          ConcernsOnRails::Support::Affix.capture(self, SCOPE_BASES).freeze
+      end
+```
+
+In the `class_methods do` block, change the macro signature and add the scope builder. `publishable_by` becomes:
+
+```ruby
+        def publishable_by(field = nil, default_scope: false, prefix: nil, suffix: nil)
+          self.publishable_field = field || :published_at
+          @publishable_boolean_column = nil
+          ensure_columns!("ConcernsOnRails::Models::Publishable", publishable_field, types: :datetime)
+
+          if prefix || suffix
+            define_publishable_scopes(prefix, suffix)
+            ConcernsOnRails::Support::Affix.retire!(self, publishable_captured_scopes,
+                                                    label: "ConcernsOnRails::Models::Publishable")
+          end
+
+          enable_published_default_scope if default_scope
+        end
+```
+
+Add to the `private` section of `class_methods`, moving the four scope bodies verbatim out of `included do`:
+
+```ruby
+        # Scopes are built here rather than inline in `included do` so their
+        # names can be affixed. `included do` calls this with no affix, so a
+        # model that only includes the concern keeps the default names; an
+        # affixed macro call rebuilds them under new names and retires the
+        # originals.
+        #
+        # All scopes branch on the column type: a boolean publishable column
+        # needs equality predicates, not the timestamp `<= now` / `> now`
+        # comparisons that produce nonsensical SQL against a boolean.
+        def define_publishable_scopes(prefix, suffix)
+          prefix = ConcernsOnRails::Support::Affix.normalize(prefix, default: publishable_field)
+          suffix = ConcernsOnRails::Support::Affix.normalize(suffix, default: publishable_field)
+          self.publishable_scope_names = SCOPE_BASES.to_h do |base|
+            [base, ConcernsOnRails::Support::Affix.name(base, prefix: prefix, suffix: suffix)]
+          end.freeze
+
+          scope publishable_scope_names[:published], lambda {
+            if publishable_boolean_column?
+              where(publishable_field => true)
+            else
+              where(arel_table[publishable_field].lteq(Time.zone.now))
+            end
+          }
+          scope publishable_scope_names[:unpublished], lambda {
+            if publishable_boolean_column?
+              unscope(where: publishable_field).where(publishable_field => [nil, false])
+            else
+              column = arel_table[publishable_field]
+              unscope(where: publishable_field).where(column.eq(nil).or(column.gt(Time.zone.now)))
+            end
+          }
+          # Set, but the publish time is still in the future (timestamp columns only).
+          scope publishable_scope_names[:scheduled], lambda {
+            next none if publishable_boolean_column?
+
+            unscope(where: publishable_field).where(arel_table[publishable_field].gt(Time.zone.now))
+          }
+          # Never published — a true draft.
+          scope publishable_scope_names[:draft], lambda {
+            if publishable_boolean_column?
+              unscope(where: publishable_field).where(publishable_field => [nil, false])
+            else
+              unscope(where: publishable_field).where(publishable_field => nil)
+            end
+          }
+        end
+```
+
+Change `enable_published_default_scope` so it does not hard-code the scope name:
+
+```ruby
+        def enable_published_default_scope
+          published_scope = publishable_scope_names.fetch(:published)
+          default_scope { public_send(published_scope) }
+        end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec spec/concerns/models/publishable_spec.rb`
+Expected: PASS — the seven new examples plus every pre-existing Publishable example.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/concerns_on_rails/models/publishable.rb spec/concerns/models/publishable_spec.rb
+git commit -m "Add prefix:/suffix: to Publishable"
+```
+
+---
+
+### Task 5: Affix SoftDeletable
+
+The riskiest affix: SoftDeletable's `default_scope` and two of its scopes call other scopes by name, and its `default_scope` is what hides deleted rows from `.all`. A missed reference means a model that silently stops filtering.
+
+**Files:**
+- Modify: `lib/concerns_on_rails/models/soft_deletable.rb`
+- Test: `spec/concerns/models/soft_deletable_spec.rb`
+
+**Interfaces:**
+- Produces: `soft_delete_scope_names -> {active:, without_deleted:, soft_deleted:, only_deleted:, with_deleted:, deleted_within:}`; `soft_deletable_by(field = nil, touch: true, default_scope: true, prefix: nil, suffix: nil)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `spec/concerns/models/soft_deletable_spec.rb`:
+
+```ruby
+  describe "scope affixing" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :affixed_docs, force: true do |t|
+          t.string :name
+          t.datetime :deleted_at
+        end
+      end
+    end
+
+    def affixed_class(**options)
+      Class.new(TestModel) do
+        self.table_name = "affixed_docs"
+        include ConcernsOnRails::SoftDeletable
+        soft_deletable_by :deleted_at, **options
+      end
+    end
+
+    it "keeps the default names with no affix" do
+      klass = affixed_class
+      expect(klass).to respond_to(:without_deleted)
+      expect(klass).to respond_to(:only_deleted)
+    end
+
+    it "defines affixed names and removes the defaults" do
+      klass = affixed_class(prefix: :doc)
+
+      expect(klass).to respond_to(:doc_without_deleted)
+      expect(klass).to respond_to(:doc_soft_deleted)
+      expect(klass).not_to respond_to(:without_deleted)
+      expect(klass).not_to respond_to(:active)
+    end
+
+    it "keeps the default_scope filtering deleted rows under an affix" do
+      klass = affixed_class(prefix: :doc)
+      live = klass.create!(name: "live")
+      gone = klass.create!(name: "gone")
+      gone.soft_delete!
+
+      expect(klass.all.pluck(:id)).to eq([live.id])
+      expect(klass.doc_with_deleted.count).to eq(2)
+      expect(klass.doc_soft_deleted.pluck(:id)).to eq([gone.id])
+    end
+
+    it "keeps only_deleted delegating to soft_deleted under an affix" do
+      klass = affixed_class(prefix: :doc)
+      gone = klass.create!(name: "gone")
+      gone.soft_delete!
+
+      expect(klass.doc_only_deleted.pluck(:id)).to eq([gone.id])
+    end
+
+    it "keeps deleted_within working under an affix" do
+      klass = affixed_class(prefix: :doc)
+      gone = klass.create!(name: "gone")
+      gone.soft_delete!
+
+      expect(klass.doc_deleted_within(1.day).pluck(:id)).to eq([gone.id])
+      expect(klass.doc_deleted_within(0.seconds).count).to eq(0)
+    end
+
+    it "honours default_scope: false under an affix" do
+      klass = affixed_class(prefix: :doc, default_scope: false)
+      klass.create!(name: "live")
+      klass.create!(name: "gone").soft_delete!
+
+      expect(klass.all.count).to eq(2)
+      expect(klass.doc_without_deleted.count).to eq(1)
+    end
+  end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec spec/concerns/models/soft_deletable_spec.rb -e "scope affixing"`
+Expected: FAIL — `unknown keyword: :prefix`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `lib/concerns_on_rails/models/soft_deletable.rb`, add `require "concerns_on_rails/support/affix"` and replace `included do` with:
+
+```ruby
+      SCOPE_BASES = %i[active without_deleted soft_deleted only_deleted with_deleted deleted_within].freeze
+
+      included do
+        # declare class attributes and set default values
+        class_attribute :soft_delete_field, instance_accessor: false, default: :deleted_at
+        class_attribute :soft_delete_touch, instance_accessor: false, default: true
+        # Whether `.all` hides soft-deleted rows via a default_scope. ON by default for
+        # backwards compatibility; opt out with `soft_deletable_by ..., default_scope: false`.
+        # A default_scope is sticky and breaks unscoped joins / uniqueness validations /
+        # eager-loading, so new models are encouraged to disable it and chain `.without_deleted`.
+        class_attribute :soft_delete_default_scope, instance_accessor: false, default: true
+        class_attribute :soft_delete_scope_names, instance_accessor: false,
+                                                  default: SCOPE_BASES.to_h { |b| [b, b] }.freeze
+        class_attribute :soft_delete_captured_scopes, instance_accessor: false, default: {}.freeze
+
+        define_soft_delete_scopes(nil, nil)
+        self.soft_delete_captured_scopes =
+          ConcernsOnRails::Support::Affix.capture(self, SCOPE_BASES).freeze
+
+        # Hide soft-deleted rows from `.all` only when enabled (the default). The block is
+        # evaluated lazily, so toggling `soft_delete_default_scope` via the macro takes effect —
+        # and it resolves the scope through the names map, so an affixed model still filters.
+        default_scope do
+          soft_delete_default_scope ? public_send(soft_delete_scope_names.fetch(:without_deleted)) : all
+        end
+      end
+```
+
+Add `prefix:`/`suffix:` to the macro:
+
+```ruby
+        def soft_deletable_by(field = nil, touch: true, default_scope: true, prefix: nil, suffix: nil)
+          self.soft_delete_field = field || :deleted_at
+          self.soft_delete_touch = touch
+          self.soft_delete_default_scope = default_scope
+          ensure_columns!("ConcernsOnRails::Models::SoftDeletable", soft_delete_field, types: :datetime)
+          return unless prefix || suffix
+
+          define_soft_delete_scopes(prefix, suffix)
+          ConcernsOnRails::Support::Affix.retire!(self, soft_delete_captured_scopes,
+                                                  label: "ConcernsOnRails::Models::SoftDeletable")
+        end
+```
+
+Add to the private section of `ClassMethods`, with every inter-scope reference routed through the map:
+
+```ruby
+        # Built here rather than inline in `included do` so the names can be
+        # affixed. Every scope that references another scope resolves it
+        # through soft_delete_scope_names — a hard-coded symbol would break
+        # the moment a model affixes.
+        def define_soft_delete_scopes(prefix, suffix)
+          prefix = ConcernsOnRails::Support::Affix.normalize(prefix, default: soft_delete_field)
+          suffix = ConcernsOnRails::Support::Affix.normalize(suffix, default: soft_delete_field)
+          self.soft_delete_scope_names = SCOPE_BASES.to_h do |base|
+            [base, ConcernsOnRails::Support::Affix.name(base, prefix: prefix, suffix: suffix)]
+          end.freeze
+
+          soft_deleted_name = soft_delete_scope_names.fetch(:soft_deleted)
+
+          scope soft_delete_scope_names[:active],
+                -> { unscope(where: soft_delete_field).where(soft_delete_field => nil) }
+          scope soft_delete_scope_names[:without_deleted],
+                -> { unscope(where: soft_delete_field).where(soft_delete_field => nil) }
+          scope soft_delete_scope_names[:soft_deleted],
+                -> { unscope(where: soft_delete_field).where.not(soft_delete_field => nil) }
+          scope soft_delete_scope_names[:only_deleted],
+                -> { public_send(soft_deleted_name) }
+          # `with_deleted` peels off the default scope so deleted + non-deleted are both returned.
+          scope soft_delete_scope_names[:with_deleted],
+                -> { unscope(where: soft_delete_field) }
+          # Records soft-deleted within the last `duration` (e.g. `deleted_within(7.days)`).
+          # Arel `gteq` rather than an endless range (`x..`): AR only translates an
+          # endless range to `>=` on Rails 6.0+, but this gem supports Rails >= 5.0.
+          # arel_table also qualifies the column with the table name, so the scope
+          # stays unambiguous inside joins against tables sharing the column.
+          scope soft_delete_scope_names[:deleted_within], lambda { |duration|
+            public_send(soft_deleted_name).where(arel_table[soft_delete_field].gteq(duration.ago))
+          }
+        end
+```
+
+Then update the three batch/class methods that call the scopes by literal name — `restore_all` and `really_destroy_all` reference `soft_deleted`:
+
+```ruby
+        def really_destroy_all
+          all.unscope(where: soft_delete_field).delete_all
+        end
+```
+(unchanged — it uses `unscope`, not a scope name)
+
+```ruby
+        def restore_all
+          deleted = all.public_send(soft_delete_scope_names.fetch(:soft_deleted))
+          return deleted.update_all(soft_delete_field => nil) if soft_delete_batch_fast_path?(:restore)
+
+          transaction do
+            count = 0
+            deleted.find_each do |record|
+              record.restore! ||
+                raise(ActiveRecord::RecordNotSaved.new(
+                        "ConcernsOnRails::Models::SoftDeletable: failed to restore record", record
+                      ))
+              count += 1
+            end
+            count
+          end
+        end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec spec/concerns/models/soft_deletable_spec.rb`
+Expected: PASS — the six new examples plus every pre-existing SoftDeletable example.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec`
+Expected: PASS. SoftDeletable's default_scope interacts with Lockable and Anonymizable specs, so a regression shows up outside its own file.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/concerns_on_rails/models/soft_deletable.rb spec/concerns/models/soft_deletable_spec.rb
+git commit -m "Add prefix:/suffix: to SoftDeletable"
+```
+
+---
+
+### Task 6: Affix Schedulable
+
+**Files:**
+- Modify: `lib/concerns_on_rails/models/schedulable.rb`
+- Test: `spec/concerns/models/schedulable_spec.rb`
+
+**Interfaces:**
+- Produces: `schedulable_scope_names -> {active_at:, current:, upcoming:, expired:}`; `schedulable_by(starts_at:, ends_at:, prefix: nil, suffix: nil)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `spec/concerns/models/schedulable_spec.rb`:
+
+```ruby
+  describe "scope affixing" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :affixed_events, force: true do |t|
+          t.datetime :starts_at
+          t.datetime :ends_at
+        end
+      end
+    end
+
+    def affixed_class(**options)
+      Class.new(TestModel) do
+        self.table_name = "affixed_events"
+        include ConcernsOnRails::Schedulable
+        schedulable_by(**options)
+      end
+    end
+
+    it "keeps the default names with no affix" do
+      klass = affixed_class
+      expect(klass).to respond_to(:current)
+      expect(klass).to respond_to(:expired)
+    end
+
+    it "defines affixed names and removes the defaults" do
+      klass = affixed_class(prefix: :event)
+
+      expect(klass).to respond_to(:event_current)
+      expect(klass).to respond_to(:event_active_at)
+      expect(klass).not_to respond_to(:current)
+      expect(klass).not_to respond_to(:expired)
+    end
+
+    it "keeps current delegating to active_at under an affix" do
+      klass = affixed_class(prefix: :event)
+      live = klass.create!(starts_at: 1.day.ago, ends_at: 1.day.from_now)
+      klass.create!(starts_at: 1.day.from_now, ends_at: 2.days.from_now)
+
+      expect(klass.event_current.pluck(:id)).to eq([live.id])
+    end
+
+    it "keeps upcoming and expired correct under an affix" do
+      klass = affixed_class(suffix: :window)
+      soon = klass.create!(starts_at: 1.day.from_now, ends_at: 2.days.from_now)
+      over = klass.create!(starts_at: 3.days.ago, ends_at: 1.day.ago)
+
+      expect(klass.upcoming_window.pluck(:id)).to eq([soon.id])
+      expect(klass.expired_window.pluck(:id)).to eq([over.id])
+    end
+  end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec spec/concerns/models/schedulable_spec.rb -e "scope affixing"`
+Expected: FAIL — `unknown keyword: :prefix`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `lib/concerns_on_rails/models/schedulable.rb`, add `require "concerns_on_rails/support/affix"` and replace `included do`:
+
+```ruby
+      SCOPE_BASES = %i[active_at current upcoming expired].freeze
+
+      included do
+        class_attribute :schedulable_starts_at_field, instance_accessor: false, default: DEFAULT_STARTS_AT_FIELD
+        class_attribute :schedulable_ends_at_field, instance_accessor: false, default: DEFAULT_ENDS_AT_FIELD
+        class_attribute :schedulable_scope_names, instance_accessor: false,
+                                                  default: SCOPE_BASES.to_h { |b| [b, b] }.freeze
+        class_attribute :schedulable_captured_scopes, instance_accessor: false, default: {}.freeze
+
+        define_schedulable_scopes(nil, nil)
+        self.schedulable_captured_scopes =
+          ConcernsOnRails::Support::Affix.capture(self, SCOPE_BASES).freeze
+      end
+```
+
+Add the keywords to the macro (keeping the existing body, with the affix block appended before the `ensure_columns!` return):
+
+```ruby
+        def schedulable_by(starts_at: DEFAULT_STARTS_AT_FIELD, ends_at: DEFAULT_ENDS_AT_FIELD,
+                           prefix: nil, suffix: nil)
+          self.schedulable_starts_at_field = starts_at&.to_sym
+          self.schedulable_ends_at_field = ends_at&.to_sym
+
+          if schedulable_starts_at_field.nil? && schedulable_ends_at_field.nil?
+            raise ArgumentError, "ConcernsOnRails::Models::Schedulable: at least one of starts_at: or ends_at: must be configured"
+          end
+
+          ensure_columns!("ConcernsOnRails::Models::Schedulable",
+                          schedulable_starts_at_field, schedulable_ends_at_field, types: :datetime)
+          return unless prefix || suffix
+
+          define_schedulable_scopes(prefix, suffix)
+          ConcernsOnRails::Support::Affix.retire!(self, schedulable_captured_scopes,
+                                                  label: "ConcernsOnRails::Models::Schedulable")
+        end
+
+        private
+
+        # Built here rather than inline in `included do` so the names can be
+        # affixed. `current` resolves `active_at` through the names map — a
+        # literal call would break under an affix.
+        def define_schedulable_scopes(prefix, suffix)
+          default_field = schedulable_starts_at_field || schedulable_ends_at_field
+          prefix = ConcernsOnRails::Support::Affix.normalize(prefix, default: default_field)
+          suffix = ConcernsOnRails::Support::Affix.normalize(suffix, default: default_field)
+          self.schedulable_scope_names = SCOPE_BASES.to_h do |base|
+            [base, ConcernsOnRails::Support::Affix.name(base, prefix: prefix, suffix: suffix)]
+          end.freeze
+
+          active_at_name = schedulable_scope_names.fetch(:active_at)
+
+          scope active_at_name, lambda { |time|
+            starts_field = schedulable_starts_at_field
+            ends_field = schedulable_ends_at_field
+            relation = all
+            relation = relation.where(arel_table[starts_field].lteq(time)) if starts_field
+            relation = relation.where(arel_table[ends_field].eq(nil).or(arel_table[ends_field].gt(time))) if ends_field
+            relation
+          }
+
+          scope schedulable_scope_names[:current], -> { public_send(active_at_name, Time.zone.now) }
+
+          scope schedulable_scope_names[:upcoming], lambda {
+            field = schedulable_starts_at_field
+            next none unless field
+
+            where(arel_table[field].gt(Time.zone.now))
+          }
+
+          scope schedulable_scope_names[:expired], lambda {
+            field = schedulable_ends_at_field
+            next none unless field
+
+            where(arel_table[field].lteq(Time.zone.now))
+          }
+        end
+```
+
+Note: `class_methods do` already contains `include ConcernsOnRails::Support::ColumnGuard` — keep it at the top of the block, and place the new `private` section after `schedulable_by`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec spec/concerns/models/schedulable_spec.rb`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/concerns_on_rails/models/schedulable.rb spec/concerns/models/schedulable_spec.rb
+git commit -m "Add prefix:/suffix: to Schedulable"
+```
+
+---
+
+### Task 7: Collision integration spec
+
+The scenario the whole affixing feature exists for. No production code changes.
+
+**Files:**
+- Create: `spec/concerns/integration/scope_collisions_spec.rb`
+
+**Interfaces:**
+- Consumes: affixed Publishable, SoftDeletable, Schedulable, plus Activatable and Expirable.
+
+- [ ] **Step 1: Write the test**
+
+```ruby
+require "spec_helper"
+
+# Three concerns each define a `.active` scope. Before 1.27 the last one
+# included silently won and there was no way out on SoftDeletable's side.
+describe "scope-name collisions across concerns" do
+  before do
+    ActiveRecord::Schema.define do
+      create_table :memberships, force: true do |t|
+        t.boolean :active
+        t.datetime :expires_at
+        t.datetime :deleted_at
+      end
+    end
+
+    stub_const("Membership", Class.new(TestModel) do
+      self.table_name = "memberships"
+
+      include ConcernsOnRails::SoftDeletable
+      include ConcernsOnRails::Activatable
+      include ConcernsOnRails::Expirable
+
+      soft_deletable_by :deleted_at, prefix: :trash, default_scope: false
+      activatable_by :active, prefix: :flag
+      expirable_by :expires_at, prefix: :term
+    end)
+  end
+
+  after(:each) do
+    ActiveRecord::Base.connection.tables.each do |table|
+      next if table == "schema_migrations"
+
+      ActiveRecord::Base.connection.drop_table(table)
+    end
+  end
+
+  it "gives each concern its own non-colliding scopes" do
+    expect(Membership).to respond_to(:trash_without_deleted)
+    expect(Membership).to respond_to(:flag_active)
+    expect(Membership).to respond_to(:term_active)
+    expect(Membership).not_to respond_to(:active)
+  end
+
+  it "returns the right rows from each affixed scope" do
+    healthy = Membership.create!(active: true, expires_at: 1.day.from_now, deleted_at: nil)
+    flagged_off = Membership.create!(active: false, expires_at: 1.day.from_now, deleted_at: nil)
+    lapsed = Membership.create!(active: true, expires_at: 1.day.ago, deleted_at: nil)
+    trashed = Membership.create!(active: true, expires_at: 1.day.from_now, deleted_at: Time.zone.now)
+
+    expect(Membership.flag_active.pluck(:id)).to match_array([healthy.id, lapsed.id, trashed.id])
+    expect(Membership.flag_inactive.pluck(:id)).to eq([flagged_off.id])
+    expect(Membership.term_active.pluck(:id)).to match_array([healthy.id, flagged_off.id, trashed.id])
+    expect(Membership.term_expired.pluck(:id)).to eq([lapsed.id])
+    expect(Membership.trash_soft_deleted.pluck(:id)).to eq([trashed.id])
+    expect(Membership.trash_without_deleted.pluck(:id)).to match_array([healthy.id, flagged_off.id, lapsed.id])
+  end
+
+  it "composes the three affixed scopes in one chain" do
+    healthy = Membership.create!(active: true, expires_at: 1.day.from_now, deleted_at: nil)
+    Membership.create!(active: true, expires_at: 1.day.ago, deleted_at: nil)
+
+    result = Membership.trash_without_deleted.flag_active.term_active
+    expect(result.pluck(:id)).to eq([healthy.id])
+  end
+end
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec spec/concerns/integration/scope_collisions_spec.rb`
+Expected: PASS (3 examples). If `Membership.active` still responds, the retirement guards are rejecting a removal they should allow — debug `Affix.retire!` before continuing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add spec/concerns/integration/scope_collisions_spec.rb
+git commit -m "Add integration spec proving affixed concerns coexist"
+```
+
+---
+
+### Task 8: `Support::BatchOps` and the SoftDeletable refactor
+
+**Files:**
+- Create: `lib/concerns_on_rails/support/batch_ops.rb`
+- Modify: `lib/concerns_on_rails.rb` (Support autoload block)
+- Modify: `lib/concerns_on_rails/models/soft_deletable.rb`
+- Test: `spec/concerns/support/batch_ops_spec.rb`
+
+**Interfaces:**
+- Produces:
+  - `BatchOps.fast_path?(klass, owner, *methods) -> Boolean`
+  - `BatchOps.run(relation, label:, message: "failed to update record") { |record| truthy | falsey | :skip } -> Integer`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `spec/concerns/support/batch_ops_spec.rb`:
+
+```ruby
+require "spec_helper"
+
+describe ConcernsOnRails::Support::BatchOps do
+  before do
+    ActiveRecord::Schema.define do
+      create_table :batch_items, force: true do |t|
+        t.string :state
+      end
+    end
+
+    stub_const("BatchItem", Class.new(TestModel) do
+      self.table_name = "batch_items"
+    end)
+  end
+
+  after(:each) do
+    ActiveRecord::Base.connection.tables.each do |table|
+      next if table == "schema_migrations"
+
+      ActiveRecord::Base.connection.drop_table(table)
+    end
+  end
+
+  describe ".fast_path?" do
+    it "is true when no listed method is overridden" do
+      owner = Module.new { def touched; end }
+      klass = Class.new { include(owner) }
+
+      expect(described_class.fast_path?(klass, owner, :touched)).to be true
+    end
+
+    it "is false when the host overrode a listed method" do
+      owner = Module.new { def touched; end }
+      klass = Class.new do
+        include(owner)
+        def touched; end
+      end
+
+      expect(described_class.fast_path?(klass, owner, :touched)).to be false
+    end
+  end
+
+  describe ".run" do
+    it "returns the count of records the block accepted" do
+      3.times { BatchItem.create!(state: "new") }
+
+      count = described_class.run(BatchItem.all, label: "Test") { |r| r.update(state: "done") }
+
+      expect(count).to eq(3)
+      expect(BatchItem.where(state: "done").count).to eq(3)
+    end
+
+    it "does not count records the block skips" do
+      BatchItem.create!(state: "new")
+      BatchItem.create!(state: "keep")
+
+      count = described_class.run(BatchItem.all, label: "Test") do |r|
+        r.state == "keep" ? :skip : r.update(state: "done")
+      end
+
+      expect(count).to eq(1)
+    end
+
+    it "raises RecordNotSaved and rolls the batch back when the block returns falsey" do
+      BatchItem.create!(state: "a")
+      BatchItem.create!(state: "b")
+
+      expect do
+        described_class.run(BatchItem.all, label: "Test") do |r|
+          r.state == "b" ? false : r.update(state: "done")
+        end
+      end.to raise_error(ActiveRecord::RecordNotSaved, /Test: failed to update record/)
+
+      expect(BatchItem.where(state: "done").count).to eq(0)
+    end
+
+    it "uses a custom message when given" do
+      BatchItem.create!(state: "a")
+
+      expect do
+        described_class.run(BatchItem.all, label: "Test", message: "failed to soft-delete record") { false }
+      end.to raise_error(ActiveRecord::RecordNotSaved, /failed to soft-delete record/)
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec spec/concerns/support/batch_ops_spec.rb`
+Expected: FAIL — `uninitialized constant ConcernsOnRails::Support::BatchOps`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `lib/concerns_on_rails/support/batch_ops.rb`:
+
+```ruby
+module ConcernsOnRails
+  module Support
+    # Shared machinery for the concerns' `*_all` batch verbs.
+    #
+    # Every batch verb follows the contract established by SoftDeletable in
+    # 1.22: it operates on the current relation, returns an Integer count,
+    # runs in a transaction, rolls the whole batch back when a record fails,
+    # filters already-transitioned rows DB-side, and collapses to a single
+    # UPDATE when the host model has overridden none of the concern's hooks
+    # or bang methods.
+    module BatchOps
+      module_function
+
+      # True when every named instance method is still the concern's own — the
+      # host model overrode none of them, so a bulk UPDATE cannot differ from
+      # looping the per-record path.
+      def fast_path?(klass, owner, *methods)
+        methods.all? { |name| klass.instance_method(name).owner == owner }
+      end
+
+      # The streaming slow path. `find_each` pages forward by primary key, so
+      # rows leaving the filtered set as they're updated are never skipped or
+      # revisited, and the relation is never materialized in full.
+      #
+      # The block returns truthy (counted), `:skip` (not counted, not an
+      # error — a record that legitimately can't transition), or falsey
+      # (raises and rolls the whole batch back).
+      def run(relation, label:, message: "failed to update record")
+        relation.klass.transaction do
+          count = 0
+          relation.find_each do |record|
+            result = yield(record)
+            next if result == :skip
+
+            raise ActiveRecord::RecordNotSaved.new("#{label}: #{message}", record) unless result
+
+            count += 1
+          end
+          count
+        end
+      end
+    end
+  end
+end
+```
+
+Add to the `module Support` autoload block in `lib/concerns_on_rails.rb`, after `:Affix`:
+
+```ruby
+    autoload :BatchOps,                "concerns_on_rails/support/batch_ops"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec spec/concerns/support/batch_ops_spec.rb`
+Expected: PASS (6 examples).
+
+- [ ] **Step 5: Refactor SoftDeletable onto it**
+
+In `lib/concerns_on_rails/models/soft_deletable.rb`, add `require "concerns_on_rails/support/batch_ops"` and replace the two slow-path loops and the fast-path predicate:
+
+```ruby
+        def soft_delete_all
+          pending = all.where(soft_delete_field => nil)
+          return pending.update_all(soft_delete_field => Time.zone.now) if soft_delete_batch_fast_path?(:soft_delete)
+
+          ConcernsOnRails::Support::BatchOps.run(
+            pending,
+            label: "ConcernsOnRails::Models::SoftDeletable",
+            message: "failed to soft-delete record"
+          ) { |record| record.soft_delete! }
+        end
+```
+
+```ruby
+        def restore_all
+          deleted = all.public_send(soft_delete_scope_names.fetch(:soft_deleted))
+          return deleted.update_all(soft_delete_field => nil) if soft_delete_batch_fast_path?(:restore)
+
+          ConcernsOnRails::Support::BatchOps.run(
+            deleted,
+            label: "ConcernsOnRails::Models::SoftDeletable",
+            message: "failed to restore record"
+          ) { |record| record.restore! }
+        end
+```
+
+```ruby
+        def soft_delete_batch_fast_path?(kind)
+          return false if soft_delete_touch
+
+          methods = if kind == :restore
+                      %i[before_restore after_restore restore!]
+                    else
+                      %i[before_soft_delete after_soft_delete soft_delete!]
+                    end
+          ConcernsOnRails::Support::BatchOps.fast_path?(self, ConcernsOnRails::Models::SoftDeletable, *methods)
+        end
+```
+
+- [ ] **Step 6: Run the SoftDeletable specs**
+
+Run: `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec spec/concerns/models/soft_deletable_spec.rb`
+Expected: PASS with the same example count as before the refactor — including the existing `/failed to soft-delete/` assertion.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/concerns_on_rails/support/batch_ops.rb lib/concerns_on_rails.rb lib/concerns_on_rails/models/soft_deletable.rb spec/concerns/support/batch_ops_spec.rb
+git commit -m "Add Support::BatchOps and route SoftDeletable through it"
+```
+
+---
+
+### Task 9: Publishable batch operations
+
+**Files:**
+- Modify: `lib/concerns_on_rails/models/publishable.rb`
+- Test: `spec/concerns/models/publishable_spec.rb`
+
+**Interfaces:**
+- Produces: `publish_all -> Integer`, `unpublish_all -> Integer`.
+
+**Semantics:** `publish_all` writes `Time.zone.now` (or `true` on a boolean column) to rows that are not currently published — which **includes scheduled rows**, overwriting a future timestamp. Because batch verbs respect the relation, the narrow case is `Post.draft.publish_all`. `unpublish_all` writes `nil` on both column types, matching what `unpublish!` writes.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `spec/concerns/models/publishable_spec.rb`:
+
+```ruby
+  describe "batch operations" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :batch_articles, force: true do |t|
+          t.datetime :published_at
+        end
+      end
+
+      stub_const("BatchArticle", Class.new(TestModel) do
+        self.table_name = "batch_articles"
+        include ConcernsOnRails::Publishable
+        publishable_by
+      end)
+    end
+
+    def capture_sql
+      statements = []
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
+        statements << args.last[:sql].to_s
+      end
+      yield
+      statements
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+    end
+
+    it "publishes every unpublished record and returns the count" do
+      BatchArticle.create!(published_at: nil)
+      BatchArticle.create!(published_at: nil)
+      already = BatchArticle.create!(published_at: 2.days.ago)
+
+      expect(BatchArticle.publish_all).to eq(2)
+      expect(BatchArticle.where(published_at: nil).count).to eq(0)
+      expect(already.reload.published_at).to be_within(1.second).of(2.days.ago)
+    end
+
+    it "is idempotent — a second call transitions nothing" do
+      BatchArticle.create!(published_at: nil)
+      BatchArticle.publish_all
+
+      expect(BatchArticle.publish_all).to eq(0)
+    end
+
+    it "respects the relation" do
+      keep = BatchArticle.create!(published_at: nil)
+      BatchArticle.create!(published_at: nil)
+
+      expect(BatchArticle.where.not(id: keep.id).publish_all).to eq(1)
+      expect(keep.reload.published_at).to be_nil
+    end
+
+    it "issues exactly one UPDATE on the fast path" do
+      2.times { BatchArticle.create!(published_at: nil) }
+
+      statements = capture_sql { BatchArticle.publish_all }
+
+      expect(statements.grep(/^UPDATE/).length).to eq(1)
+    end
+
+    it "unpublishes every published record" do
+      BatchArticle.create!(published_at: 1.day.ago)
+      BatchArticle.create!(published_at: nil)
+
+      expect(BatchArticle.unpublish_all).to eq(1)
+      expect(BatchArticle.where.not(published_at: nil).count).to eq(0)
+    end
+
+    it "runs the hooks once per record when they are overridden" do
+      stub_const("HookedArticle", Class.new(TestModel) do
+        self.table_name = "batch_articles"
+        include ConcernsOnRails::Publishable
+        publishable_by
+
+        cattr_accessor :published_ids
+        self.published_ids = []
+
+        def after_publish
+          self.class.published_ids << id
+        end
+      end)
+      a = HookedArticle.create!(published_at: nil)
+      b = HookedArticle.create!(published_at: nil)
+
+      expect(HookedArticle.publish_all).to eq(2)
+      expect(HookedArticle.published_ids).to match_array([a.id, b.id])
+    end
+
+    it "rolls the whole batch back when a record fails" do
+      stub_const("FailingArticle", Class.new(TestModel) do
+        self.table_name = "batch_articles"
+        include ConcernsOnRails::Publishable
+        publishable_by
+
+        def publish!
+          false
+        end
+      end)
+      FailingArticle.create!(published_at: nil)
+
+      expect { FailingArticle.publish_all }.to raise_error(ActiveRecord::RecordNotSaved)
+      expect(FailingArticle.where(published_at: nil).count).to eq(1)
+    end
+  end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec spec/concerns/models/publishable_spec.rb -e "batch operations"`
+Expected: FAIL — `undefined method 'publish_all'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `require "concerns_on_rails/support/batch_ops"` to `lib/concerns_on_rails/models/publishable.rb`, and add these to the public part of `class_methods do` (above the existing `private`):
+
+```ruby
+        # Publish every not-currently-published record in the relation.
+        # Returns the Integer count. NOTE this includes *scheduled* rows,
+        # whose future timestamp is overwritten with now — chain the draft
+        # scope (`Post.draft.publish_all`) when that isn't what you want.
+        def publish_all
+          pending = all.public_send(publishable_scope_names.fetch(:unpublished))
+          value = publishable_boolean_column? ? true : Time.zone.now
+          return pending.update_all(publishable_field => value) if publishable_batch_fast_path?(:publish)
+
+          ConcernsOnRails::Support::BatchOps.run(
+            pending,
+            label: "ConcernsOnRails::Models::Publishable",
+            message: "failed to publish record"
+          ) { |record| record.publish! }
+        end
+
+        # Unpublish every published record in the relation. Writes nil on both
+        # column types, exactly as `unpublish!` does.
+        def unpublish_all
+          live = all.public_send(publishable_scope_names.fetch(:published))
+          return live.update_all(publishable_field => nil) if publishable_batch_fast_path?(:unpublish)
+
+          ConcernsOnRails::Support::BatchOps.run(
+            live,
+            label: "ConcernsOnRails::Models::Publishable",
+            message: "failed to unpublish record"
+          ) { |record| record.unpublish! }
+        end
+```
+
+And in the private section:
+
+```ruby
+        def publishable_batch_fast_path?(kind)
+          methods = if kind == :publish
+                      %i[before_publish after_publish publish!]
+                    else
+                      %i[before_unpublish after_unpublish unpublish!]
+                    end
+          ConcernsOnRails::Support::BatchOps.fast_path?(self, ConcernsOnRails::Models::Publishable, *methods)
+        end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec spec/concerns/models/publishable_spec.rb`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/concerns_on_rails/models/publishable.rb spec/concerns/models/publishable_spec.rb
+git commit -m "Add Publishable#publish_all / #unpublish_all"
+```
+
+---
+
+### Task 10: Expirable and Activatable batch operations
+
+Both concerns define no lifecycle hooks, so the only thing that can force the slow path is a host model overriding the bang method. This refines the spec's "fast path: always" — an overridden `expire!` or `activate!` must still be honoured.
+
+**Files:**
+- Modify: `lib/concerns_on_rails/models/expirable.rb`
+- Modify: `lib/concerns_on_rails/models/activatable.rb`
+- Test: `spec/concerns/models/expirable_spec.rb`, `spec/concerns/models/activatable_spec.rb`
+
+**Interfaces:**
+- Produces: `expire_all(time = Time.zone.now) -> Integer`, `activate_all -> Integer`, `deactivate_all -> Integer`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `spec/concerns/models/expirable_spec.rb`:
+
+```ruby
+  describe "batch operations" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :batch_tokens, force: true do |t|
+          t.datetime :expires_at
+        end
+      end
+
+      stub_const("BatchToken", Class.new(TestModel) do
+        self.table_name = "batch_tokens"
+        include ConcernsOnRails::Expirable
+        expirable_by
+      end)
+    end
+
+    it "expires every active record and returns the count" do
+      BatchToken.create!(expires_at: 1.day.from_now)
+      BatchToken.create!(expires_at: nil)
+      done = BatchToken.create!(expires_at: 1.day.ago)
+
+      expect(BatchToken.expire_all).to eq(2)
+      expect(BatchToken.expired.count).to eq(3)
+      expect(done.reload.expires_at).to be_within(1.second).of(1.day.ago)
+    end
+
+    it "is idempotent" do
+      BatchToken.create!(expires_at: 1.day.from_now)
+      BatchToken.expire_all
+
+      expect(BatchToken.expire_all).to eq(0)
+    end
+
+    it "accepts an explicit time" do
+      BatchToken.create!(expires_at: nil)
+      at = 2.days.ago
+
+      BatchToken.expire_all(at)
+
+      expect(BatchToken.first.expires_at).to be_within(1.second).of(at)
+    end
+
+    it "uses the per-record path when expire! is overridden" do
+      stub_const("CountingToken", Class.new(TestModel) do
+        self.table_name = "batch_tokens"
+        include ConcernsOnRails::Expirable
+        expirable_by
+
+        cattr_accessor :calls
+        self.calls = 0
+
+        def expire!(time = Time.zone.now)
+          self.class.calls += 1
+          super
+        end
+      end)
+      2.times { CountingToken.create!(expires_at: nil) }
+
+      expect(CountingToken.expire_all).to eq(2)
+      expect(CountingToken.calls).to eq(2)
+    end
+  end
+```
+
+Append to `spec/concerns/models/activatable_spec.rb`:
+
+```ruby
+  describe "batch operations" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :batch_flags, force: true do |t|
+          t.boolean :active
+        end
+      end
+
+      stub_const("BatchFlag", Class.new(TestModel) do
+        self.table_name = "batch_flags"
+        include ConcernsOnRails::Activatable
+        activatable_by
+      end)
+    end
+
+    it "activates every inactive record and returns the count" do
+      BatchFlag.create!(active: false)
+      BatchFlag.create!(active: nil)
+      BatchFlag.create!(active: true)
+
+      expect(BatchFlag.activate_all).to eq(2)
+      expect(BatchFlag.active.count).to eq(3)
+    end
+
+    it "deactivates every active record" do
+      BatchFlag.create!(active: true)
+      BatchFlag.create!(active: false)
+
+      expect(BatchFlag.deactivate_all).to eq(1)
+      expect(BatchFlag.inactive.count).to eq(2)
+    end
+
+    it "is idempotent" do
+      BatchFlag.create!(active: false)
+      BatchFlag.activate_all
+
+      expect(BatchFlag.activate_all).to eq(0)
+    end
+
+    it "respects the relation" do
+      keep = BatchFlag.create!(active: false)
+      BatchFlag.create!(active: false)
+
+      expect(BatchFlag.where.not(id: keep.id).activate_all).to eq(1)
+      expect(keep.reload.active).to be false
+    end
+  end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec spec/concerns/models/expirable_spec.rb spec/concerns/models/activatable_spec.rb -e "batch operations"`
+Expected: FAIL — `undefined method 'expire_all'` / `undefined method 'activate_all'`
+
+- [ ] **Step 3: Write the Expirable implementation**
+
+Add `require "concerns_on_rails/support/batch_ops"` to `lib/concerns_on_rails/models/expirable.rb` and add to the public part of `class_methods do` (above `private`):
+
+```ruby
+        # Expire every currently-active record in the relation. Returns the
+        # Integer count. Expirable defines no lifecycle hooks, so this is a
+        # single UPDATE unless the model overrode `expire!`.
+        def expire_all(time = Time.zone.now)
+          active = all.public_send(expirable_scope_names.fetch(:active))
+          if ConcernsOnRails::Support::BatchOps.fast_path?(self, ConcernsOnRails::Models::Expirable, :expire!)
+            return active.update_all(expirable_field => time)
+          end
+
+          ConcernsOnRails::Support::BatchOps.run(
+            active,
+            label: "ConcernsOnRails::Models::Expirable",
+            message: "failed to expire record"
+          ) { |record| record.expire!(time) }
+        end
+```
+
+- [ ] **Step 4: Write the Activatable implementation**
+
+Add `require "concerns_on_rails/support/batch_ops"` to `lib/concerns_on_rails/models/activatable.rb` and add to `class_methods do` (above `private`):
+
+```ruby
+        # Activate every inactive record in the relation; returns the count.
+        def activate_all
+          inactive = all.public_send(activatable_scope_names.fetch(:inactive))
+          if ConcernsOnRails::Support::BatchOps.fast_path?(self, ConcernsOnRails::Models::Activatable, :activate!)
+            return inactive.update_all(activatable_field => true)
+          end
+
+          ConcernsOnRails::Support::BatchOps.run(
+            inactive,
+            label: "ConcernsOnRails::Models::Activatable",
+            message: "failed to activate record"
+          ) { |record| record.activate! }
+        end
+
+        # Deactivate every active record in the relation; returns the count.
+        def deactivate_all
+          active = all.public_send(activatable_scope_names.fetch(:active))
+          if ConcernsOnRails::Support::BatchOps.fast_path?(self, ConcernsOnRails::Models::Activatable, :deactivate!)
+            return active.update_all(activatable_field => false)
+          end
+
+          ConcernsOnRails::Support::BatchOps.run(
+            active,
+            label: "ConcernsOnRails::Models::Activatable",
+            message: "failed to deactivate record"
+          ) { |record| record.deactivate! }
+        end
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec spec/concerns/models/expirable_spec.rb spec/concerns/models/activatable_spec.rb`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/concerns_on_rails/models/expirable.rb lib/concerns_on_rails/models/activatable.rb spec/concerns/models/expirable_spec.rb spec/concerns/models/activatable_spec.rb
+git commit -m "Add Expirable#expire_all and Activatable#activate_all / #deactivate_all"
+```
+
+---
+
+### Task 11: Lockable `unlock_expired`
+
+**Files:**
+- Modify: `lib/concerns_on_rails/models/lockable.rb`
+- Test: `spec/concerns/models/lockable_spec.rb`
+
+**Interfaces:**
+- Produces: `unlock_expired -> Integer`.
+
+**Semantics:** targets rows whose `locked_at <= Time.zone.now - unlock_in` — the same inclusive boundary as `lock_expired?` and the `.locked`/`.unlocked` scopes. Clears `locked_at` **and** zeroes the attempts counter, mirroring `unlock_access!`. Returns `0` without querying when `unlock_in` is nil (manual-unlock-only models have nothing that expires).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `spec/concerns/models/lockable_spec.rb`:
+
+```ruby
+  describe "#unlock_expired" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :batch_accounts, force: true do |t|
+          t.integer :failed_attempts, default: 0
+          t.datetime :locked_at
+        end
+      end
+    end
+
+    def lockable_class(**options)
+      Class.new(TestModel) do
+        self.table_name = "batch_accounts"
+        include ConcernsOnRails::Lockable
+        lockable_by(attempts: :failed_attempts, locked_at: :locked_at, **options)
+      end
+    end
+
+    it "unlocks only the rows whose window has elapsed, and returns the count" do
+      klass = lockable_class(unlock_in: 15.minutes)
+      stale = klass.create!(failed_attempts: 5, locked_at: 1.hour.ago)
+      fresh = klass.create!(failed_attempts: 5, locked_at: 1.minute.ago)
+      never = klass.create!(failed_attempts: 2, locked_at: nil)
+
+      expect(klass.unlock_expired).to eq(1)
+
+      expect(stale.reload.locked_at).to be_nil
+      expect(stale.failed_attempts).to eq(0)
+      expect(fresh.reload.locked_at).not_to be_nil
+      expect(fresh.failed_attempts).to eq(5)
+      expect(never.reload.failed_attempts).to eq(2)
+    end
+
+    it "returns 0 when unlock_in is nil" do
+      klass = lockable_class(unlock_in: nil)
+      klass.create!(failed_attempts: 5, locked_at: 1.year.ago)
+
+      expect(klass.unlock_expired).to eq(0)
+      expect(klass.first.locked_at).not_to be_nil
+    end
+
+    it "is idempotent" do
+      klass = lockable_class(unlock_in: 15.minutes)
+      klass.create!(failed_attempts: 5, locked_at: 1.hour.ago)
+      klass.unlock_expired
+
+      expect(klass.unlock_expired).to eq(0)
+    end
+
+    it "fires the unlock hooks once per record when they are overridden" do
+      klass = Class.new(TestModel) do
+        self.table_name = "batch_accounts"
+        include ConcernsOnRails::Lockable
+        lockable_by attempts: :failed_attempts, locked_at: :locked_at, unlock_in: 15.minutes
+
+        cattr_accessor :unlocked_ids
+        self.unlocked_ids = []
+
+        def after_unlock
+          self.class.unlocked_ids << id
+        end
+      end
+      stub_const("HookedAccount", klass)
+      a = HookedAccount.create!(failed_attempts: 5, locked_at: 1.hour.ago)
+
+      expect(HookedAccount.unlock_expired).to eq(1)
+      expect(HookedAccount.unlocked_ids).to eq([a.id])
+    end
+  end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec spec/concerns/models/lockable_spec.rb -e "unlock_expired"`
+Expected: FAIL — `undefined method 'unlock_expired'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `require "concerns_on_rails/support/batch_ops"` to `lib/concerns_on_rails/models/lockable.rb` and add to the public part of `module ClassMethods` (above `private`):
+
+```ruby
+        # Unlock every row whose lock window has fully elapsed, clearing
+        # locked_at and zeroing the attempts counter exactly as
+        # unlock_access! does. Returns the Integer count.
+        #
+        # Nothing expires when unlock_in is nil (manual unlock only), so that
+        # case returns 0 without touching the database. The boundary instant
+        # counts as expired, matching lock_expired? and the scopes.
+        def unlock_expired
+          unlock_in = lockable_unlock_in
+          return 0 unless unlock_in
+
+          locked_field = lockable_locked_at_field
+          attempts_field = lockable_attempts_field
+          # `lteq` on a NULL locked_at is NULL, so never-locked rows are
+          # excluded without an extra predicate.
+          expired = all.where(arel_table[locked_field].lteq(Time.zone.now - unlock_in))
+
+          if ConcernsOnRails::Support::BatchOps.fast_path?(self, ConcernsOnRails::Models::Lockable,
+                                                           :before_unlock, :after_unlock, :unlock_access!)
+            return expired.update_all(locked_field => nil, attempts_field => 0)
+          end
+
+          ConcernsOnRails::Support::BatchOps.run(
+            expired,
+            label: LABEL,
+            message: "failed to unlock record"
+          ) { |record| record.unlock_access! }
+        end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec spec/concerns/models/lockable_spec.rb`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/concerns_on_rails/models/lockable.rb spec/concerns/models/lockable_spec.rb
+git commit -m "Add Lockable#unlock_expired"
+```
+
+---
+
+### Task 12: Stateable `transition_all`
+
+**Files:**
+- Modify: `lib/concerns_on_rails/models/stateable.rb`
+- Test: `spec/concerns/models/stateable_spec.rb`
+
+**Interfaces:**
+- Produces: `transition_all(event) -> Integer`.
+
+**Semantics — no fast path, ever.** The per-record path (`stateable_execute_transition!`) uses `update!`, which runs **validations**; every other concern's per-record path uses `update_column`/`update_columns`, which do not. Collapsing Stateable to `update_all` would therefore silently skip validations the single-record call runs. It always streams. Guard membership is still filtered DB-side (`where(field => from)`) so the query is cheap, and records that fail `may_<event>?` at call time are **skipped, not errors**.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `spec/concerns/models/stateable_spec.rb`:
+
+```ruby
+  describe "#transition_all" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :batch_orders, force: true do |t|
+          t.string :status
+        end
+      end
+
+      stub_const("BatchOrder", Class.new(TestModel) do
+        self.table_name = "batch_orders"
+        include ConcernsOnRails::Stateable
+        stateable_by :status,
+                     states: %i[draft submitted approved],
+                     default: :draft,
+                     transitions: {
+                       submit: { from: :draft, to: :submitted },
+                       approve: { from: :submitted, to: :approved }
+                     }
+      end)
+    end
+
+    it "transitions every eligible record and returns the count" do
+      BatchOrder.create!(status: "draft")
+      BatchOrder.create!(status: "draft")
+      other = BatchOrder.create!(status: "submitted")
+
+      expect(BatchOrder.transition_all(:submit)).to eq(2)
+      expect(BatchOrder.where(status: "submitted").count).to eq(3)
+      expect(other.reload.status).to eq("submitted")
+    end
+
+    it "skips records the guard rejects rather than raising" do
+      BatchOrder.create!(status: "draft")
+      BatchOrder.create!(status: "approved")
+
+      expect(BatchOrder.transition_all(:submit)).to eq(1)
+    end
+
+    it "is idempotent" do
+      BatchOrder.create!(status: "draft")
+      BatchOrder.transition_all(:submit)
+
+      expect(BatchOrder.transition_all(:submit)).to eq(0)
+    end
+
+    it "respects the relation" do
+      keep = BatchOrder.create!(status: "draft")
+      BatchOrder.create!(status: "draft")
+
+      expect(BatchOrder.where.not(id: keep.id).transition_all(:submit)).to eq(1)
+      expect(keep.reload.status).to eq("draft")
+    end
+
+    it "fires the transition hooks once per record" do
+      stub_const("HookedOrder", Class.new(TestModel) do
+        self.table_name = "batch_orders"
+        include ConcernsOnRails::Stateable
+        stateable_by :status, states: %i[draft submitted],
+                              transitions: { submit: { from: :draft, to: :submitted } }
+
+        cattr_accessor :events
+        self.events = []
+
+        def after_transition(event, from, to)
+          self.class.events << [event, from, to]
+        end
+      end)
+      HookedOrder.create!(status: "draft")
+
+      expect(HookedOrder.transition_all(:submit)).to eq(1)
+      expect(HookedOrder.events).to eq([[:submit, "draft", "submitted"]])
+    end
+
+    it "raises on an unknown event" do
+      expect { BatchOrder.transition_all(:nope) }
+        .to raise_error(ArgumentError, /unknown transition 'nope'/)
+    end
+
+    it "honours affixed event names" do
+      stub_const("AffixedOrder", Class.new(TestModel) do
+        self.table_name = "batch_orders"
+        include ConcernsOnRails::Stateable
+        stateable_by :status, states: %i[draft submitted], prefix: :order,
+                              transitions: { submit: { from: :draft, to: :submitted } }
+      end)
+      AffixedOrder.create!(status: "draft")
+
+      expect(AffixedOrder.transition_all(:submit)).to eq(1)
+      expect(AffixedOrder.where(status: "submitted").count).to eq(1)
+    end
+  end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec spec/concerns/models/stateable_spec.rb -e "transition_all"`
+Expected: FAIL — `undefined method 'transition_all'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `require "concerns_on_rails/support/batch_ops"` to `lib/concerns_on_rails/models/stateable.rb` and add to the public part of `module ClassMethods` (above `private`):
+
+```ruby
+        # Run one declared transition across the relation. Returns the Integer
+        # count of records transitioned; records whose current state the
+        # event's guard rejects are skipped, not errors.
+        #
+        # There is deliberately NO single-UPDATE fast path here: the
+        # per-record path goes through `update!`, which runs validations,
+        # while every fast path in this gem uses `update_all`, which does not.
+        # Collapsing would silently skip validations that `<event>!` runs.
+        # Guard membership is still filtered DB-side, so the scan is cheap.
+        def transition_all(event)
+          name = event.to_sym
+          config = stateable_transitions[name] || stateable_transitions[event.to_s]
+          raise ArgumentError, "#{LABEL}: unknown transition '#{event}'" unless config
+
+          from = Array(config[:from]).map(&:to_s)
+          to = config.fetch(:to).to_s
+          field = stateable_field
+          method_base = stateable_method_name(name)
+
+          eligible = from.empty? ? all : all.where(field => from)
+          eligible = eligible.where.not(field => to)
+
+          ConcernsOnRails::Support::BatchOps.run(
+            eligible,
+            label: LABEL,
+            message: "failed to transition record"
+          ) do |record|
+            record.public_send(:"may_#{method_base}?") ? record.public_send(:"#{method_base}!") : :skip
+          end
+        end
+```
+
+Note: `stateable_method_name` is private on `ClassMethods`; `transition_all` is in the same module, so the implicit-receiver call is legal.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec spec/concerns/models/stateable_spec.rb`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `ASDF_RUBY_VERSION=3.2.2 bundle exec rspec`
+Expected: PASS, 0 failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/concerns_on_rails/models/stateable.rb spec/concerns/models/stateable_spec.rb
+git commit -m "Add Stateable#transition_all"
+```
+
+---
+
+### Task 13: Documentation and 1.27.0 release preparation
+
+Per the project release process every one of these files moves together — README omission is how Encryptable once shipped undocumented.
+
+**Files:**
+- Modify: `lib/concerns_on_rails/version.rb`
+- Modify: `Gemfile.lock` (PATH pin, line 4)
+- Modify: `CHANGELOG.md`
+- Modify: `README.md`
+- Modify: `docs/assets/js/concerns.js`
+
+- [ ] **Step 1: Bump the version and the lockfile pin**
+
+```bash
+sed -i '' 's/VERSION = "1.26.0"/VERSION = "1.27.0"/' lib/concerns_on_rails/version.rb
+sed -i '' 's/concerns_on_rails (1.26.0)/concerns_on_rails (1.27.0)/' Gemfile.lock
+grep -n "1.27.0" lib/concerns_on_rails/version.rb Gemfile.lock
+```
+
+- [ ] **Step 2: Add the CHANGELOG entry**
+
+Insert directly below the `<!-- CHANGELOG.md -->` line:
+
+```markdown
+## 1.27.0 (2026-08-29)
+
+Scope-name collisions finally have an escape hatch on every concern that
+generates scopes, and the 1.22 batch-operation contract reaches five more
+concerns. No new columns, migrations or dependencies.
+
+### Added
+- **Models::Publishable / SoftDeletable / Schedulable**: `prefix:`/`suffix:` on
+  `publishable_by` / `soft_deletable_by` / `schedulable_by` rename the generated
+  scopes, so a model can include SoftDeletable (`.active`) alongside Activatable
+  or Expirable (also `.active`) without one silently clobbering the other. With
+  no affix passed the scope names, default scopes and emitted SQL are unchanged.
+  `prefix: true` (use the configured field name), previously honoured only by
+  Stateable, now works on every affixing concern.
+- **Models::Publishable**: `publish_all` / `unpublish_all`. `publish_all` targets
+  every not-currently-published row — *including scheduled ones*, whose future
+  timestamp it overwrites; chain the draft scope (`Post.draft.publish_all`) to
+  narrow it. Both respect the relation, return an Integer count, run in a
+  transaction, and collapse to one UPDATE unless a hook or bang method is
+  overridden.
+- **Models::Expirable**: `expire_all(time = Time.zone.now)`.
+- **Models::Activatable**: `activate_all` / `deactivate_all`.
+- **Models::Lockable**: `unlock_expired` — clears `locked_at` and zeroes the
+  attempts counter on every row whose `unlock_in` window has elapsed, mirroring
+  `unlock_access!`. Returns 0 without querying when `unlock_in` is nil.
+- **Models::Stateable**: `transition_all(event)` — runs one declared transition
+  across the relation, skipping (not failing) records the guard rejects.
+  Deliberately has no single-UPDATE fast path: the per-record path runs
+  validations through `update!` and a bulk UPDATE would skip them.
+
+### Internal
+- New `Support::Affix` (affixed-name computation, `prefix: true` normalization,
+  and the guarded scope capture/retirement used by the three newly affixable
+  concerns) replaces six duplicated implementations across Activatable,
+  Expirable, Lockable, Anonymizable, Stateable and Storable.
+- New `Support::BatchOps` (hook-ownership fast-path predicate + the
+  transactional `find_each` runner); SoftDeletable's `soft_delete_all` /
+  `restore_all` now route through it, so the contract has one definition.
+- Retiring a default-named scope is guarded three ways — the name must have been
+  recorded by the concern, be owned by the class's own singleton, and still be
+  the exact method captured — so a model's own override survives and a parent's
+  scopes are never removed from a subclass (that case raises with a pointer to
+  the parent).
+```
+
+- [ ] **Step 3: Update the README**
+
+Three edits:
+
+1. In each of the Publishable, SoftDeletable and Schedulable sections, add the new
+   option to the options list: `prefix:` / `suffix:` — affix the generated scope
+   names so they don't collide with another concern's; `true` means the
+   configured field name.
+2. In the Publishable, Expirable, Activatable, Lockable and Stateable sections,
+   document the new batch verb with a one-line example, e.g.
+   `Post.draft.publish_all   # => 12` and
+   `Account.unlock_expired    # => 3`.
+3. Add a short note where `prefix:` is first documented, distinguishing its three
+   meanings: scope-name affix (Activatable, Expirable, Lockable, Stateable,
+   Anonymizable, Publishable, SoftDeletable, Schedulable), accessor-name affix
+   (Storable), and a literal string prepended to the generated value
+   (Sequenceable). Searchable's `match: :prefix` is a LIKE mode, unrelated to
+   either.
+
+- [ ] **Step 4: Bump the docs-site version**
+
+```bash
+grep -n "1\.26\.0" docs/assets/js/concerns.js
+```
+Update the version string to `1.27.0`.
+
+- [ ] **Step 5: Verify everything**
+
+```bash
+ASDF_RUBY_VERSION=3.2.2 bundle exec rspec
+ASDF_RUBY_VERSION=3.2.2 bundle exec rubocop
+```
+Expected: RSpec 0 failures; RuboCop clean. If RuboCop flags offences, fix them by hand — do **not** run `rubocop -A` on files containing lambda literals.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/concerns_on_rails/version.rb Gemfile.lock CHANGELOG.md README.md docs/assets/js/concerns.js
+git commit -m "Release 1.27.0: scope affixing + batch operations"
+```
+
+Do not tag or push — releasing is a separate, explicitly-authorized step.

--- a/docs/superpowers/specs/2026-08-29-affixing-and-batch-ops-design.md
+++ b/docs/superpowers/specs/2026-08-29-affixing-and-batch-ops-design.md
@@ -189,22 +189,48 @@ Every batch verb, matching `soft_delete_all` / `restore_all` / `anonymize_all!`:
 `soft_delete_batch_fast_path?` generalizes to:
 
 ```ruby
-ConcernsOnRails::Support::BatchOps.fast_path?(klass, owner, *methods)
+ConcernsOnRails::Support::BatchOps.unoverridden?(klass, owner, *methods)
 # true when every named instance method is still owned by `owner`
 # (i.e. the host model overrode none of the concern's hooks or bang methods)
+
+ConcernsOnRails::Support::BatchOps.fast_path?(klass, owner, *methods)
+# the WHOLE decision: unoverridden? AND the host model declares no validations
+
+ConcernsOnRails::Support::BatchOps.with_timestamps(klass, attributes)
+# the bulk-write payload, plus updated_at/updated_on when the model has them
+# and record_timestamps is on
 ```
 
-SoftDeletable is refactored onto it — keeping its extra `return false if
-soft_delete_touch` guard at the call site — so the rule has one definition rather
-than six. Its existing specs guard the move. Autoloaded alongside `Support::Affix`.
+The validations half cannot be `klass.validators.empty?`: `validators` is
+populated only by `validates` / `validates_with`, while a custom
+`validate :method` (or `validate do … end`) registers only a `_validate_callbacks`
+entry and leaves `validators` empty — so that gate took the fast path, and wrote
+invalid rows, through one of the most common declaration forms. `validations?`
+therefore also diffs `_validate_callbacks` filters against
+`ActiveRecord::Base`'s own (Rails ships one there, so a raw count doesn't work).
+Hoisting the whole decision into `fast_path?` keeps it in one place instead of
+three near-copies.
+
+`with_timestamps` exists because `update_all` never touches `updated_at` while
+the per-record `update` does: without it a batch verb would bump `updated_at` or
+not depending on whether the model happens to declare a validator, silently
+staling cache keys and `updated_since` sync jobs. It is what Rails' own
+`touch_all` / `update_counters(touch:)` do.
+
+SoftDeletable and Lockable call `unoverridden?` rather than `fast_path?` — both
+are exempt from the validations half (and from `with_timestamps`) because their
+per-record paths write via `update_column(s)`, which already skips validations
+and timestamps, so their two paths are equivalent as they stand. SoftDeletable
+keeps its extra `return false if soft_delete_touch` guard at the call site. Its
+existing specs guard the move. Autoloaded alongside `Support::Affix`.
 
 ### Verbs
 
 | Concern | Verb(s) | Target rows | Fast path | Notes |
 |---|---|---|---|---|
-| Publishable | `publish_all`, `unpublish_all` | not currently published / currently published | when `before/after_publish`, `before/after_unpublish`, `publish!`, `unpublish!` are unoverridden **and the model declares no validators** | branches boolean vs timestamp column, like every other Publishable scope. The per-record path calls `update`, which runs validations, while `update_all` does not — so a model with `validates` must take the slow path even with every hook unoverridden |
-| Expirable | `expire_all` | currently active | when `expire!` is unoverridden **and the model declares no validators** | Expirable defines no hooks, so an overridden bang method or the presence of validators forces the slow path; same `update` vs `update_all` gap as Publishable |
-| Activatable | `activate_all`, `deactivate_all` | inactive / active | when the bang method is unoverridden **and the model declares no validators** | Activatable defines no hooks; `toggle_active!`'s row lock has no batch analogue; same `update` vs `update_all` gap as Publishable |
+| Publishable | `publish_all`, `unpublish_all` | not currently published / currently published | when `before/after_publish`, `before/after_unpublish`, `publish!`, `unpublish!` are unoverridden **and the model declares no validations** (`validates`/`validates_with` or a custom `validate`) | branches boolean vs timestamp column, like every other Publishable scope. The per-record path calls `update`, which runs validations, while `update_all` does not — so a model with any validation must take the slow path even with every hook unoverridden |
+| Expirable | `expire_all` | currently active | when `expire!` is unoverridden **and the model declares no validations** | Expirable defines no hooks, so an overridden bang method or any declared validation forces the slow path; same `update` vs `update_all` gap as Publishable |
+| Activatable | `activate_all`, `deactivate_all` | inactive / active | when the bang method is unoverridden **and the model declares no validations** | Activatable defines no hooks; `toggle_active!`'s row lock has no batch analogue; same `update` vs `update_all` gap as Publishable |
 | Lockable | `unlock_expired` | locked rows whose `locked_at + unlock_in` has passed | when `before/after_unlock` and `unlock_access!` are unoverridden | must also reset failed attempts, mirroring `unlock_access!`; matches nothing when `unlock_in` is nil |
 | Stateable | `transition_all(event)` | rows in a state the event can leave, minus rows already in the target state | **never** | the per-record path uses `update!`, which runs validations, while every fast path uses `update_all`, which does not — collapsing would silently skip them. Guard membership is still filtered DB-side; records failing `may_<event>?` are **skipped, not errors** |
 
@@ -215,6 +241,26 @@ than six. Its existing specs guard the move. Autoloaded alongside `Support::Affi
 verbs respect the relation, the narrow case is expressible without a special
 case: `Post.draft.publish_all`. Documented in the Publishable section of the
 README; not special-cased in code.
+
+For that mitigation to actually work, `publish_all` builds its "not currently
+published" predicate INLINE against `all` instead of calling the `unpublished`
+scope: that scope's body opens with `unscope(where: publishable_field)`, which
+strips the *caller's own* predicate on the publish column right back off — so
+`Post.draft.publish_all` silently discarded `.draft`, published scheduled rows
+and overwrote their future timestamps unrecoverably. Rejected alternatives: an
+`include_scheduled:` keyword (public surface routing around a bug) and merely
+documenting the sharp edge (the relation-respecting contract exists so that
+chaining works).
+
+Accepted consequence: on a model configured with `default_scope: true`, `all`
+is already narrowed to published rows, so a bare `Post.publish_all` targets
+nothing. Such callers chain `.draft` or `.unpublished` first — both unscope the
+field themselves, so the chain resolves correctly. Documented on the method, in
+the README and in the CHANGELOG.
+
+`unpublish_all` needs no equivalent change: it targets the `published` scope,
+whose body does not unscope, so a caller's constraint on the publish column
+already composes.
 
 ### No bangs on the new verbs
 

--- a/docs/superpowers/specs/2026-08-29-affixing-and-batch-ops-design.md
+++ b/docs/superpowers/specs/2026-08-29-affixing-and-batch-ops-design.md
@@ -1,0 +1,303 @@
+# Scope affixing + batch operations
+
+**Date:** 2026-08-29
+**Target release:** 1.27.0
+**Status:** approved design, not yet implemented
+
+Sub-project 1 of a four-part "deepen the existing concerns" wave. The remaining
+three (controller-side polish, Encryptable key rotation, Rails-native bridges)
+each get their own spec and release; see *Wave context* at the end.
+
+## Problem
+
+Two gaps in the shipped model concerns, both traceable to the 1.22 review
+backlog.
+
+**Scope-name collisions have no escape hatch on three concerns.** SoftDeletable,
+Publishable and Schedulable define their scopes in `included do`, with hard-coded
+names. Activatable, Expirable, Lockable, Stateable and Anonymizable define theirs
+inside their macro and accept `prefix:`/`suffix:` to rename them. So a model that
+includes SoftDeletable (`.active`) alongside Activatable (`.active`) or Expirable
+(`.active`) gets a silent clobber — whichever concern is included last wins.
+Activatable's own source comments the problem and offers no way out:
+
+    # Note: SoftDeletable also defines a `.active` scope (alias of `.without_deleted`).
+    # If both concerns are included on the same model, the later one wins.
+
+**Batch verbs exist on two concerns and are missing on five.** SoftDeletable has
+`soft_delete_all`/`restore_all` and Anonymizable has `anonymize_all!`, both built
+on a deliberate contract (relation-respecting, Integer count, transactional,
+DB-side filtering, single-UPDATE fast path). Publishable, Expirable, Activatable,
+Lockable and Stateable have per-record bang methods only, so the equivalent bulk
+operation is a hand-rolled `find_each` in application code with none of those
+properties.
+
+A third, smaller problem sits underneath both: the affix-name computation is
+duplicated six times, and `prefix: true` ("use the field name") is honoured by
+Stateable alone.
+
+## Non-goals
+
+- Encryptable key rotation, controller-concern polish, Rails-native bridges — the
+  other three sub-projects of the wave.
+- Any new concern.
+- Renaming Sequenceable's or Searchable's `prefix:` (see *Naming hazard*).
+- Adding affixing to concerns that generate no scopes.
+- New columns, migrations, or dependencies. This release adds none of the three.
+
+## Part 1 — `Support::Affix`
+
+A new support module, autoloaded from `lib/concerns_on_rails.rb`, with two
+methods:
+
+```ruby
+ConcernsOnRails::Support::Affix.normalize(option, default:)
+# nil / false        -> nil
+# true               -> default.to_s      (the configured field name)
+# String / Symbol    -> option.to_s
+
+ConcernsOnRails::Support::Affix.name(base, prefix:, suffix:)
+# -> [prefix, base, suffix].compact.join("_").to_sym
+```
+
+`name` replaces six copies of the same expression: the identical private
+`activatable_scope_name` / `expirable_scope_name` / `lockable_scope_name`
+methods, Anonymizable's `affixed` lambda, Stateable's `stateable_method_name`,
+and Storable's inline join in `storable_normalize_spec`.
+
+`normalize` generalizes Stateable's `stateable_affix` — today Stateable is the
+only concern where `prefix: true` means "use the field name"; after this change
+every affixing concern accepts it. That is a pure addition: no currently valid
+call changes meaning.
+
+Each refactored call site keeps its existing public behaviour exactly; the
+concerns' current specs are the regression guard for the extraction.
+
+### Naming hazard (documented, not fixed)
+
+`prefix:` already carries three unrelated meanings in this gem:
+
+| Concern | `prefix:` means |
+|---|---|
+| Activatable, Expirable, Lockable, Stateable, Anonymizable, + the three added here | affix on generated **scope names** |
+| Storable | affix on generated **accessor names** |
+| Sequenceable | a literal string prepended to the **generated value** (`"INV-"`) |
+
+Searchable additionally uses `match: :prefix` for a LIKE mode. Renaming any of
+these is a breaking change with no functional gain, so the README gains a short
+note distinguishing them. The design does not pretend they are uniform.
+
+## Part 2 — affixing Publishable, SoftDeletable, Schedulable
+
+### Strategy: additive by default, opt-in removal
+
+Chosen over two alternatives (recorded in *Decisions* below).
+
+1. `included do` keeps defining the default-named scopes exactly as it does
+   today. A model that only includes the concern, never calling the macro, is
+   completely unaffected — this is a supported and documented usage today, since
+   each concern defaults its field in `included do`.
+2. The scope bodies move out of `included do` into a private
+   `define_<concern>_scopes(prefix, suffix)` class method — the pattern
+   Expirable already uses. `included do` calls it with `nil, nil`.
+3. The macro gains `prefix:`/`suffix:`. When either is present it calls
+   `define_<concern>_scopes` again with the affixes, then retires the
+   default-named scopes it previously defined.
+
+### Retirement rules
+
+At include time each concern records, in a `class_attribute` (e.g.
+`publishable_default_scopes`), a name => `UnboundMethod` map: the scope names it
+defined, each paired with the `singleton_class.instance_method(name)` captured
+immediately after definition. A name is removed only when **all three** hold:
+
+- it is in that recorded map (never a name the concern did not create);
+- `singleton_class.instance_method(name).owner == singleton_class` — the scope is
+  owned by *this* class's own singleton, not inherited; and
+- the currently bound `UnboundMethod` `==` the one recorded at definition time —
+  the scope is still the concern's own, not something the model redefined.
+
+Verified mechanics (probe, 2026-08-29): `scope` defines a method on the class's
+own singleton; the owner check returns `true` on the defining class and `false`
+when viewed from a subclass; `remove_method` on the singleton removes the scope
+from the class and its subclasses; affixed scopes chain normally afterwards.
+
+Consequences of the three guards:
+
+- **User override preserved.** If the model redefined `.published` itself, the
+  first two conditions still hold (same name, same singleton) but the third
+  fails — the bound method is no longer the one the concern recorded — so the
+  override is left alone and nothing is removed.
+- **Parent scopes are never removed from a subclass.** Covered by the owner
+  check, which is `false` for inherited scopes.
+
+### STI subclass raises
+
+Calling the macro with an affix on a subclass whose parent owns the scopes raises
+`ArgumentError`, naming the parent class and telling the caller to affix there.
+
+Rationale: the alternative — skipping silently — leaves the parent's colliding
+scope in place and returns an escape hatch that does not work. A teaching
+`ArgumentError` matches how this gem already handles misconfiguration
+(ColumnGuard's migration hints, Sortable's unknown-option and invalid-direction
+raises from 1.26).
+
+### The failure mode this must not ship
+
+Affixing breaks any scope body that references another scope **by literal name**.
+Every such reference must resolve through the stored affixed name (kept in a
+`class_attribute` and invoked with `public_send`), not a hard-coded symbol:
+
+| Concern | Reference |
+|---|---|
+| SoftDeletable | `default_scope { soft_delete_default_scope ? without_deleted : all }` |
+| SoftDeletable | `only_deleted` delegates to `soft_deleted` |
+| SoftDeletable | `deleted_within(duration)` builds on `soft_deleted` |
+| Publishable | `enable_published_default_scope` calls `default_scope { published }` |
+| Schedulable | `current` calls `active_at(Time.zone.now)` |
+
+A missed reference produces a `NoMethodError` at query time, or — worse, for the
+`default_scope` cases — a model whose default scope silently stops filtering.
+These get dedicated specs (see *Testing*).
+
+### Macro option validation
+
+Sortable and Stateable raise on unknown macro options as of 1.26. `prefix:` and
+`suffix:` must be added to the relevant `OPTIONS` lists, or last release's
+hardening rejects the new keywords.
+
+## Part 3 — batch operations
+
+### The contract (already established, not invented here)
+
+Every batch verb, matching `soft_delete_all` / `restore_all` / `anonymize_all!`:
+
+- is a class method on `ClassMethods`, operating on `all` — it respects the
+  current relation, so `Post.draft.publish_all` works;
+- returns the **Integer count** of records transitioned;
+- runs inside a `transaction`; a record that fails to save raises
+  `ActiveRecord::RecordNotSaved` (message prefixed with the concern's label) and
+  rolls the entire batch back;
+- filters already-transitioned rows **DB-side**, making it idempotent — a second
+  call returns 0 and issues no per-record work;
+- collapses to a **single `UPDATE`** when the fast path applies;
+- otherwise streams with `find_each` (memory-bounded; forward-by-PK pagination is
+  safe even as updated rows leave the filtered set).
+
+### `Support::BatchOps`
+
+`soft_delete_batch_fast_path?` generalizes to:
+
+```ruby
+ConcernsOnRails::Support::BatchOps.fast_path?(klass, owner, *methods)
+# true when every named instance method is still owned by `owner`
+# (i.e. the host model overrode none of the concern's hooks or bang methods)
+```
+
+SoftDeletable is refactored onto it — keeping its extra `return false if
+soft_delete_touch` guard at the call site — so the rule has one definition rather
+than six. Its existing specs guard the move. Autoloaded alongside `Support::Affix`.
+
+### Verbs
+
+| Concern | Verb(s) | Target rows | Fast path | Notes |
+|---|---|---|---|---|
+| Publishable | `publish_all`, `unpublish_all` | not currently published / currently published | when `before/after_publish`, `before/after_unpublish`, `publish!`, `unpublish!` are unoverridden | branches boolean vs timestamp column, like every other Publishable scope |
+| Expirable | `expire_all` | currently active | always | Expirable defines no hooks |
+| Activatable | `activate_all`, `deactivate_all` | inactive / active | always | Activatable defines no hooks; `toggle_active!`'s row lock has no batch analogue |
+| Lockable | `unlock_expired` | locked rows whose `locked_at + unlock_in` has passed | when `before/after_unlock` and `unlock_access!` are unoverridden | must also reset failed attempts, mirroring `unlock_access!`; matches nothing when `unlock_in` is nil |
+| Stateable | `transition_all(event)` | rows in a state the event can leave | only when the event is unguarded and hooks are unoverridden | guards are per-record, so the guarded case always streams; records failing `may_<event>?` are **skipped, not errors** |
+
+### `publish_all` and scheduled rows
+
+`publish_all` targets rows that are not currently published, which includes
+*scheduled* rows — overwriting a future `published_at` with now. Because batch
+verbs respect the relation, the narrow case is expressible without a special
+case: `Post.draft.publish_all`. Documented in the Publishable section of the
+README; not special-cased in code.
+
+### No bangs on the new verbs
+
+The shipped precedent is inconsistent: `soft_delete_all` and `really_destroy_all`
+carry no bang, `anonymize_all!` does; the instance methods (`soft_delete!`,
+`activate!`) all do. The new verbs follow the majority and take no bang.
+`anonymize_all!` keeps its name — renaming it would break users — and is
+documented as the irreversible-erasure exception.
+
+## Testing
+
+Per affixed concern (Publishable, SoftDeletable, Schedulable):
+
+- default scope names unchanged when the macro is called with no affix;
+- default scope names unchanged when the macro is never called at all;
+- affixed names defined, and default names **gone**, when an affix is passed;
+- `default_scope` still filters correctly under an affix (SoftDeletable,
+  Publishable);
+- inter-scope references resolve under an affix (`only_deleted`,
+  `deleted_within`, `current`);
+- a user's own redefinition of a default-named scope survives the macro;
+- affixing on an STI subclass whose parent owns the scopes raises `ArgumentError`.
+
+Integration (does not exist today, and is the scenario that motivates the whole
+part): one model including SoftDeletable + Activatable + Expirable, each affixed,
+asserting all scopes coexist and each returns the right rows.
+
+Per batch verb:
+
+- returns the Integer count;
+- a failing record raises `RecordNotSaved` and rolls the batch back;
+- idempotent — a second call returns 0;
+- respects the relation;
+- fast path issues exactly one `UPDATE` (SQL statement-count assertions, the
+  style introduced in 1.26 for CounterCacheable and Sequenceable);
+- slow path runs the concern's hooks once per record;
+- Stateable: guarded records are skipped, and the guarded event never takes the
+  fast path.
+
+Unit specs for `Support::Affix` (including `normalize(true, default:)`) and
+`Support::BatchOps`.
+
+## Compatibility and rollout
+
+Fully backward compatible. Passing no affix leaves every scope name, default
+scope and query byte-identical; the six `Support::Affix` refactors are
+behaviour-preserving; batch verbs are pure additions. No new columns, migrations,
+gemspec changes or dependencies.
+
+Ships as **1.27.0**, a minor release. Per the project release process, bump
+together: `lib/concerns_on_rails/version.rb`, the `Gemfile.lock` PATH pin,
+`CHANGELOG.md`, `README.md` (TOC row, concern sections, version pins) and
+`docs/assets/js/concerns.js`. Then create the GitHub Release with the built
+`.gem` attached — the `v*` tag triggers CI's trusted-publishing job, which pushes
+to RubyGems. Never `gem push` locally.
+
+## Decisions
+
+**Affixing strategy — additive with opt-in removal.** Rejected: (a) moving all
+scope definitions into the macro behind a deprecation runway — uniform, but fires
+a deprecation at every include-only user for a collision they do not have, and
+defers the clean state to 2.0; (b) additive aliases with no removal — zero risk,
+but the unaffixed scope still clobbers, so the escape hatch would not work. The
+chosen approach confines all new behaviour to models that opt in, and leaves the
+code routed through `define_*_scopes` helpers so 2.0 can reach the uniform end
+state by deleting the include-time calls.
+
+**Raise rather than no-op on STI subclass affixing.** A no-op returns a
+non-functional escape hatch; the raise names the fix.
+
+**Document the three meanings of `prefix:` rather than unify them.** Renaming
+Sequenceable's or Searchable's is breaking, for no functional gain.
+
+## Wave context
+
+1. **1.27 — this spec:** affixing + batch ops.
+2. **1.28 — controller-side polish:** Respondable `render_collection` + RFC 8288
+   Link headers + problem+json, Cacheable ETag `extras:` + auto-Vary, Filterable
+   `type:`/operator coercion, Idempotentable header capture on replay,
+   ErrorHandleable expanded exception map. 1.26 audited only the model concerns.
+3. **1.29 — Encryptable key rotation:** multi-key registry keyed by the envelope's
+   already-reserved `key_id` byte, decrypt-with-any / encrypt-with-current,
+   `reencrypt_all!`, blind-index rehash.
+4. **2.0 — Rails-native bridges:** Normalizable to `normalizes`, Throttleable to
+   Rails 8 `rate_limit`, Tokenizable to `generates_token_for`, Stateable
+   inclusion validation — cheaper after 2.0 moves the Rails floor to >= 6.1.

--- a/docs/superpowers/specs/2026-08-29-affixing-and-batch-ops-design.md
+++ b/docs/superpowers/specs/2026-08-29-affixing-and-batch-ops-design.md
@@ -202,9 +202,9 @@ than six. Its existing specs guard the move. Autoloaded alongside `Support::Affi
 
 | Concern | Verb(s) | Target rows | Fast path | Notes |
 |---|---|---|---|---|
-| Publishable | `publish_all`, `unpublish_all` | not currently published / currently published | when `before/after_publish`, `before/after_unpublish`, `publish!`, `unpublish!` are unoverridden | branches boolean vs timestamp column, like every other Publishable scope |
-| Expirable | `expire_all` | currently active | when `expire!` is unoverridden | Expirable defines no hooks, so only an overridden bang method forces the slow path |
-| Activatable | `activate_all`, `deactivate_all` | inactive / active | when the bang method is unoverridden | Activatable defines no hooks; `toggle_active!`'s row lock has no batch analogue |
+| Publishable | `publish_all`, `unpublish_all` | not currently published / currently published | when `before/after_publish`, `before/after_unpublish`, `publish!`, `unpublish!` are unoverridden **and the model declares no validators** | branches boolean vs timestamp column, like every other Publishable scope. The per-record path calls `update`, which runs validations, while `update_all` does not — so a model with `validates` must take the slow path even with every hook unoverridden |
+| Expirable | `expire_all` | currently active | when `expire!` is unoverridden **and the model declares no validators** | Expirable defines no hooks, so an overridden bang method or the presence of validators forces the slow path; same `update` vs `update_all` gap as Publishable |
+| Activatable | `activate_all`, `deactivate_all` | inactive / active | when the bang method is unoverridden **and the model declares no validators** | Activatable defines no hooks; `toggle_active!`'s row lock has no batch analogue; same `update` vs `update_all` gap as Publishable |
 | Lockable | `unlock_expired` | locked rows whose `locked_at + unlock_in` has passed | when `before/after_unlock` and `unlock_access!` are unoverridden | must also reset failed attempts, mirroring `unlock_access!`; matches nothing when `unlock_in` is nil |
 | Stateable | `transition_all(event)` | rows in a state the event can leave, minus rows already in the target state | **never** | the per-record path uses `update!`, which runs validations, while every fast path uses `update_all`, which does not — collapsing would silently skip them. Guard membership is still filtered DB-side; records failing `may_<event>?` are **skipped, not errors** |
 

--- a/docs/superpowers/specs/2026-08-29-affixing-and-batch-ops-design.md
+++ b/docs/superpowers/specs/2026-08-29-affixing-and-batch-ops-design.md
@@ -203,10 +203,10 @@ than six. Its existing specs guard the move. Autoloaded alongside `Support::Affi
 | Concern | Verb(s) | Target rows | Fast path | Notes |
 |---|---|---|---|---|
 | Publishable | `publish_all`, `unpublish_all` | not currently published / currently published | when `before/after_publish`, `before/after_unpublish`, `publish!`, `unpublish!` are unoverridden | branches boolean vs timestamp column, like every other Publishable scope |
-| Expirable | `expire_all` | currently active | always | Expirable defines no hooks |
-| Activatable | `activate_all`, `deactivate_all` | inactive / active | always | Activatable defines no hooks; `toggle_active!`'s row lock has no batch analogue |
+| Expirable | `expire_all` | currently active | when `expire!` is unoverridden | Expirable defines no hooks, so only an overridden bang method forces the slow path |
+| Activatable | `activate_all`, `deactivate_all` | inactive / active | when the bang method is unoverridden | Activatable defines no hooks; `toggle_active!`'s row lock has no batch analogue |
 | Lockable | `unlock_expired` | locked rows whose `locked_at + unlock_in` has passed | when `before/after_unlock` and `unlock_access!` are unoverridden | must also reset failed attempts, mirroring `unlock_access!`; matches nothing when `unlock_in` is nil |
-| Stateable | `transition_all(event)` | rows in a state the event can leave | only when the event is unguarded and hooks are unoverridden | guards are per-record, so the guarded case always streams; records failing `may_<event>?` are **skipped, not errors** |
+| Stateable | `transition_all(event)` | rows in a state the event can leave, minus rows already in the target state | **never** | the per-record path uses `update!`, which runs validations, while every fast path uses `update_all`, which does not — collapsing would silently skip them. Guard membership is still filtered DB-side; records failing `may_<event>?` are **skipped, not errors** |
 
 ### `publish_all` and scheduled rows
 

--- a/lib/concerns_on_rails.rb
+++ b/lib/concerns_on_rails.rb
@@ -79,6 +79,7 @@ module ConcernsOnRails
     autoload :Money,                   "concerns_on_rails/support/money"
     autoload :Encryptor,               "concerns_on_rails/support/encryptor"
     autoload :Affix,                   "concerns_on_rails/support/affix"
+    autoload :BatchOps,                "concerns_on_rails/support/batch_ops"
   end
 
   # Encryption config + error types (Support::Encryptor requires it itself)

--- a/lib/concerns_on_rails.rb
+++ b/lib/concerns_on_rails.rb
@@ -78,6 +78,7 @@ module ConcernsOnRails
     autoload :Masker,                  "concerns_on_rails/support/masker"
     autoload :Money,                   "concerns_on_rails/support/money"
     autoload :Encryptor,               "concerns_on_rails/support/encryptor"
+    autoload :Affix,                   "concerns_on_rails/support/affix"
   end
 
   # Encryption config + error types (Support::Encryptor requires it itself)

--- a/lib/concerns_on_rails/models/activatable.rb
+++ b/lib/concerns_on_rails/models/activatable.rb
@@ -55,7 +55,11 @@ module ConcernsOnRails
         # Activate every inactive record in the relation; returns the count.
         def activate_all
           inactive = all.public_send(activatable_scope_names.fetch(:inactive))
-          return inactive.update_all(activatable_field => true) if activatable_batch_fast_path?(:activate!)
+          if activatable_batch_fast_path?(:activate!)
+            return inactive.update_all(
+              ConcernsOnRails::Support::BatchOps.with_timestamps(self, activatable_field => true)
+            )
+          end
 
           ConcernsOnRails::Support::BatchOps.run(
             inactive,
@@ -68,7 +72,11 @@ module ConcernsOnRails
         # Deactivate every active record in the relation; returns the count.
         def deactivate_all
           active = all.public_send(activatable_scope_names.fetch(:active))
-          return active.update_all(activatable_field => false) if activatable_batch_fast_path?(:deactivate!)
+          if activatable_batch_fast_path?(:deactivate!)
+            return active.update_all(
+              ConcernsOnRails::Support::BatchOps.with_timestamps(self, activatable_field => false)
+            )
+          end
 
           ConcernsOnRails::Support::BatchOps.run(
             active,
@@ -80,19 +88,11 @@ module ConcernsOnRails
 
         private
 
-        # The single-UPDATE fast path is only safe when per-record behavior
-        # cannot differ from update_all: the given bang method not overridden
-        # by the host model, AND no validators — update_all skips validations
-        # entirely, so a model with any validates would silently write
-        # invalid records instead of honoring the batch contract
-        # (RecordNotSaved + rollback on a record that can't save). Activatable
-        # defines no lifecycle hooks, so the bang method is the only method
-        # that needs gating; save callbacks are deliberately NOT gated on —
-        # update_all skipping callbacks is documented Rails behavior shared
-        # by every *_all method.
+        # Whether the single-UPDATE fast path is safe — the whole decision
+        # (bang method unoverridden AND the model declares no validations,
+        # plus why) lives in Support::BatchOps.fast_path?. Activatable defines
+        # no lifecycle hooks, so the bang method is the only one to check.
         def activatable_batch_fast_path?(method)
-          return false unless validators.empty?
-
           ConcernsOnRails::Support::BatchOps.fast_path?(self, ConcernsOnRails::Models::Activatable, method)
         end
       end

--- a/lib/concerns_on_rails/models/activatable.rb
+++ b/lib/concerns_on_rails/models/activatable.rb
@@ -1,5 +1,6 @@
 require "active_support/concern"
 require "concerns_on_rails/support/column_guard"
+require "concerns_on_rails/support/affix"
 
 module ConcernsOnRails
   module Models
@@ -26,6 +27,8 @@ module ConcernsOnRails
 
       included do
         class_attribute :activatable_field, instance_accessor: false, default: DEFAULT_FIELD
+        class_attribute :activatable_scope_names, instance_accessor: false,
+                                                  default: { active: :active, inactive: :inactive }.freeze
       end
 
       class_methods do
@@ -35,16 +38,17 @@ module ConcernsOnRails
           self.activatable_field = field.to_sym
           ensure_columns!("ConcernsOnRails::Models::Activatable", activatable_field, types: :boolean)
 
+          prefix = ConcernsOnRails::Support::Affix.normalize(prefix, default: activatable_field)
+          suffix = ConcernsOnRails::Support::Affix.normalize(suffix, default: activatable_field)
+          self.activatable_scope_names = {
+            active: ConcernsOnRails::Support::Affix.name(:active, prefix: prefix, suffix: suffix),
+            inactive: ConcernsOnRails::Support::Affix.name(:inactive, prefix: prefix, suffix: suffix)
+          }.freeze
+
           # Affix the scope names so two concerns that each define `.active`
           # (e.g. SoftDeletable / Expirable) can coexist on one model.
-          scope activatable_scope_name(:active, prefix, suffix),   -> { where(activatable_field => true) }
-          scope activatable_scope_name(:inactive, prefix, suffix), -> { where(activatable_field => [false, nil]) }
-        end
-
-        private
-
-        def activatable_scope_name(base, prefix, suffix)
-          [prefix, base, suffix].compact.join("_").to_sym
+          scope activatable_scope_names[:active],   -> { where(activatable_field => true) }
+          scope activatable_scope_names[:inactive], -> { where(activatable_field => [false, nil]) }
         end
       end
 

--- a/lib/concerns_on_rails/models/activatable.rb
+++ b/lib/concerns_on_rails/models/activatable.rb
@@ -1,6 +1,7 @@
 require "active_support/concern"
 require "concerns_on_rails/support/column_guard"
 require "concerns_on_rails/support/affix"
+require "concerns_on_rails/support/batch_ops"
 
 module ConcernsOnRails
   module Models
@@ -31,7 +32,7 @@ module ConcernsOnRails
                                                   default: { active: :active, inactive: :inactive }.freeze
       end
 
-      class_methods do
+      class_methods do # rubocop:disable Metrics/BlockLength
         include ConcernsOnRails::Support::ColumnGuard
 
         def activatable_by(field = DEFAULT_FIELD, prefix: nil, suffix: nil)
@@ -49,6 +50,50 @@ module ConcernsOnRails
           # (e.g. SoftDeletable / Expirable) can coexist on one model.
           scope activatable_scope_names[:active],   -> { where(activatable_field => true) }
           scope activatable_scope_names[:inactive], -> { where(activatable_field => [false, nil]) }
+        end
+
+        # Activate every inactive record in the relation; returns the count.
+        def activate_all
+          inactive = all.public_send(activatable_scope_names.fetch(:inactive))
+          return inactive.update_all(activatable_field => true) if activatable_batch_fast_path?(:activate!)
+
+          ConcernsOnRails::Support::BatchOps.run(
+            inactive,
+            label: "ConcernsOnRails::Models::Activatable",
+            message: "failed to activate record",
+            &:activate!
+          )
+        end
+
+        # Deactivate every active record in the relation; returns the count.
+        def deactivate_all
+          active = all.public_send(activatable_scope_names.fetch(:active))
+          return active.update_all(activatable_field => false) if activatable_batch_fast_path?(:deactivate!)
+
+          ConcernsOnRails::Support::BatchOps.run(
+            active,
+            label: "ConcernsOnRails::Models::Activatable",
+            message: "failed to deactivate record",
+            &:deactivate!
+          )
+        end
+
+        private
+
+        # The single-UPDATE fast path is only safe when per-record behavior
+        # cannot differ from update_all: the given bang method not overridden
+        # by the host model, AND no validators — update_all skips validations
+        # entirely, so a model with any validates would silently write
+        # invalid records instead of honoring the batch contract
+        # (RecordNotSaved + rollback on a record that can't save). Activatable
+        # defines no lifecycle hooks, so the bang method is the only method
+        # that needs gating; save callbacks are deliberately NOT gated on —
+        # update_all skipping callbacks is documented Rails behavior shared
+        # by every *_all method.
+        def activatable_batch_fast_path?(method)
+          return false unless validators.empty?
+
+          ConcernsOnRails::Support::BatchOps.fast_path?(self, ConcernsOnRails::Models::Activatable, method)
         end
       end
 

--- a/lib/concerns_on_rails/models/anonymizable.rb
+++ b/lib/concerns_on_rails/models/anonymizable.rb
@@ -1,5 +1,6 @@
 require "active_support/concern"
 require "concerns_on_rails/support/column_guard"
+require "concerns_on_rails/support/affix"
 require "digest"
 require "securerandom"
 
@@ -152,9 +153,12 @@ module ConcernsOnRails
           return if anonymizable_scopes_defined || anonymizable_stamp.nil?
 
           self.anonymizable_scopes_defined = true
-          affixed = ->(base) { [prefix, base, suffix].compact.join("_") }
-          scope affixed.call("anonymized"), -> { where.not(anonymizable_stamp => nil) }
-          scope affixed.call("not_anonymized"), -> { where(anonymizable_stamp => nil) }
+          prefix = ConcernsOnRails::Support::Affix.normalize(prefix, default: anonymizable_stamp)
+          suffix = ConcernsOnRails::Support::Affix.normalize(suffix, default: anonymizable_stamp)
+          scope ConcernsOnRails::Support::Affix.name(:anonymized, prefix: prefix, suffix: suffix),
+                -> { where.not(anonymizable_stamp => nil) }
+          scope ConcernsOnRails::Support::Affix.name(:not_anonymized, prefix: prefix, suffix: suffix),
+                -> { where(anonymizable_stamp => nil) }
         end
       end
 

--- a/lib/concerns_on_rails/models/expirable.rb
+++ b/lib/concerns_on_rails/models/expirable.rb
@@ -1,6 +1,7 @@
 require "active_support/concern"
 require "concerns_on_rails/support/column_guard"
 require "concerns_on_rails/support/affix"
+require "concerns_on_rails/support/batch_ops"
 
 module ConcernsOnRails
   module Models
@@ -29,7 +30,36 @@ module ConcernsOnRails
           define_expirable_scopes(prefix, suffix)
         end
 
+        # Expire every currently-active record in the relation. Returns the
+        # Integer count. Expirable defines no lifecycle hooks, so this is a
+        # single UPDATE unless the model overrode `expire!`.
+        def expire_all(time = Time.zone.now)
+          active = all.public_send(expirable_scope_names.fetch(:active))
+          return active.update_all(expirable_field => time) if expirable_batch_fast_path?
+
+          ConcernsOnRails::Support::BatchOps.run(
+            active,
+            label: "ConcernsOnRails::Models::Expirable",
+            message: "failed to expire record"
+          ) { |record| record.expire!(time) }
+        end
+
         private
+
+        # The single-UPDATE fast path is only safe when per-record behavior
+        # cannot differ from update_all: `expire!` not overridden by the host
+        # model, AND no validators — update_all skips validations entirely,
+        # so a model with any validates would silently write invalid records
+        # instead of honoring the batch contract (RecordNotSaved + rollback
+        # on a record that can't save). Expirable defines no lifecycle hooks,
+        # so `expire!` is the only method that needs gating; save callbacks
+        # are deliberately NOT gated on — update_all skipping callbacks is
+        # documented Rails behavior shared by every *_all method.
+        def expirable_batch_fast_path?
+          return false unless validators.empty?
+
+          ConcernsOnRails::Support::BatchOps.fast_path?(self, ConcernsOnRails::Models::Expirable, :expire!)
+        end
 
         # Scopes live here (not in `included do`) so their names can be affixed —
         # letting Expirable's `.active`/`.expired` coexist with the same-named

--- a/lib/concerns_on_rails/models/expirable.rb
+++ b/lib/concerns_on_rails/models/expirable.rb
@@ -1,5 +1,6 @@
 require "active_support/concern"
 require "concerns_on_rails/support/column_guard"
+require "concerns_on_rails/support/affix"
 
 module ConcernsOnRails
   module Models
@@ -10,9 +11,12 @@ module ConcernsOnRails
 
       included do
         class_attribute :expirable_field, instance_accessor: false, default: DEFAULT_FIELD
+        class_attribute :expirable_scope_names, instance_accessor: false,
+                                                default: { active: :active, expired: :expired,
+                                                           expiring_within: :expiring_within }.freeze
       end
 
-      class_methods do
+      class_methods do # rubocop:disable Metrics/BlockLength
         include ConcernsOnRails::Support::ColumnGuard
 
         # Configure the expiry column.
@@ -31,22 +35,24 @@ module ConcernsOnRails
         # letting Expirable's `.active`/`.expired` coexist with the same-named
         # scopes from SoftDeletable / Activatable on a single model.
         def define_expirable_scopes(prefix, suffix)
-          scope expirable_scope_name(:active, prefix, suffix), lambda {
+          prefix = ConcernsOnRails::Support::Affix.normalize(prefix, default: expirable_field)
+          suffix = ConcernsOnRails::Support::Affix.normalize(suffix, default: expirable_field)
+          self.expirable_scope_names = %i[active expired expiring_within].to_h do |base|
+            [base, ConcernsOnRails::Support::Affix.name(base, prefix: prefix, suffix: suffix)]
+          end.freeze
+
+          scope expirable_scope_names[:active], lambda {
             column = arel_table[expirable_field]
             where(column.eq(nil).or(column.gt(Time.zone.now)))
           }
-          scope expirable_scope_name(:expired, prefix, suffix), lambda {
+          scope expirable_scope_names[:expired], lambda {
             where(arel_table[expirable_field].lteq(Time.zone.now))
           }
-          scope expirable_scope_name(:expiring_within, prefix, suffix), lambda { |duration|
+          scope expirable_scope_names[:expiring_within], lambda { |duration|
             column = arel_table[expirable_field]
             now = Time.zone.now
             where(column.gt(now)).where(column.lteq(now + duration))
           }
-        end
-
-        def expirable_scope_name(base, prefix, suffix)
-          [prefix, base, suffix].compact.join("_").to_sym
         end
       end
 

--- a/lib/concerns_on_rails/models/expirable.rb
+++ b/lib/concerns_on_rails/models/expirable.rb
@@ -32,10 +32,15 @@ module ConcernsOnRails
 
         # Expire every currently-active record in the relation. Returns the
         # Integer count. Expirable defines no lifecycle hooks, so this is a
-        # single UPDATE unless the model overrode `expire!`.
+        # single UPDATE unless the model overrode `expire!` or declares
+        # validations (see Support::BatchOps.fast_path?).
         def expire_all(time = Time.zone.now)
           active = all.public_send(expirable_scope_names.fetch(:active))
-          return active.update_all(expirable_field => time) if expirable_batch_fast_path?
+          if expirable_batch_fast_path?
+            return active.update_all(
+              ConcernsOnRails::Support::BatchOps.with_timestamps(self, expirable_field => time)
+            )
+          end
 
           ConcernsOnRails::Support::BatchOps.run(
             active,
@@ -46,18 +51,11 @@ module ConcernsOnRails
 
         private
 
-        # The single-UPDATE fast path is only safe when per-record behavior
-        # cannot differ from update_all: `expire!` not overridden by the host
-        # model, AND no validators — update_all skips validations entirely,
-        # so a model with any validates would silently write invalid records
-        # instead of honoring the batch contract (RecordNotSaved + rollback
-        # on a record that can't save). Expirable defines no lifecycle hooks,
-        # so `expire!` is the only method that needs gating; save callbacks
-        # are deliberately NOT gated on — update_all skipping callbacks is
-        # documented Rails behavior shared by every *_all method.
+        # Whether the single-UPDATE fast path is safe — the whole decision
+        # (bang method unoverridden AND the model declares no validations,
+        # plus why) lives in Support::BatchOps.fast_path?. Expirable defines
+        # no lifecycle hooks, so `expire!` is the only method to check.
         def expirable_batch_fast_path?
-          return false unless validators.empty?
-
           ConcernsOnRails::Support::BatchOps.fast_path?(self, ConcernsOnRails::Models::Expirable, :expire!)
         end
 

--- a/lib/concerns_on_rails/models/lockable.rb
+++ b/lib/concerns_on_rails/models/lockable.rb
@@ -1,5 +1,6 @@
 require "active_support/concern"
 require "concerns_on_rails/support/column_guard"
+require "concerns_on_rails/support/affix"
 
 module ConcernsOnRails
   module Models
@@ -59,6 +60,8 @@ module ConcernsOnRails
         class_attribute :lockable_locked_at_field, instance_accessor: false, default: DEFAULT_LOCKED_AT_FIELD
         class_attribute :lockable_max_attempts, instance_accessor: false, default: DEFAULT_MAX_ATTEMPTS
         class_attribute :lockable_unlock_in, instance_accessor: false, default: nil
+        class_attribute :lockable_scope_names, instance_accessor: false,
+                                               default: { locked: :locked, unlocked: :unlocked }.freeze
       end
 
       module ClassMethods
@@ -109,7 +112,14 @@ module ConcernsOnRails
         # configuration and compute the cutoff in Ruby at call time, so the
         # predicate stays portable (no adapter-specific SQL date math).
         def define_lockable_scopes(prefix, suffix)
-          scope lockable_scope_name(:locked, prefix, suffix), lambda {
+          prefix = ConcernsOnRails::Support::Affix.normalize(prefix, default: lockable_locked_at_field)
+          suffix = ConcernsOnRails::Support::Affix.normalize(suffix, default: lockable_locked_at_field)
+          self.lockable_scope_names = {
+            locked: ConcernsOnRails::Support::Affix.name(:locked, prefix: prefix, suffix: suffix),
+            unlocked: ConcernsOnRails::Support::Affix.name(:unlocked, prefix: prefix, suffix: suffix)
+          }.freeze
+
+          scope lockable_scope_names[:locked], lambda {
             field = lockable_locked_at_field
             if lockable_unlock_in
               where(arel_table[field].gt(Time.zone.now - lockable_unlock_in))
@@ -117,7 +127,7 @@ module ConcernsOnRails
               where.not(field => nil)
             end
           }
-          scope lockable_scope_name(:unlocked, prefix, suffix), lambda {
+          scope lockable_scope_names[:unlocked], lambda {
             field = lockable_locked_at_field
             if lockable_unlock_in
               column = arel_table[field]
@@ -126,10 +136,6 @@ module ConcernsOnRails
               where(field => nil)
             end
           }
-        end
-
-        def lockable_scope_name(base, prefix, suffix)
-          [prefix, base, suffix].compact.join("_").to_sym
         end
 
         def positive_integer_or_nil?(value)

--- a/lib/concerns_on_rails/models/lockable.rb
+++ b/lib/concerns_on_rails/models/lockable.rb
@@ -1,6 +1,7 @@
 require "active_support/concern"
 require "concerns_on_rails/support/column_guard"
 require "concerns_on_rails/support/affix"
+require "concerns_on_rails/support/batch_ops"
 
 module ConcernsOnRails
   module Models
@@ -82,6 +83,36 @@ module ConcernsOnRails
                           types: { attempts => :integer, locked_at => :datetime })
           validate_lockable_attempts_column!(attempts)
           define_lockable_scopes(prefix, suffix)
+        end
+
+        # Unlock every row whose lock window has fully elapsed, clearing
+        # locked_at and zeroing the attempts counter exactly as
+        # unlock_access! does. Returns the Integer count.
+        #
+        # Nothing expires when unlock_in is nil (manual unlock only), so that
+        # case returns 0 without touching the database. The boundary instant
+        # counts as expired, matching lock_expired? and the scopes.
+        def unlock_expired
+          unlock_in = lockable_unlock_in
+          return 0 unless unlock_in
+
+          locked_field = lockable_locked_at_field
+          attempts_field = lockable_attempts_field
+          # `lteq` on a NULL locked_at is NULL, so never-locked rows are
+          # excluded without an extra predicate.
+          expired = all.where(arel_table[locked_field].lteq(Time.zone.now - unlock_in))
+
+          if ConcernsOnRails::Support::BatchOps.fast_path?(self, ConcernsOnRails::Models::Lockable,
+                                                           :before_unlock, :after_unlock, :unlock_access!)
+            return expired.update_all(locked_field => nil, attempts_field => 0)
+          end
+
+          ConcernsOnRails::Support::BatchOps.run(
+            expired,
+            label: LABEL,
+            message: "failed to unlock record",
+            &:unlock_access!
+          )
         end
 
         private

--- a/lib/concerns_on_rails/models/lockable.rb
+++ b/lib/concerns_on_rails/models/lockable.rb
@@ -102,8 +102,11 @@ module ConcernsOnRails
           # excluded without an extra predicate.
           expired = all.where(arel_table[locked_field].lteq(Time.zone.now - unlock_in))
 
-          if ConcernsOnRails::Support::BatchOps.fast_path?(self, ConcernsOnRails::Models::Lockable,
-                                                           :before_unlock, :after_unlock, :unlock_access!)
+          # Ownership-only check (no validations gate, and no updated_at on the
+          # bulk write): `unlock_access!` writes via update_columns, which
+          # already skips validations and timestamps, so the two paths agree.
+          if ConcernsOnRails::Support::BatchOps.unoverridden?(self, ConcernsOnRails::Models::Lockable,
+                                                              :before_unlock, :after_unlock, :unlock_access!)
             return expired.update_all(locked_field => nil, attempts_field => 0)
           end
 

--- a/lib/concerns_on_rails/models/publishable.rb
+++ b/lib/concerns_on_rails/models/publishable.rb
@@ -1,6 +1,7 @@
 require "active_support/concern"
 require "concerns_on_rails/support/column_guard"
 require "concerns_on_rails/support/affix"
+require "concerns_on_rails/support/batch_ops"
 
 module ConcernsOnRails
   module Models
@@ -54,6 +55,37 @@ module ConcernsOnRails
           @publishable_boolean_column = columns_hash[publishable_field.to_s]&.type == :boolean
         end
 
+        # Publish every not-currently-published record in the relation.
+        # Returns the Integer count. NOTE this includes *scheduled* rows,
+        # whose future timestamp is overwritten with now — chain the draft
+        # scope (`Post.draft.publish_all`) when that isn't what you want.
+        def publish_all
+          pending = all.public_send(publishable_scope_names.fetch(:unpublished))
+          value = publishable_boolean_column? || Time.zone.now
+          return pending.update_all(publishable_field => value) if publishable_batch_fast_path?(:publish)
+
+          ConcernsOnRails::Support::BatchOps.run(
+            pending,
+            label: "ConcernsOnRails::Models::Publishable",
+            message: "failed to publish record",
+            &:publish!
+          )
+        end
+
+        # Unpublish every published record in the relation. Writes nil on both
+        # column types, exactly as `unpublish!` does.
+        def unpublish_all
+          live = all.public_send(publishable_scope_names.fetch(:published))
+          return live.update_all(publishable_field => nil) if publishable_batch_fast_path?(:unpublish)
+
+          ConcernsOnRails::Support::BatchOps.run(
+            live,
+            label: "ConcernsOnRails::Models::Publishable",
+            message: "failed to unpublish record",
+            &:unpublish!
+          )
+        end
+
         private
 
         # Scopes are built here rather than inline in `included do` so their
@@ -102,12 +134,31 @@ module ConcernsOnRails
             end
           }
         end
+        # Scopes the disable above to just this method instead of running to
+        # EOF (which silently exempted every method below it). RuboCop flags
+        # the enable itself as redundant only because nothing below currently
+        # trips PerceivedComplexity — that's the point, not a reason to drop it.
+        # rubocop:disable Lint/RedundantCopEnableDirective
+        # rubocop:enable Metrics/PerceivedComplexity
+        # rubocop:enable Lint/RedundantCopEnableDirective
 
         # Routed through a helper so the `default_scope:` keyword doesn't shadow
         # the `default_scope` macro inside `publishable_by`.
         def enable_published_default_scope
           published_scope = publishable_scope_names.fetch(:published)
           default_scope { public_send(published_scope) }
+        end
+
+        # The single-UPDATE fast path is only safe when per-record behavior
+        # cannot differ from update_all: none of the concern's hooks or bang
+        # methods overridden by the host model.
+        def publishable_batch_fast_path?(kind)
+          methods = if kind == :publish
+                      %i[before_publish after_publish publish!]
+                    else
+                      %i[before_unpublish after_unpublish unpublish!]
+                    end
+          ConcernsOnRails::Support::BatchOps.fast_path?(self, ConcernsOnRails::Models::Publishable, *methods)
         end
       end
 

--- a/lib/concerns_on_rails/models/publishable.rb
+++ b/lib/concerns_on_rails/models/publishable.rb
@@ -134,13 +134,6 @@ module ConcernsOnRails
             end
           }
         end
-        # Scopes the disable above to just this method instead of running to
-        # EOF (which silently exempted every method below it). RuboCop flags
-        # the enable itself as redundant only because nothing below currently
-        # trips PerceivedComplexity — that's the point, not a reason to drop it.
-        # rubocop:disable Lint/RedundantCopEnableDirective
-        # rubocop:enable Metrics/PerceivedComplexity
-        # rubocop:enable Lint/RedundantCopEnableDirective
 
         # Routed through a helper so the `default_scope:` keyword doesn't shadow
         # the `default_scope` macro inside `publishable_by`.
@@ -151,8 +144,15 @@ module ConcernsOnRails
 
         # The single-UPDATE fast path is only safe when per-record behavior
         # cannot differ from update_all: none of the concern's hooks or bang
-        # methods overridden by the host model.
+        # methods overridden by the host model, AND no validators — update_all
+        # skips validations entirely, so a model with any validates would
+        # silently write invalid records instead of honoring the batch
+        # contract (RecordNotSaved + rollback on a record that can't save).
+        # Save callbacks are deliberately NOT gated on: update_all skipping
+        # callbacks is documented Rails behavior shared by every *_all method.
         def publishable_batch_fast_path?(kind)
+          return false unless validators.empty?
+
           methods = if kind == :publish
                       %i[before_publish after_publish publish!]
                     else

--- a/lib/concerns_on_rails/models/publishable.rb
+++ b/lib/concerns_on_rails/models/publishable.rb
@@ -1,59 +1,42 @@
 require "active_support/concern"
 require "concerns_on_rails/support/column_guard"
+require "concerns_on_rails/support/affix"
 
 module ConcernsOnRails
   module Models
     module Publishable
       extend ActiveSupport::Concern
 
-      included do # rubocop:disable Metrics/BlockLength
+      SCOPE_BASES = %i[published unpublished scheduled draft].freeze
+
+      included do
         class_attribute :publishable_field, instance_accessor: false, default: :published_at
+        class_attribute :publishable_scope_names, instance_accessor: false,
+                                                  default: SCOPE_BASES.to_h { |b| [b, b] }.freeze
+        class_attribute :publishable_captured_scopes, instance_accessor: false, default: {}.freeze
 
-        # All scopes branch on the column type: a boolean publishable column (which
-        # the macro and instance methods also accept) needs equality predicates,
-        # not the timestamp `<= now` / `> now` comparisons that produce nonsensical
-        # SQL against a boolean.
-        scope :published, lambda {
-          if publishable_boolean_column?
-            where(publishable_field => true)
-          else
-            where(arel_table[publishable_field].lteq(Time.zone.now))
-          end
-        }
-        scope :unpublished, lambda {
-          if publishable_boolean_column?
-            unscope(where: publishable_field).where(publishable_field => [nil, false])
-          else
-            column = arel_table[publishable_field]
-            unscope(where: publishable_field).where(column.eq(nil).or(column.gt(Time.zone.now)))
-          end
-        }
-        # Set, but the publish time is still in the future (timestamp columns only).
-        scope :scheduled, lambda {
-          next none if publishable_boolean_column?
-
-          unscope(where: publishable_field).where(arel_table[publishable_field].gt(Time.zone.now))
-        }
-        # Never published — a true draft.
-        scope :draft, lambda {
-          if publishable_boolean_column?
-            unscope(where: publishable_field).where(publishable_field => [nil, false])
-          else
-            unscope(where: publishable_field).where(publishable_field => nil)
-          end
-        }
+        define_publishable_scopes(nil, nil)
+        self.publishable_captured_scopes =
+          ConcernsOnRails::Support::Affix.capture(self, SCOPE_BASES).freeze
       end
 
-      class_methods do
+      class_methods do # rubocop:disable Metrics/BlockLength
         include ConcernsOnRails::Support::ColumnGuard
 
         # Pass `default_scope: true` to hide unpublished records by default
         # (`.all` then returns only published). The negative scopes
         # (.unpublished/.scheduled/.draft) unscope the field, so they still work.
-        def publishable_by(field = nil, default_scope: false)
+        def publishable_by(field = nil, default_scope: false, prefix: nil, suffix: nil)
           self.publishable_field = field || :published_at
           @publishable_boolean_column = nil
           ensure_columns!("ConcernsOnRails::Models::Publishable", publishable_field, types: :datetime)
+
+          if prefix || suffix
+            define_publishable_scopes(prefix, suffix)
+            ConcernsOnRails::Support::Affix.retire!(self, publishable_captured_scopes,
+                                                    label: "ConcernsOnRails::Models::Publishable")
+          end
+
           enable_published_default_scope if default_scope
         end
 
@@ -73,10 +56,58 @@ module ConcernsOnRails
 
         private
 
+        # Scopes are built here rather than inline in `included do` so their
+        # names can be affixed. `included do` calls this with no affix, so a
+        # model that only includes the concern keeps the default names; an
+        # affixed macro call rebuilds them under new names and retires the
+        # originals.
+        #
+        # All scopes branch on the column type: a boolean publishable column
+        # needs equality predicates, not the timestamp `<= now` / `> now`
+        # comparisons that produce nonsensical SQL against a boolean.
+        def define_publishable_scopes(prefix, suffix) # rubocop:disable Metrics/PerceivedComplexity
+          prefix = ConcernsOnRails::Support::Affix.normalize(prefix, default: publishable_field)
+          suffix = ConcernsOnRails::Support::Affix.normalize(suffix, default: publishable_field)
+          self.publishable_scope_names = SCOPE_BASES.to_h do |base|
+            [base, ConcernsOnRails::Support::Affix.name(base, prefix: prefix, suffix: suffix)]
+          end.freeze
+
+          scope publishable_scope_names[:published], lambda {
+            if publishable_boolean_column?
+              where(publishable_field => true)
+            else
+              where(arel_table[publishable_field].lteq(Time.zone.now))
+            end
+          }
+          scope publishable_scope_names[:unpublished], lambda {
+            if publishable_boolean_column?
+              unscope(where: publishable_field).where(publishable_field => [nil, false])
+            else
+              column = arel_table[publishable_field]
+              unscope(where: publishable_field).where(column.eq(nil).or(column.gt(Time.zone.now)))
+            end
+          }
+          # Set, but the publish time is still in the future (timestamp columns only).
+          scope publishable_scope_names[:scheduled], lambda {
+            next none if publishable_boolean_column?
+
+            unscope(where: publishable_field).where(arel_table[publishable_field].gt(Time.zone.now))
+          }
+          # Never published — a true draft.
+          scope publishable_scope_names[:draft], lambda {
+            if publishable_boolean_column?
+              unscope(where: publishable_field).where(publishable_field => [nil, false])
+            else
+              unscope(where: publishable_field).where(publishable_field => nil)
+            end
+          }
+        end
+
         # Routed through a helper so the `default_scope:` keyword doesn't shadow
         # the `default_scope` macro inside `publishable_by`.
         def enable_published_default_scope
-          default_scope { published }
+          published_scope = publishable_scope_names.fetch(:published)
+          default_scope { public_send(published_scope) }
         end
       end
 

--- a/lib/concerns_on_rails/models/publishable.rb
+++ b/lib/concerns_on_rails/models/publishable.rb
@@ -59,10 +59,27 @@ module ConcernsOnRails
         # Returns the Integer count. NOTE this includes *scheduled* rows,
         # whose future timestamp is overwritten with now — chain the draft
         # scope (`Post.draft.publish_all`) when that isn't what you want.
+        #
+        # The target predicate is built INLINE against `all` rather than
+        # routed through the `unpublished` scope, whose body opens with
+        # `unscope(where: publishable_field)` — that would strip the caller's
+        # own constraint on the publish column right back off, so
+        # `Post.draft.publish_all` used to silently publish scheduled rows
+        # too and destroy their future timestamps.
+        #
+        # The composing consequence: on a model configured with
+        # `publishable_by ..., default_scope: true`, `all` is already limited
+        # to published rows, so a bare `Post.publish_all` targets nothing.
+        # Chain `.draft` or `.unpublished` first — both unscope the field
+        # themselves, so the chain resolves to the rows you mean.
         def publish_all
-          pending = all.public_send(publishable_scope_names.fetch(:unpublished))
-          value = publishable_boolean_column? || Time.zone.now
-          return pending.update_all(publishable_field => value) if publishable_batch_fast_path?(:publish)
+          pending = publishable_pending_relation
+          if publishable_batch_fast_path?(:publish)
+            value = publishable_boolean_column? || Time.zone.now
+            return pending.update_all(
+              ConcernsOnRails::Support::BatchOps.with_timestamps(self, publishable_field => value)
+            )
+          end
 
           ConcernsOnRails::Support::BatchOps.run(
             pending,
@@ -73,10 +90,16 @@ module ConcernsOnRails
         end
 
         # Unpublish every published record in the relation. Writes nil on both
-        # column types, exactly as `unpublish!` does.
+        # column types, exactly as `unpublish!` does. The `published` scope
+        # does NOT unscope the field, so a caller's own constraint on the
+        # publish column composes here as it should.
         def unpublish_all
           live = all.public_send(publishable_scope_names.fetch(:published))
-          return live.update_all(publishable_field => nil) if publishable_batch_fast_path?(:unpublish)
+          if publishable_batch_fast_path?(:unpublish)
+            return live.update_all(
+              ConcernsOnRails::Support::BatchOps.with_timestamps(self, publishable_field => nil)
+            )
+          end
 
           ConcernsOnRails::Support::BatchOps.run(
             live,
@@ -142,17 +165,21 @@ module ConcernsOnRails
           default_scope { public_send(published_scope) }
         end
 
-        # The single-UPDATE fast path is only safe when per-record behavior
-        # cannot differ from update_all: none of the concern's hooks or bang
-        # methods overridden by the host model, AND no validators — update_all
-        # skips validations entirely, so a model with any validates would
-        # silently write invalid records instead of honoring the batch
-        # contract (RecordNotSaved + rollback on a record that can't save).
-        # Save callbacks are deliberately NOT gated on: update_all skipping
-        # callbacks is documented Rails behavior shared by every *_all method.
-        def publishable_batch_fast_path?(kind)
-          return false unless validators.empty?
+        # "Not currently published", built against the CURRENT relation: the
+        # same predicate the `unpublished` scope body applies, minus the
+        # `unscope` that would peel the caller's own constraint on the column
+        # back off (see publish_all).
+        def publishable_pending_relation
+          return all.where(publishable_field => [nil, false]) if publishable_boolean_column?
 
+          column = arel_table[publishable_field]
+          all.where(column.eq(nil).or(column.gt(Time.zone.now)))
+        end
+
+        # Whether the single-UPDATE fast path is safe — hooks/bang methods
+        # unoverridden AND the model declares no validations. The whole
+        # decision, including why, lives in Support::BatchOps.fast_path?.
+        def publishable_batch_fast_path?(kind)
           methods = if kind == :publish
                       %i[before_publish after_publish publish!]
                     else

--- a/lib/concerns_on_rails/models/schedulable.rb
+++ b/lib/concerns_on_rails/models/schedulable.rb
@@ -1,5 +1,6 @@
 require "active_support/concern"
 require "concerns_on_rails/support/column_guard"
+require "concerns_on_rails/support/affix"
 
 module ConcernsOnRails
   module Models
@@ -8,38 +9,21 @@ module ConcernsOnRails
 
       DEFAULT_STARTS_AT_FIELD = :starts_at
       DEFAULT_ENDS_AT_FIELD = :ends_at
+      SCOPE_BASES = %i[active_at current upcoming expired].freeze
 
       included do
         class_attribute :schedulable_starts_at_field, instance_accessor: false, default: DEFAULT_STARTS_AT_FIELD
         class_attribute :schedulable_ends_at_field, instance_accessor: false, default: DEFAULT_ENDS_AT_FIELD
+        class_attribute :schedulable_scope_names, instance_accessor: false,
+                                                  default: SCOPE_BASES.to_h { |b| [b, b] }.freeze
+        class_attribute :schedulable_captured_scopes, instance_accessor: false, default: {}.freeze
 
-        scope :active_at, lambda { |time|
-          starts_field = schedulable_starts_at_field
-          ends_field = schedulable_ends_at_field
-          relation = all
-          relation = relation.where(arel_table[starts_field].lteq(time)) if starts_field
-          relation = relation.where(arel_table[ends_field].eq(nil).or(arel_table[ends_field].gt(time))) if ends_field
-          relation
-        }
-
-        scope :current, -> { active_at(Time.zone.now) }
-
-        scope :upcoming, lambda {
-          field = schedulable_starts_at_field
-          next none unless field
-
-          where(arel_table[field].gt(Time.zone.now))
-        }
-
-        scope :expired, lambda {
-          field = schedulable_ends_at_field
-          next none unless field
-
-          where(arel_table[field].lteq(Time.zone.now))
-        }
+        define_schedulable_scopes(nil, nil)
+        self.schedulable_captured_scopes =
+          ConcernsOnRails::Support::Affix.capture(self, SCOPE_BASES).freeze
       end
 
-      class_methods do
+      class_methods do # rubocop:disable Metrics/BlockLength
         include ConcernsOnRails::Support::ColumnGuard
 
         # Configure the start/end timestamp columns.
@@ -47,7 +31,8 @@ module ConcernsOnRails
         #   schedulable_by                                          # uses :starts_at and :ends_at
         #   schedulable_by starts_at: :starts_on, ends_at: :ends_on
         #   schedulable_by starts_at: nil, ends_at: :expires_at     # open-ended start
-        def schedulable_by(starts_at: DEFAULT_STARTS_AT_FIELD, ends_at: DEFAULT_ENDS_AT_FIELD)
+        def schedulable_by(starts_at: DEFAULT_STARTS_AT_FIELD, ends_at: DEFAULT_ENDS_AT_FIELD,
+                           prefix: nil, suffix: nil)
           self.schedulable_starts_at_field = starts_at&.to_sym
           self.schedulable_ends_at_field = ends_at&.to_sym
 
@@ -57,8 +42,54 @@ module ConcernsOnRails
 
           ensure_columns!("ConcernsOnRails::Models::Schedulable",
                           schedulable_starts_at_field, schedulable_ends_at_field, types: :datetime)
+          return unless prefix || suffix
+
+          define_schedulable_scopes(prefix, suffix)
+          ConcernsOnRails::Support::Affix.retire!(self, schedulable_captured_scopes,
+                                                  label: "ConcernsOnRails::Models::Schedulable")
         end
-      end
+
+        private
+
+        # Built here rather than inline in `included do` so the names can be
+        # affixed. `current` resolves `active_at` through the names map — a
+        # literal call would break under an affix.
+        def define_schedulable_scopes(prefix, suffix)
+          default_field = schedulable_starts_at_field || schedulable_ends_at_field
+          prefix = ConcernsOnRails::Support::Affix.normalize(prefix, default: default_field)
+          suffix = ConcernsOnRails::Support::Affix.normalize(suffix, default: default_field)
+          self.schedulable_scope_names = SCOPE_BASES.to_h do |base|
+            [base, ConcernsOnRails::Support::Affix.name(base, prefix: prefix, suffix: suffix)]
+          end.freeze
+
+          active_at_name = schedulable_scope_names.fetch(:active_at)
+
+          scope active_at_name, lambda { |time|
+            starts_field = schedulable_starts_at_field
+            ends_field = schedulable_ends_at_field
+            relation = all
+            relation = relation.where(arel_table[starts_field].lteq(time)) if starts_field
+            relation = relation.where(arel_table[ends_field].eq(nil).or(arel_table[ends_field].gt(time))) if ends_field
+            relation
+          }
+
+          scope schedulable_scope_names[:current], -> { public_send(active_at_name, Time.zone.now) }
+
+          scope schedulable_scope_names[:upcoming], lambda {
+            field = schedulable_starts_at_field
+            next none unless field
+
+            where(arel_table[field].gt(Time.zone.now))
+          }
+
+          scope schedulable_scope_names[:expired], lambda {
+            field = schedulable_ends_at_field
+            next none unless field
+
+            where(arel_table[field].lteq(Time.zone.now))
+          }
+        end
+      end # rubocop:enable Metrics/BlockLength
 
       # Is the record active at the given time? Inclusive start, exclusive end.
       def active_at?(time)
@@ -118,8 +149,9 @@ module ConcernsOnRails
         update(attrs)
       end
 
-      private
-
+      # Postfix private — the keyword form trips RuboCop's scope analysis
+      # against the `private` inside the class_methods block (Publishable's
+      # pattern).
       def schedulable_started_by?(time)
         field = self.class.schedulable_starts_at_field
         return true unless field
@@ -127,6 +159,7 @@ module ConcernsOnRails
         value = self[field]
         !value.nil? && value <= time
       end
+      private :schedulable_started_by?
 
       def schedulable_not_ended_at?(time)
         field = self.class.schedulable_ends_at_field
@@ -135,6 +168,7 @@ module ConcernsOnRails
         value = self[field]
         value.nil? || value > time
       end
+      private :schedulable_not_ended_at?
     end
   end
 end

--- a/lib/concerns_on_rails/models/soft_deletable.rb
+++ b/lib/concerns_on_rails/models/soft_deletable.rb
@@ -1,6 +1,7 @@
 require "active_support/concern"
 require "concerns_on_rails/support/column_guard"
 require "concerns_on_rails/support/affix"
+require "concerns_on_rails/support/batch_ops"
 
 module ConcernsOnRails
   module Models
@@ -63,25 +64,15 @@ module ConcernsOnRails
         # 1.22 the rollback happened silently and the method returned nil. With
         # `touch: false` and no overridden hooks this is a single UPDATE.
         def soft_delete_all
-          if soft_delete_batch_fast_path?(:soft_delete)
-            return all.where(soft_delete_field => nil).update_all(soft_delete_field => Time.zone.now)
-          end
+          pending = all.where(soft_delete_field => nil)
+          return pending.update_all(soft_delete_field => Time.zone.now) if soft_delete_batch_fast_path?(:soft_delete)
 
-          # find_each streams in PK batches instead of materializing the whole
-          # relation; filtering deleted rows DB-side also skips loading them at
-          # all. Updated rows leave the filtered set, but pagination is strictly
-          # forward by id, so nothing is skipped or revisited.
-          transaction do
-            count = 0
-            all.where(soft_delete_field => nil).find_each do |record|
-              record.soft_delete! ||
-                raise(ActiveRecord::RecordNotSaved.new(
-                        "ConcernsOnRails::Models::SoftDeletable: failed to soft-delete record", record
-                      ))
-              count += 1
-            end
-            count
-          end
+          ConcernsOnRails::Support::BatchOps.run(
+            pending,
+            label: "ConcernsOnRails::Models::SoftDeletable",
+            message: "failed to soft-delete record",
+            &:soft_delete!
+          )
         end
 
         # Override destroy_all to soft delete. Kept for backwards compatibility, but prefer the
@@ -109,17 +100,12 @@ module ConcernsOnRails
           deleted = all.public_send(soft_delete_scope_names.fetch(:soft_deleted))
           return deleted.update_all(soft_delete_field => nil) if soft_delete_batch_fast_path?(:restore)
 
-          transaction do
-            count = 0
-            deleted.find_each do |record|
-              record.restore! ||
-                raise(ActiveRecord::RecordNotSaved.new(
-                        "ConcernsOnRails::Models::SoftDeletable: failed to restore record", record
-                      ))
-              count += 1
-            end
-            count
-          end
+          ConcernsOnRails::Support::BatchOps.run(
+            deleted,
+            label: "ConcernsOnRails::Models::SoftDeletable",
+            message: "failed to restore record",
+            &:restore!
+          )
         end
 
         private
@@ -170,7 +156,7 @@ module ConcernsOnRails
                     else
                       %i[before_soft_delete after_soft_delete soft_delete!]
                     end
-          methods.all? { |m| instance_method(m).owner == ConcernsOnRails::Models::SoftDeletable }
+          ConcernsOnRails::Support::BatchOps.fast_path?(self, ConcernsOnRails::Models::SoftDeletable, *methods)
         end
       end
 

--- a/lib/concerns_on_rails/models/soft_deletable.rb
+++ b/lib/concerns_on_rails/models/soft_deletable.rb
@@ -1,10 +1,13 @@
 require "active_support/concern"
 require "concerns_on_rails/support/column_guard"
+require "concerns_on_rails/support/affix"
 
 module ConcernsOnRails
   module Models
     module SoftDeletable
       extend ActiveSupport::Concern
+
+      SCOPE_BASES = %i[active without_deleted soft_deleted only_deleted with_deleted deleted_within].freeze
 
       included do
         # declare class attributes and set default values
@@ -15,26 +18,20 @@ module ConcernsOnRails
         # A default_scope is sticky and breaks unscoped joins / uniqueness validations /
         # eager-loading, so new models are encouraged to disable it and chain `.without_deleted`.
         class_attribute :soft_delete_default_scope, instance_accessor: false, default: true
+        class_attribute :soft_delete_scope_names, instance_accessor: false,
+                                                  default: SCOPE_BASES.to_h { |b| [b, b] }.freeze
+        class_attribute :soft_delete_captured_scopes, instance_accessor: false, default: {}.freeze
 
-        # scopes
-        scope :active, -> { unscope(where: soft_delete_field).where(soft_delete_field => nil) }
-        scope :without_deleted, -> { unscope(where: soft_delete_field).where(soft_delete_field => nil) }
-        scope :soft_deleted, -> { unscope(where: soft_delete_field).where.not(soft_delete_field => nil) }
-        scope :only_deleted, -> { soft_deleted }
-        # `with_deleted` peels off the default scope so deleted + non-deleted are both returned.
-        scope :with_deleted, -> { unscope(where: soft_delete_field) }
-        # Records soft-deleted within the last `duration` (e.g. `deleted_within(7.days)`).
-        # Arel `gteq` rather than an endless range (`x..`): AR only translates an
-        # endless range to `>=` on Rails 6.0+, but this gem supports Rails >= 5.0.
-        # arel_table also qualifies the column with the table name, so the scope
-        # stays unambiguous inside joins against tables sharing the column.
-        scope :deleted_within, lambda { |duration|
-          soft_deleted.where(arel_table[soft_delete_field].gteq(duration.ago))
-        }
+        define_soft_delete_scopes(nil, nil)
+        self.soft_delete_captured_scopes =
+          ConcernsOnRails::Support::Affix.capture(self, SCOPE_BASES).freeze
 
         # Hide soft-deleted rows from `.all` only when enabled (the default). The block is
-        # evaluated lazily, so toggling `soft_delete_default_scope` via the macro takes effect.
-        default_scope { soft_delete_default_scope ? without_deleted : all }
+        # evaluated lazily, so toggling `soft_delete_default_scope` via the macro takes effect —
+        # and it resolves the scope through the names map, so an affixed model still filters.
+        default_scope do
+          soft_delete_default_scope ? public_send(soft_delete_scope_names.fetch(:without_deleted)) : all
+        end
       end
 
       # A real module (not `class_methods do`) so the batch helpers and their
@@ -47,11 +44,16 @@ module ConcernsOnRails
         # Example:
         #   soft_deletable_by :deleted_at, touch: false
         #   soft_deletable_by :deleted_at, default_scope: false  # don't hide deleted rows from .all
-        def soft_deletable_by(field = nil, touch: true, default_scope: true)
+        def soft_deletable_by(field = nil, touch: true, default_scope: true, prefix: nil, suffix: nil)
           self.soft_delete_field = field || :deleted_at
           self.soft_delete_touch = touch
           self.soft_delete_default_scope = default_scope
           ensure_columns!("ConcernsOnRails::Models::SoftDeletable", soft_delete_field, types: :datetime)
+          return unless prefix || suffix
+
+          define_soft_delete_scopes(prefix, suffix)
+          ConcernsOnRails::Support::Affix.retire!(self, soft_delete_captured_scopes,
+                                                  label: "ConcernsOnRails::Models::SoftDeletable")
         end
 
         # Soft-delete every matching record. Returns the Integer count of
@@ -104,11 +106,12 @@ module ConcernsOnRails
         # Integer count, RecordNotSaved + rollback on failure, single UPDATE
         # when the fast path applies.
         def restore_all
-          return soft_deleted.update_all(soft_delete_field => nil) if soft_delete_batch_fast_path?(:restore)
+          deleted = all.public_send(soft_delete_scope_names.fetch(:soft_deleted))
+          return deleted.update_all(soft_delete_field => nil) if soft_delete_batch_fast_path?(:restore)
 
           transaction do
             count = 0
-            soft_deleted.find_each do |record|
+            deleted.find_each do |record|
               record.restore! ||
                 raise(ActiveRecord::RecordNotSaved.new(
                         "ConcernsOnRails::Models::SoftDeletable: failed to restore record", record
@@ -120,6 +123,40 @@ module ConcernsOnRails
         end
 
         private
+
+        # Built here rather than inline in `included do` so the names can be
+        # affixed. Every scope that references another scope resolves it
+        # through soft_delete_scope_names — a hard-coded symbol would break
+        # the moment a model affixes.
+        def define_soft_delete_scopes(prefix, suffix)
+          prefix = ConcernsOnRails::Support::Affix.normalize(prefix, default: soft_delete_field)
+          suffix = ConcernsOnRails::Support::Affix.normalize(suffix, default: soft_delete_field)
+          self.soft_delete_scope_names = SCOPE_BASES.to_h do |base|
+            [base, ConcernsOnRails::Support::Affix.name(base, prefix: prefix, suffix: suffix)]
+          end.freeze
+
+          soft_deleted_name = soft_delete_scope_names.fetch(:soft_deleted)
+
+          scope soft_delete_scope_names[:active],
+                -> { unscope(where: soft_delete_field).where(soft_delete_field => nil) }
+          scope soft_delete_scope_names[:without_deleted],
+                -> { unscope(where: soft_delete_field).where(soft_delete_field => nil) }
+          scope soft_delete_scope_names[:soft_deleted],
+                -> { unscope(where: soft_delete_field).where.not(soft_delete_field => nil) }
+          scope soft_delete_scope_names[:only_deleted],
+                -> { public_send(soft_deleted_name) }
+          # `with_deleted` peels off the default scope so deleted + non-deleted are both returned.
+          scope soft_delete_scope_names[:with_deleted],
+                -> { unscope(where: soft_delete_field) }
+          # Records soft-deleted within the last `duration` (e.g. `deleted_within(7.days)`).
+          # Arel `gteq` rather than an endless range (`x..`): AR only translates an
+          # endless range to `>=` on Rails 6.0+, but this gem supports Rails >= 5.0.
+          # arel_table also qualifies the column with the table name, so the scope
+          # stays unambiguous inside joins against tables sharing the column.
+          scope soft_delete_scope_names[:deleted_within], lambda { |duration|
+            public_send(soft_deleted_name).where(arel_table[soft_delete_field].gteq(duration.ago))
+          }
+        end
 
         # The single-UPDATE fast path is only safe when per-record behavior
         # cannot differ from update_all: `touch: false` (the per-record path is

--- a/lib/concerns_on_rails/models/soft_deletable.rb
+++ b/lib/concerns_on_rails/models/soft_deletable.rb
@@ -148,6 +148,9 @@ module ConcernsOnRails
         # cannot differ from update_all: `touch: false` (the per-record path is
         # update_column — already no validations/callbacks/updated_at) and none
         # of the gem's hooks or bang methods overridden by the host model.
+        # Exempt from BatchOps.fast_path?'s validations gate for that first
+        # reason: under `touch: false` both paths skip validations already, so
+        # only the ownership half (`unoverridden?`) applies.
         def soft_delete_batch_fast_path?(kind)
           return false if soft_delete_touch
 
@@ -156,7 +159,7 @@ module ConcernsOnRails
                     else
                       %i[before_soft_delete after_soft_delete soft_delete!]
                     end
-          ConcernsOnRails::Support::BatchOps.fast_path?(self, ConcernsOnRails::Models::SoftDeletable, *methods)
+          ConcernsOnRails::Support::BatchOps.unoverridden?(self, ConcernsOnRails::Models::SoftDeletable, *methods)
         end
       end
 

--- a/lib/concerns_on_rails/models/stateable.rb
+++ b/lib/concerns_on_rails/models/stateable.rb
@@ -1,6 +1,7 @@
 require "active_support/concern"
 require "concerns_on_rails/support/column_guard"
 require "concerns_on_rails/support/affix"
+require "concerns_on_rails/support/batch_ops"
 
 module ConcernsOnRails
   module Models
@@ -90,6 +91,37 @@ module ConcernsOnRails
           stateable_define_states
           stateable_define_transitions
           stateable_apply_default
+        end
+
+        # Run one declared transition across the relation. Returns the Integer
+        # count of records transitioned; records whose current state the
+        # event's guard rejects are skipped, not errors.
+        #
+        # There is deliberately NO single-UPDATE fast path here: the
+        # per-record path goes through `update!`, which runs validations,
+        # while every fast path in this gem uses `update_all`, which does not.
+        # Collapsing would silently skip validations that `<event>!` runs.
+        # Guard membership is still filtered DB-side, so the scan is cheap.
+        def transition_all(event)
+          name = event.to_sym
+          config = stateable_transitions[name] || stateable_transitions[event.to_s]
+          raise ArgumentError, "#{LABEL}: unknown transition '#{event}'" unless config
+
+          from = Array(config[:from]).map(&:to_s)
+          to = config.fetch(:to).to_s
+          field = stateable_field
+          method_base = stateable_method_name(name)
+
+          eligible = from.empty? ? all : all.where(field => from)
+          eligible = eligible.where.not(field => to)
+
+          ConcernsOnRails::Support::BatchOps.run(
+            eligible,
+            label: LABEL,
+            message: "failed to transition record"
+          ) do |record|
+            record.public_send(:"may_#{method_base}?") ? record.public_send(:"#{method_base}!") : :skip
+          end
         end
 
         private

--- a/lib/concerns_on_rails/models/stateable.rb
+++ b/lib/concerns_on_rails/models/stateable.rb
@@ -1,5 +1,6 @@
 require "active_support/concern"
 require "concerns_on_rails/support/column_guard"
+require "concerns_on_rails/support/affix"
 
 module ConcernsOnRails
   module Models
@@ -107,15 +108,12 @@ module ConcernsOnRails
           ensure_columns!(LABEL, stateable_field, types: :string)
         end
 
-        # `true` => use the field name; a string/symbol => use it literally; else none.
         def stateable_affix(option)
-          return nil unless option
-
-          option == true ? stateable_field.to_s : option.to_s
+          ConcernsOnRails::Support::Affix.normalize(option, default: stateable_field)
         end
 
         def stateable_method_name(base)
-          [stateable_prefix, base, stateable_suffix].compact.join("_")
+          ConcernsOnRails::Support::Affix.name(base, prefix: stateable_prefix, suffix: stateable_suffix).to_s
         end
 
         def stateable_validate!

--- a/lib/concerns_on_rails/models/storable.rb
+++ b/lib/concerns_on_rails/models/storable.rb
@@ -1,5 +1,6 @@
 require "active_support/concern"
 require "concerns_on_rails/support/column_guard"
+require "concerns_on_rails/support/affix"
 require "active_support/core_ext/object/deep_dup"
 require "active_model/type"
 require "bigdecimal"
@@ -169,7 +170,7 @@ module ConcernsOnRails
           end
 
           { type: type, default: raw_spec[:default], in: inclusion,
-            accessor: [prefix, key, suffix].compact.join("_").to_sym }
+            accessor: ConcernsOnRails::Support::Affix.name(key, prefix: prefix, suffix: suffix) }
         end
 
         # Guard collisions against a working copy of the owners map (so two keys

--- a/lib/concerns_on_rails/support/affix.rb
+++ b/lib/concerns_on_rails/support/affix.rb
@@ -22,6 +22,59 @@ module ConcernsOnRails
 
         option == true ? default.to_s : option.to_s
       end
+
+      # Snapshot the scopes a concern just defined on `klass`: a
+      # name => UnboundMethod map, captured immediately after definition.
+      # Names that aren't defined are skipped (a concern may generate a scope
+      # only under some configurations).
+      def capture(klass, names)
+        singleton = klass.singleton_class
+        names.each_with_object({}) do |base, acc|
+          name = base.to_sym
+          next unless singleton.method_defined?(name)
+
+          acc[name] = singleton.instance_method(name)
+        end
+      end
+
+      # Remove the default-named scopes recorded by `capture` so their affixed
+      # replacements are the only ones left. Returns the names removed.
+      #
+      # Three guards, all of which must pass before a name is removed:
+      #   1. it is in the captured map (never a name the concern did not create);
+      #   2. it is owned by THIS class's own singleton (never inherited);
+      #   3. it is still the exact method captured (never a model's override).
+      #
+      # Guard 2 failing means the concern was configured on a parent and the
+      # affix is being declared on a subclass — retiring nothing would hand
+      # back an escape hatch that doesn't work, because the parent's colliding
+      # scopes would survive. That raises instead.
+      def retire!(klass, captured, label:)
+        singleton = klass.singleton_class
+        captured.each_with_object([]) do |(name, recorded), removed|
+          next unless singleton.method_defined?(name)
+
+          current = singleton.instance_method(name)
+          retire_guard_owner!(current, singleton, klass, name, label)
+          next unless current == recorded
+
+          singleton.send(:remove_method, name)
+          removed << name
+        end
+      end
+
+      # Postfix private: keeps the public module_function methods above
+      # callable as `Affix.foo` while hiding the helper.
+      def retire_guard_owner!(current, singleton, klass, name, label)
+        return if current.owner == singleton
+
+        owner = current.owner.attached_object
+        raise ArgumentError,
+              "#{label}: cannot affix scopes on #{klass} because '#{name}' is defined on #{owner}. " \
+              "Declare the prefix:/suffix: option on #{owner} itself — affixing here would leave " \
+              "#{owner}'s unaffixed scopes in place and the collision unresolved."
+      end
+      private_class_method :retire_guard_owner!
     end
   end
 end

--- a/lib/concerns_on_rails/support/affix.rb
+++ b/lib/concerns_on_rails/support/affix.rb
@@ -1,0 +1,27 @@
+module ConcernsOnRails
+  module Support
+    # Shared naming for concerns that generate affixable scopes or accessors.
+    #
+    # Two concerns that each define `.active` (SoftDeletable, Activatable,
+    # Expirable) can coexist on one model only if their generated names can be
+    # renamed, so every such concern takes `prefix:`/`suffix:` and routes the
+    # name through here rather than re-implementing the join.
+    module Affix
+      module_function
+
+      # `[prefix, base, suffix]`, underscore-joined, as a Symbol.
+      def name(base, prefix: nil, suffix: nil)
+        [prefix, base, suffix].compact.join("_").to_sym
+      end
+
+      # Normalize an affix option: `true` means "use the configured field
+      # name" (Stateable's semantics, generalized to every affixing concern),
+      # a String/Symbol is used literally, and nil/false means no affix.
+      def normalize(option, default:)
+        return nil unless option
+
+        option == true ? default.to_s : option.to_s
+      end
+    end
+  end
+end

--- a/lib/concerns_on_rails/support/batch_ops.rb
+++ b/lib/concerns_on_rails/support/batch_ops.rb
@@ -1,0 +1,44 @@
+module ConcernsOnRails
+  module Support
+    # Shared machinery for the concerns' `*_all` batch verbs.
+    #
+    # Every batch verb follows the contract established by SoftDeletable in
+    # 1.22: it operates on the current relation, returns an Integer count,
+    # runs in a transaction, rolls the whole batch back when a record fails,
+    # filters already-transitioned rows DB-side, and collapses to a single
+    # UPDATE when the host model has overridden none of the concern's hooks
+    # or bang methods.
+    module BatchOps
+      module_function
+
+      # True when every named instance method is still the concern's own — the
+      # host model overrode none of them, so a bulk UPDATE cannot differ from
+      # looping the per-record path.
+      def fast_path?(klass, owner, *methods)
+        methods.all? { |name| klass.instance_method(name).owner == owner }
+      end
+
+      # The streaming slow path. `find_each` pages forward by primary key, so
+      # rows leaving the filtered set as they're updated are never skipped or
+      # revisited, and the relation is never materialized in full.
+      #
+      # The block returns truthy (counted), `:skip` (not counted, not an
+      # error — a record that legitimately can't transition), or falsey
+      # (raises and rolls the whole batch back).
+      def run(relation, label:, message: "failed to update record")
+        relation.klass.transaction do
+          count = 0
+          relation.find_each do |record|
+            result = yield(record)
+            next if result == :skip
+
+            raise ActiveRecord::RecordNotSaved.new("#{label}: #{message}", record) unless result
+
+            count += 1
+          end
+          count
+        end
+      end
+    end
+  end
+end

--- a/lib/concerns_on_rails/support/batch_ops.rb
+++ b/lib/concerns_on_rails/support/batch_ops.rb
@@ -6,16 +6,65 @@ module ConcernsOnRails
     # 1.22: it operates on the current relation, returns an Integer count,
     # runs in a transaction, rolls the whole batch back when a record fails,
     # filters already-transitioned rows DB-side, and collapses to a single
-    # UPDATE when the host model has overridden none of the concern's hooks
-    # or bang methods.
+    # UPDATE when that cannot differ from looping the per-record path.
     module BatchOps
+      # Columns Rails itself bumps when a record is updated with timestamps on.
+      TOUCH_COLUMNS = %w[updated_at updated_on].freeze
+
       module_function
 
       # True when every named instance method is still the concern's own — the
-      # host model overrode none of them, so a bulk UPDATE cannot differ from
-      # looping the per-record path.
-      def fast_path?(klass, owner, *methods)
+      # host model overrode none of them. This is the ownership half of the
+      # fast-path decision on its own, for the two concerns whose per-record
+      # path already skips validations (SoftDeletable under `touch: false` and
+      # Lockable, both of which write via update_column(s)) and so are exempt
+      # from the validations half.
+      def unoverridden?(klass, owner, *methods)
         methods.all? { |name| klass.instance_method(name).owner == owner }
+      end
+
+      # The whole safety decision for a single-UPDATE fast path: it is only
+      # taken when per-record behavior cannot differ from `update_all` —
+      # the host model overrode none of the concern's hooks or bang methods,
+      # AND it declares no validations (update_all skips validations
+      # entirely, so an unguarded fast path would silently write invalid
+      # records instead of honoring the batch contract: RecordNotSaved +
+      # rollback on a record that can't save).
+      #
+      # Save callbacks are deliberately NOT gated on: update_all skipping
+      # callbacks is documented Rails behavior shared by every *_all method.
+      def fast_path?(klass, owner, *methods)
+        !validations?(klass) && unoverridden?(klass, owner, *methods)
+      end
+
+      # True when the host model declares anything that runs at validation time.
+      #
+      # `validators` alone is not enough: it is populated only by `validates` /
+      # `validates_with`. A custom `validate :some_check` (or `validate do … end`)
+      # registers only a `_validate_callbacks` entry and leaves `validators`
+      # EMPTY — so gating on `validators.empty?` took the fast path on one of
+      # the most common declaration forms and wrote invalid rows. Callbacks
+      # can't merely be counted either: Rails registers validate callbacks of
+      # its own on ActiveRecord::Base, so the class's filters are compared
+      # against the base class's.
+      def validations?(klass)
+        klass.validators.any? ||
+          (klass._validate_callbacks.map(&:filter) - base_validate_filters).any?
+      end
+
+      # `update_all` never touches updated_at, but the per-record `update` the
+      # slow path uses does — so the fast path writes the timestamp itself and
+      # the two paths agree, the same thing Rails' own `touch_all` and
+      # `update_counters(touch:)` do. Otherwise a batch verb would bump
+      # updated_at or not depending on whether the model happens to declare a
+      # validator, silently staling cache keys and `updated_since` sync jobs.
+      def with_timestamps(klass, attributes)
+        return attributes unless klass.record_timestamps
+
+        now = Time.zone.now
+        (TOUCH_COLUMNS & klass.column_names).each_with_object(attributes.dup) do |column, attrs|
+          attrs[column] = now
+        end
       end
 
       # The streaming slow path. `find_each` pages forward by primary key, so
@@ -38,6 +87,16 @@ module ConcernsOnRails
           end
           count
         end
+      end
+
+      # The validate callbacks every ActiveRecord model carries out of the box
+      # (Rails 7.1 registers :cant_modify_encrypted_attributes_when_frozen on
+      # ActiveRecord::Base), subtracted so a bare model doesn't read as "has
+      # validations". Resolved on first use rather than at load time: no file
+      # in lib/ requires active_record, and referencing ActiveRecord::Base
+      # while this file loads would force it.
+      def base_validate_filters
+        @base_validate_filters ||= ActiveRecord::Base._validate_callbacks.map(&:filter).freeze
       end
     end
   end

--- a/lib/concerns_on_rails/version.rb
+++ b/lib/concerns_on_rails/version.rb
@@ -1,3 +1,3 @@
 module ConcernsOnRails
-  VERSION = "1.26.0".freeze
+  VERSION = "1.27.0".freeze
 end

--- a/spec/concerns/integration/scope_collisions_spec.rb
+++ b/spec/concerns/integration/scope_collisions_spec.rb
@@ -1,0 +1,64 @@
+require "spec_helper"
+
+# Three concerns each define a `.active` scope. Before 1.27 the last one
+# included silently won and there was no way out on SoftDeletable's side.
+describe "scope-name collisions across concerns" do
+  before do
+    ActiveRecord::Schema.define do
+      create_table :memberships, force: true do |t|
+        t.boolean :active
+        t.datetime :expires_at
+        t.datetime :deleted_at
+      end
+    end
+
+    stub_const("Membership", Class.new(TestModel) do
+      self.table_name = "memberships"
+
+      include ConcernsOnRails::SoftDeletable
+      include ConcernsOnRails::Activatable
+      include ConcernsOnRails::Expirable
+
+      soft_deletable_by :deleted_at, prefix: :trash, default_scope: false
+      activatable_by :active, prefix: :flag
+      expirable_by :expires_at, prefix: :term
+    end)
+  end
+
+  after(:each) do
+    ActiveRecord::Base.connection.tables.each do |table|
+      next if table == "schema_migrations"
+
+      ActiveRecord::Base.connection.drop_table(table)
+    end
+  end
+
+  it "gives each concern its own non-colliding scopes" do
+    expect(Membership).to respond_to(:trash_without_deleted)
+    expect(Membership).to respond_to(:flag_active)
+    expect(Membership).to respond_to(:term_active)
+    expect(Membership).not_to respond_to(:active)
+  end
+
+  it "returns the right rows from each affixed scope" do
+    healthy = Membership.create!(active: true, expires_at: 1.day.from_now, deleted_at: nil)
+    flagged_off = Membership.create!(active: false, expires_at: 1.day.from_now, deleted_at: nil)
+    lapsed = Membership.create!(active: true, expires_at: 1.day.ago, deleted_at: nil)
+    trashed = Membership.create!(active: true, expires_at: 1.day.from_now, deleted_at: Time.zone.now)
+
+    expect(Membership.flag_active.pluck(:id)).to match_array([healthy.id, lapsed.id, trashed.id])
+    expect(Membership.flag_inactive.pluck(:id)).to eq([flagged_off.id])
+    expect(Membership.term_active.pluck(:id)).to match_array([healthy.id, flagged_off.id, trashed.id])
+    expect(Membership.term_expired.pluck(:id)).to eq([lapsed.id])
+    expect(Membership.trash_soft_deleted.pluck(:id)).to eq([trashed.id])
+    expect(Membership.trash_without_deleted.pluck(:id)).to match_array([healthy.id, flagged_off.id, lapsed.id])
+  end
+
+  it "composes the three affixed scopes in one chain" do
+    healthy = Membership.create!(active: true, expires_at: 1.day.from_now, deleted_at: nil)
+    Membership.create!(active: true, expires_at: 1.day.ago, deleted_at: nil)
+
+    result = Membership.trash_without_deleted.flag_active.term_active
+    expect(result.pluck(:id)).to eq([healthy.id])
+  end
+end

--- a/spec/concerns/models/activatable_spec.rb
+++ b/spec/concerns/models/activatable_spec.rb
@@ -153,4 +153,72 @@ describe ConcernsOnRails::Activatable do
       expect(klass.respond_to?(:active)).to be(false)
     end
   end
+
+  describe "batch operations" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :batch_flags, force: true do |t|
+          t.boolean :active
+          t.string :title
+        end
+      end
+
+      stub_const("BatchFlag", Class.new(TestModel) do
+        self.table_name = "batch_flags"
+        include ConcernsOnRails::Activatable
+
+        activatable_by
+      end)
+    end
+
+    it "activates every inactive record and returns the count" do
+      BatchFlag.create!(active: false)
+      BatchFlag.create!(active: nil)
+      BatchFlag.create!(active: true)
+
+      expect(BatchFlag.activate_all).to eq(2)
+      expect(BatchFlag.active.count).to eq(3)
+    end
+
+    it "deactivates every active record" do
+      BatchFlag.create!(active: true)
+      BatchFlag.create!(active: false)
+
+      expect(BatchFlag.deactivate_all).to eq(1)
+      expect(BatchFlag.inactive.count).to eq(2)
+    end
+
+    it "is idempotent" do
+      BatchFlag.create!(active: false)
+      BatchFlag.activate_all
+
+      expect(BatchFlag.activate_all).to eq(0)
+    end
+
+    it "respects the relation" do
+      keep = BatchFlag.create!(active: false)
+      BatchFlag.create!(active: false)
+
+      expect(BatchFlag.where.not(id: keep.id).activate_all).to eq(1)
+      expect(keep.reload.active).to be false
+    end
+
+    it "cannot take the fast path when the model has validations — an invalid record rolls the whole batch back" do
+      stub_const("ValidatedFlag", Class.new(TestModel) do
+        self.table_name = "batch_flags"
+        include ConcernsOnRails::Activatable
+
+        activatable_by
+
+        validates :title, presence: true
+      end)
+      valid = ValidatedFlag.create!(title: "ok", active: false)
+      invalid = ValidatedFlag.create!(title: "temporary", active: false)
+      invalid.update_column(:title, nil)
+
+      expect { ValidatedFlag.activate_all }.to raise_error(ActiveRecord::RecordNotSaved)
+      expect(valid.reload.active).to be false
+      expect(invalid.reload.active).to be false
+    end
+  end
 end

--- a/spec/concerns/models/activatable_spec.rb
+++ b/spec/concerns/models/activatable_spec.rb
@@ -220,5 +220,30 @@ describe ConcernsOnRails::Activatable do
       expect(valid.reload.active).to be false
       expect(invalid.reload.active).to be false
     end
+
+    # Regression: `validate :method` leaves `validators` EMPTY (only `validates`
+    # / `validates_with` populate it), so the old `validators.empty?` gate took
+    # the fast path and activated invalid rows.
+    it "cannot take the fast path when the model has a custom validate method" do
+      stub_const("CallbackValidatedFlag", Class.new(TestModel) do
+        self.table_name = "batch_flags"
+        include ConcernsOnRails::Activatable
+
+        activatable_by
+        validate :title_must_be_present
+
+        def title_must_be_present
+          errors.add(:title, "can't be blank") if title.blank?
+        end
+      end)
+      valid = CallbackValidatedFlag.create!(title: "ok", active: false)
+      invalid = CallbackValidatedFlag.create!(title: "temporary", active: false)
+      invalid.update_column(:title, nil)
+
+      expect(CallbackValidatedFlag.validators).to be_empty
+      expect { CallbackValidatedFlag.activate_all }.to raise_error(ActiveRecord::RecordNotSaved)
+      expect(valid.reload.active).to be false
+      expect(invalid.reload.active).to be false
+    end
   end
 end

--- a/spec/concerns/models/expirable_spec.rb
+++ b/spec/concerns/models/expirable_spec.rb
@@ -217,4 +217,87 @@ describe ConcernsOnRails::Expirable do
       expect(klass.respond_to?(:active)).to be(false)
     end
   end
+
+  describe "batch operations" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :batch_tokens, force: true do |t|
+          t.datetime :expires_at
+          t.string :title
+        end
+      end
+
+      stub_const("BatchToken", Class.new(TestModel) do
+        self.table_name = "batch_tokens"
+        include ConcernsOnRails::Expirable
+
+        expirable_by
+      end)
+    end
+
+    it "expires every active record and returns the count" do
+      BatchToken.create!(expires_at: 1.day.from_now)
+      BatchToken.create!(expires_at: nil)
+      done = BatchToken.create!(expires_at: 1.day.ago)
+
+      expect(BatchToken.expire_all).to eq(2)
+      expect(BatchToken.expired.count).to eq(3)
+      expect(done.reload.expires_at).to be_within(1.second).of(1.day.ago)
+    end
+
+    it "is idempotent" do
+      BatchToken.create!(expires_at: 1.day.from_now)
+      BatchToken.expire_all
+
+      expect(BatchToken.expire_all).to eq(0)
+    end
+
+    it "accepts an explicit time" do
+      BatchToken.create!(expires_at: nil)
+      at = 2.days.ago
+
+      BatchToken.expire_all(at)
+
+      expect(BatchToken.first.expires_at).to be_within(1.second).of(at)
+    end
+
+    it "uses the per-record path when expire! is overridden" do
+      stub_const("CountingToken", Class.new(TestModel) do
+        self.table_name = "batch_tokens"
+        include ConcernsOnRails::Expirable
+
+        expirable_by
+
+        cattr_accessor :calls
+        self.calls = 0
+
+        def expire!(time = Time.zone.now)
+          self.class.calls += 1
+          super
+        end
+      end)
+      2.times { CountingToken.create!(expires_at: nil) }
+
+      expect(CountingToken.expire_all).to eq(2)
+      expect(CountingToken.calls).to eq(2)
+    end
+
+    it "cannot take the fast path when the model has validations — an invalid record rolls the whole batch back" do
+      stub_const("ValidatedToken", Class.new(TestModel) do
+        self.table_name = "batch_tokens"
+        include ConcernsOnRails::Expirable
+
+        expirable_by
+
+        validates :title, presence: true
+      end)
+      valid = ValidatedToken.create!(title: "ok", expires_at: nil)
+      invalid = ValidatedToken.create!(title: "temporary", expires_at: nil)
+      invalid.update_column(:title, nil)
+
+      expect { ValidatedToken.expire_all }.to raise_error(ActiveRecord::RecordNotSaved)
+      expect(valid.reload.expires_at).to be_nil
+      expect(invalid.reload.expires_at).to be_nil
+    end
+  end
 end

--- a/spec/concerns/models/expirable_spec.rb
+++ b/spec/concerns/models/expirable_spec.rb
@@ -299,5 +299,30 @@ describe ConcernsOnRails::Expirable do
       expect(valid.reload.expires_at).to be_nil
       expect(invalid.reload.expires_at).to be_nil
     end
+
+    # Regression: `validate :method` leaves `validators` EMPTY (only `validates`
+    # / `validates_with` populate it), so the old `validators.empty?` gate took
+    # the fast path and expired invalid rows.
+    it "cannot take the fast path when the model has a custom validate method" do
+      stub_const("CallbackValidatedToken", Class.new(TestModel) do
+        self.table_name = "batch_tokens"
+        include ConcernsOnRails::Expirable
+
+        expirable_by
+        validate :title_must_be_present
+
+        def title_must_be_present
+          errors.add(:title, "can't be blank") if title.blank?
+        end
+      end)
+      valid = CallbackValidatedToken.create!(title: "ok", expires_at: nil)
+      invalid = CallbackValidatedToken.create!(title: "temporary", expires_at: nil)
+      invalid.update_column(:title, nil)
+
+      expect(CallbackValidatedToken.validators).to be_empty
+      expect { CallbackValidatedToken.expire_all }.to raise_error(ActiveRecord::RecordNotSaved)
+      expect(valid.reload.expires_at).to be_nil
+      expect(invalid.reload.expires_at).to be_nil
+    end
   end
 end

--- a/spec/concerns/models/lockable_spec.rb
+++ b/spec/concerns/models/lockable_spec.rb
@@ -665,4 +665,76 @@ describe ConcernsOnRails::Lockable do
       expect(klass.unscoped.find(user.id).failed_attempts).to eq(1)
     end
   end
+
+  describe "#unlock_expired" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :batch_accounts, force: true do |t|
+          t.integer :failed_attempts, default: 0
+          t.datetime :locked_at
+        end
+      end
+    end
+
+    def lockable_class(**options)
+      Class.new(TestModel) do
+        self.table_name = "batch_accounts"
+        include ConcernsOnRails::Lockable
+
+        lockable_by(attempts: :failed_attempts, locked_at: :locked_at, **options)
+      end
+    end
+
+    it "unlocks only the rows whose window has elapsed, and returns the count" do
+      klass = lockable_class(unlock_in: 15.minutes)
+      stale = klass.create!(failed_attempts: 5, locked_at: 1.hour.ago)
+      fresh = klass.create!(failed_attempts: 5, locked_at: 1.minute.ago)
+      never = klass.create!(failed_attempts: 2, locked_at: nil)
+
+      expect(klass.unlock_expired).to eq(1)
+
+      expect(stale.reload.locked_at).to be_nil
+      expect(stale.failed_attempts).to eq(0)
+      expect(fresh.reload.locked_at).not_to be_nil
+      expect(fresh.failed_attempts).to eq(5)
+      expect(never.reload.failed_attempts).to eq(2)
+    end
+
+    it "returns 0 when unlock_in is nil" do
+      klass = lockable_class(unlock_in: nil)
+      klass.create!(failed_attempts: 5, locked_at: 1.year.ago)
+
+      expect(klass.unlock_expired).to eq(0)
+      expect(klass.first.locked_at).not_to be_nil
+    end
+
+    it "is idempotent" do
+      klass = lockable_class(unlock_in: 15.minutes)
+      klass.create!(failed_attempts: 5, locked_at: 1.hour.ago)
+      klass.unlock_expired
+
+      expect(klass.unlock_expired).to eq(0)
+    end
+
+    it "fires the unlock hooks once per record when they are overridden" do
+      klass = Class.new(TestModel) do
+        self.table_name = "batch_accounts"
+        include ConcernsOnRails::Lockable
+
+        lockable_by attempts: :failed_attempts, locked_at: :locked_at, unlock_in: 15.minutes
+
+        cattr_accessor :unlocked_ids
+        self.unlocked_ids = []
+
+        def after_unlock
+          self.class.unlocked_ids << id
+        end
+      end
+      stub_const("HookedAccount", klass)
+      a = HookedAccount.create!(failed_attempts: 5, locked_at: 1.hour.ago)
+
+      expect(HookedAccount.unlock_expired).to eq(1)
+      expect(HookedAccount.unlocked_ids).to eq([a.id])
+    end
+  end
 end

--- a/spec/concerns/models/publishable_spec.rb
+++ b/spec/concerns/models/publishable_spec.rb
@@ -238,4 +238,96 @@ describe ConcernsOnRails::Publishable do
       expect(article.log).to eq(%i[before_publish after_publish before_unpublish after_unpublish])
     end
   end
+
+  describe "scope affixing" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :affixed_articles, force: true do |t|
+          t.datetime :published_at
+        end
+      end
+    end
+
+    it "keeps the default scope names when no affix is given" do
+      klass = Class.new(TestModel) do
+        self.table_name = "affixed_articles"
+        include ConcernsOnRails::Publishable
+        publishable_by
+      end
+
+      expect(klass).to respond_to(:published)
+      expect(klass).to respond_to(:draft)
+    end
+
+    it "keeps the default scope names when the macro is never called" do
+      klass = Class.new(TestModel) do
+        self.table_name = "affixed_articles"
+        include ConcernsOnRails::Publishable
+      end
+
+      expect(klass).to respond_to(:published)
+    end
+
+    it "defines affixed names and removes the defaults" do
+      klass = Class.new(TestModel) do
+        self.table_name = "affixed_articles"
+        include ConcernsOnRails::Publishable
+        publishable_by :published_at, prefix: :article
+      end
+
+      expect(klass).to respond_to(:article_published)
+      expect(klass).to respond_to(:article_draft)
+      expect(klass).not_to respond_to(:published)
+      expect(klass).not_to respond_to(:draft)
+    end
+
+    it "accepts prefix: true, meaning the field name" do
+      klass = Class.new(TestModel) do
+        self.table_name = "affixed_articles"
+        include ConcernsOnRails::Publishable
+        publishable_by :published_at, prefix: true
+      end
+
+      expect(klass).to respond_to(:published_at_published)
+    end
+
+    it "returns the right rows through the affixed scopes" do
+      klass = Class.new(TestModel) do
+        self.table_name = "affixed_articles"
+        include ConcernsOnRails::Publishable
+        publishable_by :published_at, suffix: :posts
+      end
+      live = klass.create!(published_at: 1.day.ago)
+      klass.create!(published_at: nil)
+
+      expect(klass.published_posts.pluck(:id)).to eq([live.id])
+      expect(klass.draft_posts.count).to eq(1)
+    end
+
+    it "keeps default_scope: true working under an affix" do
+      klass = Class.new(TestModel) do
+        self.table_name = "affixed_articles"
+        include ConcernsOnRails::Publishable
+        publishable_by :published_at, prefix: :article, default_scope: true
+      end
+      live = klass.create!(published_at: 1.day.ago)
+      klass.create!(published_at: nil)
+
+      expect(klass.all.pluck(:id)).to eq([live.id])
+      expect(klass.article_draft.count).to eq(1)
+    end
+
+    it "raises when affixing on a subclass whose parent owns the scopes" do
+      parent = Class.new(TestModel) do
+        self.table_name = "affixed_articles"
+        include ConcernsOnRails::Publishable
+        publishable_by
+      end
+      stub_const("AffixedParentArticle", parent)
+
+      expect do
+        Class.new(parent) { publishable_by :published_at, prefix: :child }
+      end.to raise_error(ArgumentError, /AffixedParentArticle/)
+    end
+  end
 end

--- a/spec/concerns/models/publishable_spec.rb
+++ b/spec/concerns/models/publishable_spec.rb
@@ -343,6 +343,7 @@ describe ConcernsOnRails::Publishable do
         create_table :batch_articles, force: true do |t|
           t.datetime :published_at
           t.string :title
+          t.timestamps
         end
       end
 
@@ -388,6 +389,31 @@ describe ConcernsOnRails::Publishable do
 
       expect(BatchArticle.where.not(id: keep.id).publish_all).to eq(1)
       expect(keep.reload.published_at).to be_nil
+    end
+
+    # Regression: publish_all used to target the `unpublished` SCOPE, whose body
+    # opens with `unscope(where: published_at)` — that stripped the caller's own
+    # predicate on the publish column back off, so `.draft` was silently
+    # discarded and scheduled rows were published, destroying their future
+    # timestamp. The existing "respects the relation" example constrains on :id,
+    # which the unscope leaves alone, so it never caught this.
+    it "composes with a caller constraint on the publish column, leaving scheduled rows alone" do
+      BatchArticle.create!(published_at: nil)
+      scheduled = BatchArticle.create!(published_at: 5.days.from_now)
+
+      expect(BatchArticle.draft.publish_all).to eq(1)
+      expect(scheduled.reload.published_at).to be_within(1.second).of(5.days.from_now)
+    end
+
+    # Regression: update_all does not touch updated_at but the per-record
+    # `update` does, so the two paths used to disagree depending on whether the
+    # model happened to declare a validator.
+    it "bumps updated_at on the fast path, exactly as the per-record path does" do
+      article = BatchArticle.create!(published_at: nil)
+      BatchArticle.where(id: article.id).update_all(updated_at: 3.days.ago)
+
+      expect(BatchArticle.publish_all).to eq(1)
+      expect(article.reload.updated_at).to be_within(5.seconds).of(Time.zone.now)
     end
 
     it "issues exactly one UPDATE on the fast path" do
@@ -457,6 +483,31 @@ describe ConcernsOnRails::Publishable do
       invalid.update_column(:title, nil)
 
       expect { ValidatedArticle.publish_all }.to raise_error(ActiveRecord::RecordNotSaved)
+      expect(valid.reload.published_at).to be_nil
+      expect(invalid.reload.published_at).to be_nil
+    end
+
+    # Regression: `validate :method` leaves `validators` EMPTY (only `validates`
+    # / `validates_with` populate it), so the old `validators.empty?` gate took
+    # the fast path and published invalid rows.
+    it "cannot take the fast path when the model has a custom validate method" do
+      stub_const("CallbackValidatedArticle", Class.new(TestModel) do
+        self.table_name = "batch_articles"
+        include ConcernsOnRails::Publishable
+
+        publishable_by
+        validate :title_must_be_present
+
+        def title_must_be_present
+          errors.add(:title, "can't be blank") if title.blank?
+        end
+      end)
+      valid = CallbackValidatedArticle.create!(title: "ok", published_at: nil)
+      invalid = CallbackValidatedArticle.create!(title: "temporary", published_at: nil)
+      invalid.update_column(:title, nil)
+
+      expect(CallbackValidatedArticle.validators).to be_empty
+      expect { CallbackValidatedArticle.publish_all }.to raise_error(ActiveRecord::RecordNotSaved)
       expect(valid.reload.published_at).to be_nil
       expect(invalid.reload.published_at).to be_nil
     end

--- a/spec/concerns/models/publishable_spec.rb
+++ b/spec/concerns/models/publishable_spec.rb
@@ -336,6 +336,7 @@ describe ConcernsOnRails::Publishable do
       ActiveRecord::Schema.define do
         create_table :batch_articles, force: true do |t|
           t.datetime :published_at
+          t.string :title
         end
       end
 
@@ -435,6 +436,23 @@ describe ConcernsOnRails::Publishable do
 
       expect { FailingArticle.publish_all }.to raise_error(ActiveRecord::RecordNotSaved)
       expect(FailingArticle.where(published_at: nil).count).to eq(1)
+    end
+
+    it "cannot take the fast path when the model has validations — an invalid record rolls the whole batch back" do
+      stub_const("ValidatedArticle", Class.new(TestModel) do
+        self.table_name = "batch_articles"
+        include ConcernsOnRails::Publishable
+
+        publishable_by
+        validates :title, presence: true
+      end)
+      valid = ValidatedArticle.create!(title: "ok", published_at: nil)
+      invalid = ValidatedArticle.create!(title: "temporary", published_at: nil)
+      invalid.update_column(:title, nil)
+
+      expect { ValidatedArticle.publish_all }.to raise_error(ActiveRecord::RecordNotSaved)
+      expect(valid.reload.published_at).to be_nil
+      expect(invalid.reload.published_at).to be_nil
     end
   end
 end

--- a/spec/concerns/models/publishable_spec.rb
+++ b/spec/concerns/models/publishable_spec.rb
@@ -330,4 +330,111 @@ describe ConcernsOnRails::Publishable do
       end.to raise_error(ArgumentError, /AffixedParentArticle/)
     end
   end
+
+  describe "batch operations" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :batch_articles, force: true do |t|
+          t.datetime :published_at
+        end
+      end
+
+      stub_const("BatchArticle", Class.new(TestModel) do
+        self.table_name = "batch_articles"
+        include ConcernsOnRails::Publishable
+
+        publishable_by
+      end)
+    end
+
+    def capture_sql
+      statements = []
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
+        statements << args.last[:sql].to_s
+      end
+      yield
+      statements
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+    end
+
+    it "publishes every unpublished record and returns the count" do
+      BatchArticle.create!(published_at: nil)
+      BatchArticle.create!(published_at: nil)
+      already = BatchArticle.create!(published_at: 2.days.ago)
+
+      expect(BatchArticle.publish_all).to eq(2)
+      expect(BatchArticle.where(published_at: nil).count).to eq(0)
+      expect(already.reload.published_at).to be_within(1.second).of(2.days.ago)
+    end
+
+    it "is idempotent — a second call transitions nothing" do
+      BatchArticle.create!(published_at: nil)
+      BatchArticle.publish_all
+
+      expect(BatchArticle.publish_all).to eq(0)
+    end
+
+    it "respects the relation" do
+      keep = BatchArticle.create!(published_at: nil)
+      BatchArticle.create!(published_at: nil)
+
+      expect(BatchArticle.where.not(id: keep.id).publish_all).to eq(1)
+      expect(keep.reload.published_at).to be_nil
+    end
+
+    it "issues exactly one UPDATE on the fast path" do
+      2.times { BatchArticle.create!(published_at: nil) }
+
+      statements = capture_sql { BatchArticle.publish_all }
+
+      expect(statements.grep(/^UPDATE/).length).to eq(1)
+    end
+
+    it "unpublishes every published record" do
+      BatchArticle.create!(published_at: 1.day.ago)
+      BatchArticle.create!(published_at: nil)
+
+      expect(BatchArticle.unpublish_all).to eq(1)
+      expect(BatchArticle.where.not(published_at: nil).count).to eq(0)
+    end
+
+    it "runs the hooks once per record when they are overridden" do
+      stub_const("HookedArticle", Class.new(TestModel) do
+        self.table_name = "batch_articles"
+        include ConcernsOnRails::Publishable
+
+        publishable_by
+
+        cattr_accessor :published_ids
+        self.published_ids = []
+
+        def after_publish
+          self.class.published_ids << id
+        end
+      end)
+      a = HookedArticle.create!(published_at: nil)
+      b = HookedArticle.create!(published_at: nil)
+
+      expect(HookedArticle.publish_all).to eq(2)
+      expect(HookedArticle.published_ids).to match_array([a.id, b.id])
+    end
+
+    it "rolls the whole batch back when a record fails" do
+      stub_const("FailingArticle", Class.new(TestModel) do
+        self.table_name = "batch_articles"
+        include ConcernsOnRails::Publishable
+
+        publishable_by
+
+        def publish!
+          false
+        end
+      end)
+      FailingArticle.create!(published_at: nil)
+
+      expect { FailingArticle.publish_all }.to raise_error(ActiveRecord::RecordNotSaved)
+      expect(FailingArticle.where(published_at: nil).count).to eq(1)
+    end
+  end
 end

--- a/spec/concerns/models/publishable_spec.rb
+++ b/spec/concerns/models/publishable_spec.rb
@@ -252,6 +252,7 @@ describe ConcernsOnRails::Publishable do
       klass = Class.new(TestModel) do
         self.table_name = "affixed_articles"
         include ConcernsOnRails::Publishable
+
         publishable_by
       end
 
@@ -272,6 +273,7 @@ describe ConcernsOnRails::Publishable do
       klass = Class.new(TestModel) do
         self.table_name = "affixed_articles"
         include ConcernsOnRails::Publishable
+
         publishable_by :published_at, prefix: :article
       end
 
@@ -285,6 +287,7 @@ describe ConcernsOnRails::Publishable do
       klass = Class.new(TestModel) do
         self.table_name = "affixed_articles"
         include ConcernsOnRails::Publishable
+
         publishable_by :published_at, prefix: true
       end
 
@@ -295,6 +298,7 @@ describe ConcernsOnRails::Publishable do
       klass = Class.new(TestModel) do
         self.table_name = "affixed_articles"
         include ConcernsOnRails::Publishable
+
         publishable_by :published_at, suffix: :posts
       end
       live = klass.create!(published_at: 1.day.ago)
@@ -308,6 +312,7 @@ describe ConcernsOnRails::Publishable do
       klass = Class.new(TestModel) do
         self.table_name = "affixed_articles"
         include ConcernsOnRails::Publishable
+
         publishable_by :published_at, prefix: :article, default_scope: true
       end
       live = klass.create!(published_at: 1.day.ago)
@@ -321,6 +326,7 @@ describe ConcernsOnRails::Publishable do
       parent = Class.new(TestModel) do
         self.table_name = "affixed_articles"
         include ConcernsOnRails::Publishable
+
         publishable_by
       end
       stub_const("AffixedParentArticle", parent)

--- a/spec/concerns/models/schedulable_spec.rb
+++ b/spec/concerns/models/schedulable_spec.rb
@@ -237,6 +237,7 @@ describe ConcernsOnRails::Schedulable do
       Class.new(TestModel) do
         self.table_name = "affixed_events"
         include ConcernsOnRails::Schedulable
+
         schedulable_by(**options)
       end
     end

--- a/spec/concerns/models/schedulable_spec.rb
+++ b/spec/concerns/models/schedulable_spec.rb
@@ -222,4 +222,55 @@ describe ConcernsOnRails::Schedulable do
     expect(ReconfigPromo.schedulable_starts_at_field).to eq(:starts_on)
     expect(ReconfigPromo.schedulable_ends_at_field).to eq(:ends_on)
   end
+
+  describe "scope affixing" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :affixed_events, force: true do |t|
+          t.datetime :starts_at
+          t.datetime :ends_at
+        end
+      end
+    end
+
+    def affixed_class(**options)
+      Class.new(TestModel) do
+        self.table_name = "affixed_events"
+        include ConcernsOnRails::Schedulable
+        schedulable_by(**options)
+      end
+    end
+
+    it "keeps the default names with no affix" do
+      klass = affixed_class
+      expect(klass).to respond_to(:current)
+      expect(klass).to respond_to(:expired)
+    end
+
+    it "defines affixed names and removes the defaults" do
+      klass = affixed_class(prefix: :event)
+
+      expect(klass).to respond_to(:event_current)
+      expect(klass).to respond_to(:event_active_at)
+      expect(klass).not_to respond_to(:current)
+      expect(klass).not_to respond_to(:expired)
+    end
+
+    it "keeps current delegating to active_at under an affix" do
+      klass = affixed_class(prefix: :event)
+      live = klass.create!(starts_at: 1.day.ago, ends_at: 1.day.from_now)
+      klass.create!(starts_at: 1.day.from_now, ends_at: 2.days.from_now)
+
+      expect(klass.event_current.pluck(:id)).to eq([live.id])
+    end
+
+    it "keeps upcoming and expired correct under an affix" do
+      klass = affixed_class(suffix: :window)
+      soon = klass.create!(starts_at: 1.day.from_now, ends_at: 2.days.from_now)
+      over = klass.create!(starts_at: 3.days.ago, ends_at: 1.day.ago)
+
+      expect(klass.upcoming_window.pluck(:id)).to eq([soon.id])
+      expect(klass.expired_window.pluck(:id)).to eq([over.id])
+    end
+  end
 end

--- a/spec/concerns/models/soft_deletable_spec.rb
+++ b/spec/concerns/models/soft_deletable_spec.rb
@@ -529,5 +529,14 @@ describe ConcernsOnRails::SoftDeletable do
       expect(klass.all.count).to eq(2)
       expect(klass.doc_without_deleted.count).to eq(1)
     end
+
+    it "restores records via restore_all under an affix" do
+      klass = affixed_class(prefix: :doc)
+      gone = klass.create!(name: "gone")
+      gone.soft_delete!
+
+      expect(klass.restore_all).to eq(1)
+      expect(gone.reload).not_to be_deleted
+    end
   end
 end

--- a/spec/concerns/models/soft_deletable_spec.rb
+++ b/spec/concerns/models/soft_deletable_spec.rb
@@ -474,6 +474,7 @@ describe ConcernsOnRails::SoftDeletable do
       Class.new(TestModel) do
         self.table_name = "affixed_docs"
         include ConcernsOnRails::SoftDeletable
+
         soft_deletable_by :deleted_at, **options
       end
     end

--- a/spec/concerns/models/soft_deletable_spec.rb
+++ b/spec/concerns/models/soft_deletable_spec.rb
@@ -459,4 +459,75 @@ describe ConcernsOnRails::SoftDeletable do
       expect(rec.reload.deleted_at).to be_nil
     end
   end
+
+  describe "scope affixing" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :affixed_docs, force: true do |t|
+          t.string :name
+          t.datetime :deleted_at
+        end
+      end
+    end
+
+    def affixed_class(**options)
+      Class.new(TestModel) do
+        self.table_name = "affixed_docs"
+        include ConcernsOnRails::SoftDeletable
+        soft_deletable_by :deleted_at, **options
+      end
+    end
+
+    it "keeps the default names with no affix" do
+      klass = affixed_class
+      expect(klass).to respond_to(:without_deleted)
+      expect(klass).to respond_to(:only_deleted)
+    end
+
+    it "defines affixed names and removes the defaults" do
+      klass = affixed_class(prefix: :doc)
+
+      expect(klass).to respond_to(:doc_without_deleted)
+      expect(klass).to respond_to(:doc_soft_deleted)
+      expect(klass).not_to respond_to(:without_deleted)
+      expect(klass).not_to respond_to(:active)
+    end
+
+    it "keeps the default_scope filtering deleted rows under an affix" do
+      klass = affixed_class(prefix: :doc)
+      live = klass.create!(name: "live")
+      gone = klass.create!(name: "gone")
+      gone.soft_delete!
+
+      expect(klass.all.pluck(:id)).to eq([live.id])
+      expect(klass.doc_with_deleted.count).to eq(2)
+      expect(klass.doc_soft_deleted.pluck(:id)).to eq([gone.id])
+    end
+
+    it "keeps only_deleted delegating to soft_deleted under an affix" do
+      klass = affixed_class(prefix: :doc)
+      gone = klass.create!(name: "gone")
+      gone.soft_delete!
+
+      expect(klass.doc_only_deleted.pluck(:id)).to eq([gone.id])
+    end
+
+    it "keeps deleted_within working under an affix" do
+      klass = affixed_class(prefix: :doc)
+      gone = klass.create!(name: "gone")
+      gone.soft_delete!
+
+      expect(klass.doc_deleted_within(1.day).pluck(:id)).to eq([gone.id])
+      expect(klass.doc_deleted_within(0.seconds).count).to eq(0)
+    end
+
+    it "honours default_scope: false under an affix" do
+      klass = affixed_class(prefix: :doc, default_scope: false)
+      klass.create!(name: "live")
+      klass.create!(name: "gone").soft_delete!
+
+      expect(klass.all.count).to eq(2)
+      expect(klass.doc_without_deleted.count).to eq(1)
+    end
+  end
 end

--- a/spec/concerns/models/stateable_spec.rb
+++ b/spec/concerns/models/stateable_spec.rb
@@ -352,5 +352,20 @@ describe ConcernsOnRails::Stateable do
       expect(AffixedOrder.transition_all(:submit)).to eq(1)
       expect(AffixedOrder.where(status: "submitted").count).to eq(1)
     end
+
+    it "is idempotent when :from is omitted (any state -> target)" do
+      stub_const("ArchivableOrder", Class.new(TestModel) do
+        self.table_name = "batch_orders"
+        include ConcernsOnRails::Stateable
+
+        stateable_by :status, states: %i[draft submitted approved archived],
+                              transitions: { archive: { to: :archived } }
+      end)
+      ArchivableOrder.create!(status: "draft")
+      ArchivableOrder.create!(status: "submitted")
+
+      expect(ArchivableOrder.transition_all(:archive)).to eq(2)
+      expect(ArchivableOrder.transition_all(:archive)).to eq(0)
+    end
   end
 end

--- a/spec/concerns/models/stateable_spec.rb
+++ b/spec/concerns/models/stateable_spec.rb
@@ -258,4 +258,99 @@ describe ConcernsOnRails::Stateable do
         .to raise_error(ConcernsOnRails::Models::Stateable::InvalidTransition)
     end
   end
+
+  describe "#transition_all" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :batch_orders, force: true do |t|
+          t.string :status
+        end
+      end
+
+      stub_const("BatchOrder", Class.new(TestModel) do
+        self.table_name = "batch_orders"
+        include ConcernsOnRails::Stateable
+
+        stateable_by :status,
+                     states: %i[draft submitted approved],
+                     default: :draft,
+                     transitions: {
+                       submit: { from: :draft, to: :submitted },
+                       approve: { from: :submitted, to: :approved }
+                     }
+      end)
+    end
+
+    it "transitions every eligible record and returns the count" do
+      BatchOrder.create!(status: "draft")
+      BatchOrder.create!(status: "draft")
+      other = BatchOrder.create!(status: "submitted")
+
+      expect(BatchOrder.transition_all(:submit)).to eq(2)
+      expect(BatchOrder.where(status: "submitted").count).to eq(3)
+      expect(other.reload.status).to eq("submitted")
+    end
+
+    it "skips records the guard rejects rather than raising" do
+      BatchOrder.create!(status: "draft")
+      BatchOrder.create!(status: "approved")
+
+      expect(BatchOrder.transition_all(:submit)).to eq(1)
+    end
+
+    it "is idempotent" do
+      BatchOrder.create!(status: "draft")
+      BatchOrder.transition_all(:submit)
+
+      expect(BatchOrder.transition_all(:submit)).to eq(0)
+    end
+
+    it "respects the relation" do
+      keep = BatchOrder.create!(status: "draft")
+      BatchOrder.create!(status: "draft")
+
+      expect(BatchOrder.where.not(id: keep.id).transition_all(:submit)).to eq(1)
+      expect(keep.reload.status).to eq("draft")
+    end
+
+    it "fires the transition hooks once per record" do
+      stub_const("HookedOrder", Class.new(TestModel) do
+        self.table_name = "batch_orders"
+        include ConcernsOnRails::Stateable
+
+        stateable_by :status, states: %i[draft submitted],
+                              transitions: { submit: { from: :draft, to: :submitted } }
+
+        cattr_accessor :events
+        self.events = []
+
+        def after_transition(event, from, to)
+          self.class.events << [event, from, to]
+        end
+      end)
+      HookedOrder.create!(status: "draft")
+
+      expect(HookedOrder.transition_all(:submit)).to eq(1)
+      expect(HookedOrder.events).to eq([[:submit, "draft", "submitted"]])
+    end
+
+    it "raises on an unknown event" do
+      expect { BatchOrder.transition_all(:nope) }
+        .to raise_error(ArgumentError, /unknown transition 'nope'/)
+    end
+
+    it "honours affixed event names" do
+      stub_const("AffixedOrder", Class.new(TestModel) do
+        self.table_name = "batch_orders"
+        include ConcernsOnRails::Stateable
+
+        stateable_by :status, states: %i[draft submitted], prefix: :order,
+                              transitions: { submit: { from: :draft, to: :submitted } }
+      end)
+      AffixedOrder.create!(status: "draft")
+
+      expect(AffixedOrder.transition_all(:submit)).to eq(1)
+      expect(AffixedOrder.where(status: "submitted").count).to eq(1)
+    end
+  end
 end

--- a/spec/concerns/support/affix_spec.rb
+++ b/spec/concerns/support/affix_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+
+describe ConcernsOnRails::Support::Affix do
+  describe ".name" do
+    it "returns the bare base as a Symbol when neither affix is given" do
+      expect(described_class.name(:active)).to eq(:active)
+    end
+
+    it "prepends the prefix" do
+      expect(described_class.name(:active, prefix: "subscription")).to eq(:subscription_active)
+    end
+
+    it "appends the suffix" do
+      expect(described_class.name(:active, suffix: "window")).to eq(:active_window)
+    end
+
+    it "applies both" do
+      expect(described_class.name(:active, prefix: "sub", suffix: "window")).to eq(:sub_active_window)
+    end
+
+    it "accepts a String base" do
+      expect(described_class.name("active", prefix: "sub")).to eq(:sub_active)
+    end
+  end
+
+  describe ".normalize" do
+    it "returns nil for nil" do
+      expect(described_class.normalize(nil, default: :status)).to be_nil
+    end
+
+    it "returns nil for false" do
+      expect(described_class.normalize(false, default: :status)).to be_nil
+    end
+
+    it "returns the default as a String for true" do
+      expect(described_class.normalize(true, default: :status)).to eq("status")
+    end
+
+    it "returns a Symbol option as a String" do
+      expect(described_class.normalize(:archived, default: :status)).to eq("archived")
+    end
+
+    it "returns a String option unchanged" do
+      expect(described_class.normalize("archived", default: :status)).to eq("archived")
+    end
+  end
+end

--- a/spec/concerns/support/affix_spec.rb
+++ b/spec/concerns/support/affix_spec.rb
@@ -44,4 +44,65 @@ describe ConcernsOnRails::Support::Affix do
       expect(described_class.normalize("archived", default: :status)).to eq("archived")
     end
   end
+
+  describe ".capture and .retire!" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :affix_posts, force: true do |t|
+          t.datetime :published_at
+        end
+      end
+
+      stub_const("AffixPost", Class.new(TestModel) do
+        self.table_name = "affix_posts"
+        scope :published, -> { where.not(published_at: nil) }
+      end)
+    end
+
+    after(:each) do
+      ActiveRecord::Base.connection.tables.each do |table|
+        next if table == "schema_migrations"
+
+        ActiveRecord::Base.connection.drop_table(table)
+      end
+    end
+
+    it "captures the named scopes as UnboundMethods" do
+      captured = described_class.capture(AffixPost, %i[published])
+      expect(captured.keys).to eq([:published])
+      expect(captured[:published]).to be_a(UnboundMethod)
+    end
+
+    it "ignores names that are not defined" do
+      captured = described_class.capture(AffixPost, %i[published nope])
+      expect(captured.keys).to eq([:published])
+    end
+
+    it "removes a captured scope that is untouched" do
+      captured = described_class.capture(AffixPost, %i[published])
+      removed = described_class.retire!(AffixPost, captured, label: "Test")
+
+      expect(removed).to eq([:published])
+      expect(AffixPost.respond_to?(:published)).to be false
+    end
+
+    it "leaves a scope the model redefined itself" do
+      captured = described_class.capture(AffixPost, %i[published])
+      AffixPost.singleton_class.send(:define_method, :published) { :mine }
+
+      removed = described_class.retire!(AffixPost, captured, label: "Test")
+
+      expect(removed).to be_empty
+      expect(AffixPost.published).to eq(:mine)
+    end
+
+    it "raises when the scope is owned by a parent class" do
+      captured = described_class.capture(AffixPost, %i[published])
+      subclass = stub_const("AffixSpecialPost", Class.new(AffixPost))
+
+      expect do
+        described_class.retire!(subclass, captured, label: "ConcernsOnRails::Models::Publishable")
+      end.to raise_error(ArgumentError, /AffixPost/)
+    end
+  end
 end

--- a/spec/concerns/support/batch_ops_spec.rb
+++ b/spec/concerns/support/batch_ops_spec.rb
@@ -1,0 +1,86 @@
+require "spec_helper"
+
+describe ConcernsOnRails::Support::BatchOps do
+  before do
+    ActiveRecord::Schema.define do
+      create_table :batch_items, force: true do |t|
+        t.string :state
+      end
+    end
+
+    stub_const("BatchItem", Class.new(TestModel) do
+      self.table_name = "batch_items"
+    end)
+  end
+
+  after(:each) do
+    ActiveRecord::Base.connection.tables.each do |table|
+      next if table == "schema_migrations"
+
+      ActiveRecord::Base.connection.drop_table(table)
+    end
+  end
+
+  describe ".fast_path?" do
+    it "is true when no listed method is overridden" do
+      owner = Module.new { def touched; end }
+      klass = Class.new { include(owner) }
+
+      expect(described_class.fast_path?(klass, owner, :touched)).to be true
+    end
+
+    it "is false when the host overrode a listed method" do
+      owner = Module.new { def touched; end }
+      klass = Class.new do
+        include(owner)
+
+        def touched; end
+      end
+
+      expect(described_class.fast_path?(klass, owner, :touched)).to be false
+    end
+  end
+
+  describe ".run" do
+    it "returns the count of records the block accepted" do
+      3.times { BatchItem.create!(state: "new") }
+
+      count = described_class.run(BatchItem.all, label: "Test") { |r| r.update(state: "done") }
+
+      expect(count).to eq(3)
+      expect(BatchItem.where(state: "done").count).to eq(3)
+    end
+
+    it "does not count records the block skips" do
+      BatchItem.create!(state: "new")
+      BatchItem.create!(state: "keep")
+
+      count = described_class.run(BatchItem.all, label: "Test") do |r|
+        r.state == "keep" ? :skip : r.update(state: "done")
+      end
+
+      expect(count).to eq(1)
+    end
+
+    it "raises RecordNotSaved and rolls the batch back when the block returns falsey" do
+      BatchItem.create!(state: "a")
+      BatchItem.create!(state: "b")
+
+      expect do
+        described_class.run(BatchItem.all, label: "Test") do |r|
+          r.state == "b" ? false : r.update(state: "done")
+        end
+      end.to raise_error(ActiveRecord::RecordNotSaved, /Test: failed to update record/)
+
+      expect(BatchItem.where(state: "done").count).to eq(0)
+    end
+
+    it "uses a custom message when given" do
+      BatchItem.create!(state: "a")
+
+      expect do
+        described_class.run(BatchItem.all, label: "Test", message: "failed to soft-delete record") { false }
+      end.to raise_error(ActiveRecord::RecordNotSaved, /failed to soft-delete record/)
+    end
+  end
+end

--- a/spec/concerns/support/batch_ops_spec.rb
+++ b/spec/concerns/support/batch_ops_spec.rb
@@ -6,6 +6,11 @@ describe ConcernsOnRails::Support::BatchOps do
       create_table :batch_items, force: true do |t|
         t.string :state
       end
+
+      create_table :stamped_items, force: true do |t|
+        t.string :state
+        t.timestamps
+      end
     end
 
     stub_const("BatchItem", Class.new(TestModel) do
@@ -21,12 +26,12 @@ describe ConcernsOnRails::Support::BatchOps do
     end
   end
 
-  describe ".fast_path?" do
+  describe ".unoverridden?" do
     it "is true when no listed method is overridden" do
       owner = Module.new { def touched; end }
       klass = Class.new { include(owner) }
 
-      expect(described_class.fast_path?(klass, owner, :touched)).to be true
+      expect(described_class.unoverridden?(klass, owner, :touched)).to be true
     end
 
     it "is false when the host overrode a listed method" do
@@ -37,7 +42,75 @@ describe ConcernsOnRails::Support::BatchOps do
         def touched; end
       end
 
+      expect(described_class.unoverridden?(klass, owner, :touched)).to be false
+    end
+  end
+
+  describe ".fast_path?" do
+    let(:owner) { Module.new { def touched; end } }
+
+    def model_including(owner, &body)
+      Class.new(TestModel) do
+        self.table_name = "batch_items"
+        include(owner)
+
+        class_eval(&body) if body
+      end
+    end
+
+    it "is true for a bare model with nothing overridden and no validations" do
+      expect(described_class.fast_path?(model_including(owner), owner, :touched)).to be true
+    end
+
+    it "is false when the host overrode a listed method" do
+      klass = model_including(owner) { def touched; end }
+
       expect(described_class.fast_path?(klass, owner, :touched)).to be false
+    end
+
+    it "is false when the model declares validates" do
+      klass = model_including(owner) { validates :state, presence: true }
+
+      expect(described_class.fast_path?(klass, owner, :touched)).to be false
+    end
+
+    # Regression: `validate :method` populates only _validate_callbacks, so a
+    # `validators.empty?` gate waved it through and update_all wrote invalid rows.
+    it "is false when the model declares a custom validate method" do
+      klass = model_including(owner) do
+        validate :state_present
+
+        def state_present; end
+      end
+
+      expect(klass.validators).to be_empty
+      expect(described_class.fast_path?(klass, owner, :touched)).to be false
+    end
+  end
+
+  describe ".with_timestamps" do
+    it "adds updated_at when the model has the column" do
+      klass = Class.new(TestModel) { self.table_name = "stamped_items" }
+
+      payload = described_class.with_timestamps(klass, state: "done")
+
+      expect(payload[:state]).to eq("done")
+      expect(payload["updated_at"]).to be_within(5.seconds).of(Time.zone.now)
+    end
+
+    it "leaves the payload alone when the model has no timestamp column" do
+      klass = Class.new(TestModel) { self.table_name = "batch_items" }
+
+      expect(described_class.with_timestamps(klass, state: "done")).to eq(state: "done")
+    end
+
+    it "leaves the payload alone when record_timestamps is off" do
+      klass = Class.new(TestModel) do
+        self.table_name = "stamped_items"
+        self.record_timestamps = false
+      end
+
+      expect(described_class.with_timestamps(klass, state: "done")).to eq(state: "done")
     end
   end
 


### PR DESCRIPTION
Release 1.27.0. Two related additions to the model concerns, plus two new shared support modules. No new columns, migrations, dependencies or gemspec changes.

## Scope affixing

Eight concerns generate scopes and several generate a `.active`, so including SoftDeletable alongside Activatable or Expirable silently clobbered one — Activatable's own source documented the problem and offered no way out. Five concerns already accepted `prefix:`/`suffix:`; the three that could not (Publishable, SoftDeletable, Schedulable) defined their scopes inline in `included do` with hard-coded names.

Those three now build scopes in a private method that `included do` calls with **no affix**, so `include`-without-macro runs the same code as 1.26.0 rather than a re-derivation. Passing an affix rebuilds them renamed and retires the originals, guarded three ways: the name must have been recorded by the concern, be owned by the class's own singleton, and still be the exact method captured — so a model's own override survives, and affixing on a subclass whose parent owns the scopes raises rather than silently leaving the collision in place.

`prefix: true` ("use the configured field name"), previously honoured only by Stateable, now works everywhere.

## Batch operations

`Support::BatchOps` extracts the contract SoftDeletable already had — relation-respecting, Integer count, transactional, rolls back on a failed record, DB-side filtering for idempotency, single-`UPDATE` fast path — and five concerns gain verbs: `publish_all`/`unpublish_all`, `expire_all`, `activate_all`/`deactivate_all`, `unlock_expired`, `transition_all(event)`.

Two correctness properties are worth calling out, because both were found by executing code rather than reading it:

- **The fast path is gated on the model having no validations.** `update_all` skips validations while the per-record path runs them, so without the gate a bulk call wrote invalid rows that a single-record call would refuse — violating the contract's own promise that a failing record raises and rolls back. Detection covers `validates`/`validates_with`, callback-form `validate :method`, and autosave association validations (a bare `has_many` registers one), so in practice most models with associations take the safe streaming path. Lockable is exempt: `unlock_access!` writes via `update_columns`, so its two paths are already equivalent. Stateable never fast-paths at all.
- **`publish_all` composes with caller constraints.** It builds its predicate inline rather than routing through the `unpublished` scope, whose `unscope(where: publishable_field)` was stripping the caller's own predicate on that column — `Post.draft.publish_all` was publishing scheduled rows and destroying their future timestamps. Consequence, documented: on a `default_scope: true` model a bare `Post.publish_all` targets zero rows and callers chain `.draft`/`.unpublished` first.

The fast path also writes `updated_at` now, so it no longer diverges from the per-record path depending on whether the model happens to declare a validator.

## Testing

1257 examples, 0 failures; RuboCop clean. Includes an integration spec building the exact three-way `.active` collision that motivated the release, statement-count assertions proving the fast path is one `UPDATE`, and regression coverage for each correctness property above.

## Docs

README, CHANGELOG, CLAUDE.md and `docs/assets/js/concerns.js` all updated together. Design doc and implementation plan are in `docs/superpowers/`.

Known follow-up, not in this release: `SoftDeletable#restore_all` has the same `unscope` shape that `publish_all` was fixed for, but that is 1.26.0 behaviour this branch did not introduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
