### PR TITLE
Paginatable: paginate Arrays and other Enumerables, not only relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1455,6 +1455,21 @@ class ArticlesController < ApplicationController
 end
 ```
 
+**Arrays and other Enumerables work too.** Results that never touched the database — an
+external API response, a loaded association, a hand-built list of Structs — get the same
+slicing, headers and `pagination_meta`. Relations still paginate in SQL (`LIMIT`/`OFFSET`);
+an in-memory collection is sliced in Ruby and comes back as an `Array`:
+
+```ruby
+def search
+  render json: paginated(ExternalCatalog.search(params[:q]))   # Array in, current page out
+end
+```
+
+Anything answering `limit`/`offset` is treated as a relation; any other non-`Hash` `Enumerable`
+(`Array`, `Set`, `Range`, `Enumerator` — consumed once) is materialized and sliced. A `Hash`,
+`nil` or a non-collection raises `ArgumentError` (call `.to_a` to paginate a Hash's pairs).
+
 **URL params**
 
 | Param        | Default | Notes                              |

--- a/docs/concerns/paginatable.md
+++ b/docs/concerns/paginatable.md
@@ -1,4 +1,4 @@
-Adds offset-based pagination to any Rails controller, exposing a single `paginated` helper method that applies `LIMIT`/`OFFSET` to an ActiveRecord relation and writes standard `X-*` response headers. It requires no Kaminari, will_paginate, or any other pagination library — the entire implementation is self-contained.
+Adds offset-based pagination to any Rails controller, exposing a single `paginated` helper method that applies `LIMIT`/`OFFSET` to an ActiveRecord relation — or slices an in-memory collection such as an `Array`, `Set` or `Range` — and writes standard `X-*` response headers. It requires no Kaminari, will_paginate, or any other pagination library — the entire implementation is self-contained.
 
 ## When to use it
 
@@ -7,6 +7,7 @@ Adds offset-based pagination to any Rails controller, exposing a single `paginat
 - GraphQL or REST endpoints that feed paginated tables in React, Vue, or mobile clients that read `X-Total-Count` and `X-Total-Pages` from response headers.
 - Any controller that needs pagination without pulling in a full pagination gem and its view helpers.
 - Controllers that compose pagination with `ConcernsOnRails::Controllers::Filterable` or `ConcernsOnRails::Controllers::Sortable` — `paginated` accepts any scoped relation.
+- Endpoints whose results never touch the database — an external API response, a search-service hit list, a loaded association or a hand-built list of Structs — `paginated` slices any Enumerable and emits the identical headers, so clients cannot tell the two apart.
 
 ## Installation
 
@@ -45,9 +46,18 @@ end
 
 ### Instance methods
 
-**`paginated(relation) → ActiveRecord::Relation`**
+**`paginated(collection) → ActiveRecord::Relation | Array`**
 
-Applies pagination to the given relation and sets the four standard response headers. The `relation` argument can be any ActiveRecord relation or scope — it is not mutated. The method strips `ORDER`, `LIMIT`, and `OFFSET` clauses before running the `COUNT` query, so pre-applied ordering does not affect the total count. Returns the paginated relation (a new relation object with `LIMIT` and `OFFSET` applied); the relation is not yet evaluated (lazy).
+Applies pagination to the given collection and sets the four standard response headers. The argument is not mutated. Two kinds of input are accepted:
+
+- **A relation** — anything that answers `limit` and `offset` (an `ActiveRecord::Relation`, an association `CollectionProxy`, a model class). The method strips `ORDER`, `LIMIT`, `OFFSET` and a custom `SELECT` before running the `COUNT` query, so pre-applied ordering does not affect the total. Returns a new relation with `LIMIT` and `OFFSET` applied; it is not yet evaluated (lazy).
+- **An in-memory collection** — any other non-`Hash` `Enumerable` (`Array`, `Set`, `Range`, `Enumerator`, …). It is materialized once with `to_a` (so an `Enumerator` is consumed a single time for both the count and the slice), the total is its size, and the current page is returned as an `Array` — `[]` when the requested page is past the end.
+
+A `Hash` is rejected with an `ArgumentError` rather than silently paginated as `[key, value]` pairs (call `.to_a` if that is what you mean); `nil` and non-collections (a String, an Integer) raise the same error, naming the class received.
+
+**`pagination_meta(collection = nil) → Hash`**
+
+Returns `{ total:, page:, per_page:, total_pages: }` **without** applying `LIMIT`/`OFFSET` or slicing — handy for body-based pagination composed with `Respondable`'s `meta:`. Called with no argument after `paginated`, it reuses that call's memoized metadata (no second `COUNT`); pass a relation or collection to compute fresh. Accepts exactly the same inputs as `paginated`.
 
 The four `X-*` headers set on `response`:
 
@@ -78,6 +88,22 @@ end
 #   X-Page: 2
 #   X-Per-Page: 20
 #   X-Total-Pages: 5
+```
+
+**Paginating an in-memory collection**
+
+```ruby
+class CatalogController < ApplicationController
+  include ConcernsOnRails::Controllers::Paginatable
+  include ConcernsOnRails::Controllers::Respondable
+
+  def search
+    hits = ExternalCatalog.search(params[:q])          # a plain Array from a third-party API
+    render_success(data: paginated(hits), meta: pagination_meta)
+  end
+end
+# GET /catalog/search?q=lamp&page=2&per_page=10
+# => data holds hits[10, 10]; meta and the X-* headers describe all of `hits`
 ```
 
 **Combining with filtering and sorting**
@@ -114,6 +140,8 @@ end
 ## Notes & gotchas
 
 - **No database columns required.** This is a pure controller concern with no model-layer dependency.
+- **In-memory collections are sliced in Ruby.** The whole collection is already in memory by definition, so `paginated(array)` costs one `to_a` plus an `Array#[]` — there is no lazy path. If the data lives in a table, pass the relation so the database does the work.
+- **Relation detection is duck-typed.** Anything answering `limit` and `offset` takes the SQL path; that includes association proxies and model classes, and keeps a `has_many` collection paginating in the database rather than loading it.
 - **Headers require a live `response` object.** The `set_pagination_headers` method guards with `respond_to?(:response) && response`. In plain unit tests without a real HTTP response object, headers are silently skipped; the return value (the paginated relation) is still correct.
 - **Page clamping is one-directional.** Values below 1 are raised to 1, but there is no upper bound on `page`. Requesting a page far beyond the last page returns an empty relation and still sets all headers correctly, including the real `X-Total-Count`.
 - **`max_per_page: 0` (or any non-positive value) disables the cap.** The guard `cap.positive? ? [requested, cap].min : requested` means a zero or negative `max_per_page` lets any caller-requested value through unchecked.

--- a/lib/concerns_on_rails/controllers/paginatable.rb
+++ b/lib/concerns_on_rails/controllers/paginatable.rb
@@ -14,9 +14,19 @@ module ConcernsOnRails
     #       render json: paginated(Article.all)
     #     end
     #   end
+    #
+    # `paginated` also takes an in-memory collection — an Array, Set, Range or
+    # any other non-Hash Enumerable — so results assembled outside the
+    # database (an external API, a loaded association, a hand-built list of
+    # Structs) get the same slicing, headers and `pagination_meta`:
+    #
+    #   def search
+    #     render json: paginated(ExternalCatalog.search(params[:q]))
+    #   end
     module Paginatable
       extend ActiveSupport::Concern
 
+      LABEL = "ConcernsOnRails::Controllers::Paginatable".freeze
       DEFAULT_PER_PAGE = 25
       DEFAULT_MAX_PER_PAGE = 200
 
@@ -35,40 +45,49 @@ module ConcernsOnRails
         end
       end
 
-      # Apply pagination to a relation and set the standard response headers.
-      # Returns the paginated relation; the metadata is memoized so a follow-up
-      # `pagination_meta` (no argument) reuses it. Safe on empty relations.
-      def paginated(relation)
+      # Apply pagination to a relation or an in-memory collection and set the
+      # standard response headers. A relation comes back as a relation with
+      # LIMIT/OFFSET applied (still lazy); an Enumerable comes back as the
+      # current page's Array slice (`[]` past the last page). The metadata is
+      # memoized so a follow-up `pagination_meta` (no argument) reuses it.
+      # Safe on empty collections.
+      def paginated(collection)
         @paginatable_meta = nil
+        source = paginatable_source(collection)
         page = pagination_page
         per_page = pagination_per_page
         offset = (page - 1) * per_page
 
-        total = paginatable_total(relation)
+        total = paginatable_total(source)
         total_pages = per_page.positive? ? (total.to_f / per_page).ceil : 0
 
-        records = relation.limit(per_page).offset(offset)
+        records =
+          if source.is_a?(Array)
+            source[offset, per_page] || []
+          else
+            source.limit(per_page).offset(offset)
+          end
 
         @paginatable_meta = { total: total, page: page, per_page: per_page, total_pages: total_pages }
         set_pagination_headers(**@paginatable_meta)
         records
       end
 
-      # Pagination metadata WITHOUT applying limit/offset — handy for
-      # body-based pagination (compose with Respondable's `meta:`). Call with
-      # no argument after `paginated` to reuse its memoized meta — the
+      # Pagination metadata WITHOUT applying limit/offset (or slicing) — handy
+      # for body-based pagination (compose with Respondable's `meta:`). Call
+      # with no argument after `paginated` to reuse its memoized meta — the
       # documented records+meta composition used to run the identical COUNT
-      # twice per request. Pass a relation to compute fresh.
-      def pagination_meta(relation = nil)
-        return @paginatable_meta if relation.nil? && @paginatable_meta
+      # twice per request. Pass a relation or collection to compute fresh.
+      def pagination_meta(collection = nil)
+        return @paginatable_meta if collection.nil? && @paginatable_meta
 
-        if relation.nil?
+        if collection.nil?
           raise ArgumentError,
-                "ConcernsOnRails::Controllers::Paginatable: pagination_meta needs a relation " \
+                "#{LABEL}: pagination_meta needs a relation or collection " \
                 "(no prior paginated call in this request to reuse)"
         end
 
-        total = paginatable_total(relation)
+        total = paginatable_total(paginatable_source(collection))
         per_page = pagination_per_page
         {
           total: total,
@@ -80,13 +99,31 @@ module ConcernsOnRails
 
       private
 
-      # COUNT with the clauses that break or skew it stripped: order/limit/
-      # offset are irrelevant, a custom SELECT list would turn into the invalid
-      # COUNT(a, b), and count(:all) keeps DISTINCT semantics. A grouped
-      # relation counts as a Hash (group => count); the meaningful total is the
-      # number of groups.
-      def paginatable_total(relation)
-        counted = relation.except(:order, :limit, :offset, :select).count(:all)
+      # Relations — anything answering `limit` and `offset`: an
+      # ActiveRecord::Relation, an association CollectionProxy, a model class —
+      # pass through untouched so they keep paginating in SQL. Any other
+      # non-Hash Enumerable is materialized ONCE into an Array, so an
+      # Enumerator is not consumed twice (once to count, once to slice). A Hash
+      # is rejected rather than silently paginated as [key, value] pairs.
+      def paginatable_source(collection)
+        return collection if collection.respond_to?(:limit) && collection.respond_to?(:offset)
+        return collection.to_a if collection.is_a?(Enumerable) && !collection.is_a?(Hash)
+
+        hint = collection.is_a?(Hash) ? " — call .to_a to paginate a Hash as [key, value] pairs" : ""
+        raise ArgumentError,
+              "#{LABEL}: expected an ActiveRecord relation or an Enumerable (Array, Set, Range, ...), " \
+              "got #{collection.class}#{hint}"
+      end
+
+      # Arrays already know their size. Relations COUNT with the clauses that
+      # break or skew it stripped: order/limit/offset are irrelevant, a custom
+      # SELECT list would turn into the invalid COUNT(a, b), and count(:all)
+      # keeps DISTINCT semantics. A grouped relation counts as a Hash
+      # (group => count); the meaningful total is the number of groups.
+      def paginatable_total(source)
+        return source.size if source.is_a?(Array)
+
+        counted = source.except(:order, :limit, :offset, :select).count(:all)
         counted.is_a?(Hash) ? counted.length : counted
       end
 

--- a/spec/concerns/controllers/paginatable_spec.rb
+++ b/spec/concerns/controllers/paginatable_spec.rb
@@ -112,4 +112,116 @@ describe ConcernsOnRails::Controllers::Paginatable do
     meta = controller.pagination_meta(Widget.all)
     expect(meta).to eq(total: 50, page: 2, per_page: 10, total_pages: 5)
   end
+  describe "in-memory collections (Array / Enumerable)" do
+    let(:items) { (1..50).map { |i| "item #{i}" } }
+
+    it "paginates an Array with the default per_page and sets the headers" do
+      controller = controller_class.new
+      page = controller.paginated(items)
+      expect(page).to be_an(Array)
+      expect(page.size).to eq(25)
+      expect(page.first).to eq("item 1")
+      expect(controller.response.headers).to include(
+        "X-Total-Count" => "50", "X-Page" => "1", "X-Per-Page" => "25", "X-Total-Pages" => "2"
+      )
+    end
+
+    it "honors page and per_page params" do
+      controller = controller_class.new(params: { page: 3, per_page: 10 })
+      page = controller.paginated(items)
+      expect(page).to eq(items[20, 10])
+      expect(controller.response.headers["X-Page"]).to eq("3")
+      expect(controller.response.headers["X-Total-Pages"]).to eq("5")
+    end
+
+    it "returns an empty Array for a page beyond the end (headers still set)" do
+      controller = controller_class.new(params: { page: 99, per_page: 10 })
+      expect(controller.paginated(items)).to eq([])
+      expect(controller.response.headers["X-Total-Count"]).to eq("50")
+      expect(controller.response.headers["X-Total-Pages"]).to eq("5")
+    end
+
+    it "handles an empty Array" do
+      controller = controller_class.new
+      expect(controller.paginated([])).to eq([])
+      expect(controller.response.headers["X-Total-Count"]).to eq("0")
+      expect(controller.response.headers["X-Total-Pages"]).to eq("0")
+    end
+
+    it "does not mutate the source Array" do
+      controller = controller_class.new(params: { per_page: 5, page: 2 })
+      source = items.dup
+      controller.paginated(source)
+      expect(source).to eq(items)
+    end
+
+    it "caps per_page at max_per_page for arrays too" do
+      klass = Class.new(FakeController) do
+        include ConcernsOnRails::Controllers::Paginatable
+
+        paginate_by per_page: 25, max_per_page: 7
+      end
+      controller = klass.new(params: { per_page: 999 })
+      expect(controller.paginated(items).size).to eq(7)
+      expect(controller.response.headers["X-Per-Page"]).to eq("7")
+    end
+
+    it "accepts any non-Hash Enumerable (Range, Set, Enumerator)" do
+      controller = controller_class.new(params: { per_page: 3, page: 2 })
+      expect(controller.paginated(1..10)).to eq([4, 5, 6])
+      expect(controller.paginated(Set.new(1..10))).to eq([4, 5, 6])
+      expect(controller.paginated((1..10).each)).to eq([4, 5, 6])
+    end
+
+    it "materializes an Enumerator only once (count + slice share one pass)" do
+      passes = 0
+      enum = Enumerator.new do |y|
+        passes += 1
+        (1..10).each { |i| y << i }
+      end
+      controller = controller_class.new(params: { per_page: 4 })
+      expect(controller.paginated(enum)).to eq([1, 2, 3, 4])
+      expect(passes).to eq(1)
+    end
+
+    it "paginates an Array of records (e.g. a loaded association) the same way" do
+      controller = controller_class.new(params: { per_page: 10, page: 2 })
+      loaded = Widget.order(:id).to_a
+      page = controller.paginated(loaded)
+      expect(page).to be_an(Array)
+      expect(page.map(&:name)).to eq(loaded[10, 10].map(&:name))
+    end
+
+    it "memoizes meta so pagination_meta with no argument reuses it" do
+      controller = controller_class.new(params: { page: 2, per_page: 20 })
+      controller.paginated(items)
+      expect(controller.pagination_meta).to eq(total: 50, page: 2, per_page: 20, total_pages: 3)
+    end
+
+    it "computes pagination_meta for an Array without slicing" do
+      controller = controller_class.new(params: { page: 2, per_page: 20 })
+      expect(controller.pagination_meta(items)).to eq(total: 50, page: 2, per_page: 20, total_pages: 3)
+    end
+
+    it "rejects a Hash with an ArgumentError that points at .to_a" do
+      controller = controller_class.new
+      expect { controller.paginated({ a: 1 }) }
+        .to raise_error(ArgumentError, /Paginatable.*got Hash.*\.to_a/)
+    end
+
+    it "rejects nil and non-collections" do
+      controller = controller_class.new
+      expect { controller.paginated(nil) }.to raise_error(ArgumentError, /Paginatable.*got NilClass/)
+      expect { controller.paginated("not a collection") }.to raise_error(ArgumentError, /Paginatable.*got String/)
+      expect { controller.paginated(42) }.to raise_error(ArgumentError, /Paginatable.*got Integer/)
+      expect { controller.pagination_meta(42) }.to raise_error(ArgumentError, /Paginatable.*got Integer/)
+    end
+
+    it "still routes relations through SQL LIMIT/OFFSET rather than loading them" do
+      controller = controller_class.new(params: { per_page: 10 })
+      records = controller.paginated(Widget.all)
+      expect(records).to be_a(ActiveRecord::Relation)
+      expect(records.to_sql).to match(/LIMIT/i)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`paginated` / `pagination_meta` required an ActiveRecord relation — anything else blew up on `.limit`. Results that never touch the database (an external API response, a search-service hit list, a loaded association, a hand-built list of Structs) had no way to get the same slicing, `X-*` headers and `pagination_meta`.

This PR makes `paginated(collection)` accept **any in-memory Enumerable** while keeping the relation path byte-for-byte unchanged:

- **Relation detection is duck-typed**: anything answering `limit` and `offset` (Relation, association `CollectionProxy`, model class) takes the SQL path exactly as before.
- **Any other non-`Hash` `Enumerable`** (`Array`, `Set`, `Range`, `Enumerator`, …) is materialized **once** via `to_a` (an Enumerator is not consumed twice for count + slice), the total is its size, and the current page comes back as an `Array` — `[]` past the last page. Headers and memoized meta are identical to the relation path.
- **A `Hash` is rejected** with an `ArgumentError` pointing at `.to_a` rather than silently paginated as `[key, value]` pairs; `nil`, String, Integer raise the same error naming the class received.
- `pagination_meta(collection)` accepts the same inputs.
- Extracted `LABEL` for error messages (Cacheable/Deprecatable precedent).

```ruby
def search
  hits = ExternalCatalog.search(params[:q])          # a plain Array
  render_success(data: paginated(hits), meta: pagination_meta)
end
```

## Docs

- `README.md` — Paginatable section gains an "Arrays and other Enumerables work too" paragraph + snippet.
- `docs/concerns/paginatable.md` — intro, "When to use it", `paginated` / `pagination_meta` method docs (the latter was undocumented), a new in-memory example, two Notes bullets.

## Changelog entry (for `CHANGELOG.md` at release — kept out of this diff so parallel enhancement PRs don't conflict)

```
### Added
- **Controllers::Paginatable**: `paginated` / `pagination_meta` accept in-memory
  collections — an `Array`, `Set`, `Range` or any other non-Hash `Enumerable` —
  not only ActiveRecord relations. The collection is materialized once, the
  total is its size and the current page comes back as an `Array` with the same
  `X-Total-Count` / `X-Page` / `X-Per-Page` / `X-Total-Pages` headers and
  memoized meta. Relations still paginate in SQL. A `Hash`, `nil` or a
  non-collection raises `ArgumentError` naming the class received.
```

## Test plan

- [x] 13 new examples in `spec/concerns/controllers/paginatable_spec.rb`: default slicing + headers, `page`/`per_page`, past-the-end → `[]`, empty Array, source not mutated, `max_per_page` cap, Range/Set/Enumerator, Enumerator single pass, Array of AR records, meta memoization + fresh meta, Hash/nil/String/Integer rejections, relation still emits `LIMIT`.
- [x] Full suite: 1271 examples, 0 failures (98.32% line coverage).
- [x] RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
