### PR TITLE
ErrorHandleable: expand the exception map from 3 to 14, add handle_errors only:/except:

### DIFF
--- a/README.md
+++ b/README.md
@@ -1681,22 +1681,42 @@ end
 
 ## 🛟 ErrorHandleable
 
-Install `rescue_from` handlers for the three most common controller exceptions and render them as the same JSON envelope used by Respondable.
+Install `rescue_from` handlers for the controller exceptions a JSON API meets in practice and render them as the same JSON envelope used by Respondable.
 
 ```ruby
 class Api::BaseController < ApplicationController
   include ConcernsOnRails::Controllers::Respondable       # recommended
   include ConcernsOnRails::Controllers::ErrorHandleable
+
+  handle_errors except: :stale_object                     # optional — let some propagate
 end
 ```
 
 **Handled exceptions**
 
-| Exception                              | Status | `code`                |
-|----------------------------------------|--------|-----------------------|
-| `ActiveRecord::RecordNotFound`         | 404    | `"not_found"`         |
-| `ActionController::ParameterMissing`   | 400    | `"parameter_missing"` |
-| `ActiveRecord::RecordInvalid`          | 422    | `"record_invalid"`    |
+| Key (= `code`)               | Exception                                      | Status | `details`                    |
+|------------------------------|------------------------------------------------|--------|------------------------------|
+| `not_found`                  | `ActiveRecord::RecordNotFound`                 | 404    | —                            |
+| `parameter_missing`          | `ActionController::ParameterMissing`           | 400    | —                            |
+| `record_invalid`             | `ActiveRecord::RecordInvalid`                  | 422    | `errors.full_messages`       |
+| `validation_error`           | `ActiveModel::ValidationError`                 | 422    | `model.errors.full_messages` |
+| `record_not_saved`           | `ActiveRecord::RecordNotSaved`                 | 422    | record errors, if any        |
+| `record_not_destroyed`       | `ActiveRecord::RecordNotDestroyed`             | 422    | record errors, if any        |
+| `stale_object`               | `ActiveRecord::StaleObjectError`               | 409    | —                            |
+| `record_not_unique`          | `ActiveRecord::RecordNotUnique`                | 409    | —                            |
+| `foreign_key_violation`      | `ActiveRecord::InvalidForeignKey`              | 409    | —                            |
+| `unpermitted_parameters`     | `ActionController::UnpermittedParameters`      | 400    | the parameter names          |
+| `invalid_authenticity_token` | `ActionController::InvalidAuthenticityToken`   | 422    | —                            |
+| `bad_request`                | `ActionController::BadRequest`                 | 400    | —                            |
+| `parse_error`                | `ActionDispatch::Http::Parameters::ParseError` | 400    | —                            |
+| `unknown_format`             | `ActionController::UnknownFormat`              | 406    | —                            |
+
+Statuses follow Rails' own `rescue_responses` wherever Rails has an opinion; the two database-constraint
+races Rails leaves as 500s (`RecordNotUnique`, `InvalidForeignKey`) get the REST-conventional 409. Messages
+for database- and parser-level errors are deliberately generic (`"Resource already exists"`,
+`"Malformed request body"`, …): the raw messages carry SQL fragments, table/column names, model class
+names or the offending input, none of which belongs in an API response. `details` is present only when
+there is something to list.
 
 Response shape (matches `Respondable#render_error`):
 
@@ -1718,8 +1738,23 @@ class Api::BaseController < ApplicationController
 end
 ```
 
+**Trimming the map**
+
+```ruby
+handle_errors except: :stale_object                               # let optimistic-lock conflicts reach the error tracker
+handle_errors except: %i[record_not_unique foreign_key_violation]  # calls accumulate
+handle_errors only: %i[not_found parameter_missing record_invalid] # just the original trio
+```
+
+`handle_errors` removes only the concern's own registrations (matched on exception *and* handler), so a
+`rescue_from` you declared yourself for the same exception is untouched, and it never re-adds — your later
+declarations keep precedence. Unknown keys raise `ArgumentError` listing the valid ones;
+`error_handleable_keys` returns the keys still active on a controller.
+
 **Notes**
 - When `Respondable` is also included, the handlers delegate to `render_error` so the envelope shape stays in one place. Otherwise they render the same envelope inline.
+- Exceptions are registered by name (string), so a class your Rails version lacks is simply never matched.
+- `ActionController::UnpermittedParameters` is only raised with `config.action_controller.action_on_unpermitted_parameters = :raise`.
 - `RecordInvalid.details` are populated from `error.record.errors.full_messages`.
 
 ---

--- a/docs/concerns/error-handleable.md
+++ b/docs/concerns/error-handleable.md
@@ -1,4 +1,4 @@
-`ErrorHandleable` installs `rescue_from` handlers for the three most common controller exceptions — `ActiveRecord::RecordNotFound`, `ActionController::ParameterMissing`, and `ActiveRecord::RecordInvalid` — and renders each as a uniform JSON error envelope. Without it, unhandled exceptions propagate as 500s or Rails HTML error pages, breaking JSON API clients. Including this concern ensures every error surface returns `{ success: false, error: { message, code } }` automatically, with no per-action rescue boilerplate.
+`ErrorHandleable` installs `rescue_from` handlers for the controller exceptions a JSON API meets in practice — not-found lookups, missing/unpermitted parameters, validation failures (ActiveRecord *and* plain ActiveModel form objects), callback-aborted saves and destroys, optimistic-locking conflicts, unique-index and foreign-key races, malformed bodies and unsupported formats — and renders each as a uniform JSON error envelope. Without it, unhandled exceptions propagate as 500s or Rails HTML error pages, breaking JSON API clients. Including this concern ensures every error surface returns `{ success: false, error: { message, code } }` automatically, with no per-action rescue boilerplate.
 
 ## When to use it
 
@@ -7,6 +7,9 @@
 - A resource endpoint calls `find!` or a bang save/create and you want 404/422 responses without extra code.
 - Strong parameters are required and you want a descriptive 400 response that names the missing parameter.
 - A subclass needs to customize one error message or response shape without re-registering `rescue_from`.
+- Models use `lock_version` and a lost update should be a 409 the client can retry, not a 500.
+- A unique index backs a uniqueness validation and the rare race should surface as a 409, not a 500 carrying the adapter's SQL error.
+- Some exceptions should still reach the error tracker — `handle_errors except:` lets them propagate.
 
 ## Installation
 
@@ -19,11 +22,39 @@ class Api::BaseController < ApplicationController
 end
 ```
 
-No configuration macro is required. The three `rescue_from` handlers are registered automatically in the `included` block.
+No configuration macro is required. Every handler in the table below is registered automatically in the `included` block; `handle_errors` (optional) trims the set.
 
 ## Configuration
 
-`ErrorHandleable` has no configuration macro. Behavior is determined entirely by which exceptions are raised and whether `Respondable` is present on the same controller. See "Methods" below for the handler signatures that can be overridden in subclasses.
+**Handled exceptions.** The key doubles as the envelope `code`.
+
+| Key (= `code`)               | Exception                                      | Status | `details`                    |
+|------------------------------|------------------------------------------------|--------|------------------------------|
+| `not_found`                  | `ActiveRecord::RecordNotFound`                 | 404    | —                            |
+| `parameter_missing`          | `ActionController::ParameterMissing`           | 400    | —                            |
+| `record_invalid`             | `ActiveRecord::RecordInvalid`                  | 422    | `errors.full_messages`       |
+| `validation_error`           | `ActiveModel::ValidationError`                 | 422    | `model.errors.full_messages` |
+| `record_not_saved`           | `ActiveRecord::RecordNotSaved`                 | 422    | record errors, if any        |
+| `record_not_destroyed`       | `ActiveRecord::RecordNotDestroyed`             | 422    | record errors, if any        |
+| `stale_object`               | `ActiveRecord::StaleObjectError`               | 409    | —                            |
+| `record_not_unique`          | `ActiveRecord::RecordNotUnique`                | 409    | —                            |
+| `foreign_key_violation`      | `ActiveRecord::InvalidForeignKey`              | 409    | —                            |
+| `unpermitted_parameters`     | `ActionController::UnpermittedParameters`      | 400    | the parameter names          |
+| `invalid_authenticity_token` | `ActionController::InvalidAuthenticityToken`   | 422    | —                            |
+| `bad_request`                | `ActionController::BadRequest`                 | 400    | —                            |
+| `parse_error`                | `ActionDispatch::Http::Parameters::ParseError` | 400    | —                            |
+| `unknown_format`             | `ActionController::UnknownFormat`              | 406    | —                            |
+
+Statuses follow Rails' own `rescue_responses` wherever Rails has an opinion; the two database-constraint races Rails leaves as 500s (`RecordNotUnique`, `InvalidForeignKey`) get the REST-conventional 409.
+
+**`handle_errors(only: nil, except: nil)`** — class macro, optional. Trims the default map: `only:` keeps just the named keys, `except:` drops them; accepts a symbol or an array; calls accumulate. Only the concern's *own* registrations are removed (matched on exception name **and** handler method), so a `rescue_from` you declared for the same exception is untouched — and nothing is ever re-added, so your later declarations keep precedence. Unknown keys raise `ArgumentError` listing the valid ones; passing both `only:` and `except:` raises.
+
+```ruby
+handle_errors except: :stale_object                                # let lock conflicts reach the error tracker
+handle_errors only: %i[not_found parameter_missing record_invalid] # the pre-expansion trio
+```
+
+**`error_handleable_keys`** — class attribute, read-only in practice: the keys still active on this controller after any `handle_errors` calls.
 
 ## Methods
 
@@ -31,11 +62,22 @@ No configuration macro is required. The three `rescue_from` handlers are registe
 
 | Method | Signature | Description |
 |---|---|---|
-| `handle_record_not_found` | `handle_record_not_found(error)` | Renders a 404 `not_found` envelope using `error.message` as the human-readable message. |
-| `handle_parameter_missing` | `handle_parameter_missing(error)` | Renders a 400 `parameter_missing` envelope; the message is `"Parameter missing: <param>"` where `<param>` comes from `error.param`. |
-| `handle_record_invalid` | `handle_record_invalid(error)` | Renders a 422 `record_invalid` envelope; `error.record.errors.full_messages` is attached as `details` when the record exposes an `errors` object. |
+| `handle_record_not_found` | `(error)` | 404 `not_found`. The message is the generic `"Resource not found"` — the raw message would leak the model class and the queried attribute/value. |
+| `handle_parameter_missing` | `(error)` | 400 `parameter_missing`; message `"Parameter missing: <param>"` from `error.param`. |
+| `handle_record_invalid` | `(error)` | 422 `record_invalid`; `error.message`, `details` = `record.errors.full_messages`. |
+| `handle_validation_error` | `(error)` | 422 `validation_error` for `validate!` on a plain `ActiveModel::Model`; `details` = `error.model.errors.full_messages`. |
+| `handle_record_not_saved` | `(error)` | 422 `record_not_saved` (`save!` aborted by a callback); `details` only when the record carries errors. |
+| `handle_record_not_destroyed` | `(error)` | 422 `record_not_destroyed`; `details` only when the record carries errors. |
+| `handle_stale_object` | `(error)` | 409 `stale_object`; generic `"Resource was modified by another request; reload and retry"` (the raw message names the model class). |
+| `handle_record_not_unique` | `(error)` | 409 `record_not_unique`; generic `"Resource already exists"` (the raw message is the adapter's SQL error). |
+| `handle_invalid_foreign_key` | `(error)` | 409 `foreign_key_violation`; generic `"Resource is referenced by other records"`. |
+| `handle_unpermitted_parameters` | `(error)` | 400 `unpermitted_parameters`; message lists the names, `details` = the names. |
+| `handle_invalid_authenticity_token` | `(error)` | 422 `invalid_authenticity_token`. |
+| `handle_bad_request` | `(error)` | 400 `bad_request`; generic `"Bad request"` — the raw message echoes the offending input. |
+| `handle_parse_error` | `(error)` | 400 `parse_error`; generic `"Malformed request body"` — the raw message carries the parser's body excerpt. |
+| `handle_unknown_format` | `(error)` | 406 `unknown_format`; `"Requested format is not supported"`. |
 
-All three methods are **public**, which is intentional: subclasses can override any handler without re-declaring `rescue_from`.
+All handlers are **public**, which is intentional: subclasses can override any one without re-declaring `rescue_from`. Each renders through the private `render_handled_error(key, message:, errors:)`, which takes `code` and status from the table; an override that wants the standard envelope with different wording can call `render_error_envelope(message:, code:, status:, errors:)`.
 
 The private helper `render_error_envelope` is not part of the public API and should not be called directly.
 
@@ -70,12 +112,25 @@ end
 
 Response for a missing record (`GET /api/users/99`):
 ```json
-{ "success": false, "error": { "message": "Couldn't find User with 'id'=99", "code": "not_found" } }
+{ "success": false, "error": { "message": "Resource not found", "code": "not_found" } }
 ```
 
 Response for a validation failure (`POST /api/users` with invalid body):
 ```json
 { "success": false, "error": { "message": "Validation failed: Name can't be blank", "code": "record_invalid", "details": ["Name can't be blank"] } }
+```
+
+**Letting some exceptions propagate**
+
+```ruby
+class Api::BaseController < ApplicationController
+  include ConcernsOnRails::Controllers::ErrorHandleable
+
+  # Lock conflicts should page us, not turn into a quiet 409.
+  handle_errors except: :stale_object
+end
+
+Api::BaseController.error_handleable_keys   # => every key but :stale_object
 ```
 
 **Overriding a single handler in a subclass**
@@ -107,14 +162,17 @@ The JSON shape rendered is identical to the `Respondable` path:
 ```json
 { "success": false, "error": { "message": "...", "code": "..." } }
 ```
-The `details` key is only present when validation errors exist (`RecordInvalid`).
+The `details` key is only present when there is something to list (validation messages, unpermitted parameter names).
 
 ## Notes & gotchas
 
 - **Exception strings, not classes.** `rescue_from` is registered with string names (`"ActiveRecord::RecordNotFound"`, etc.) rather than constant references. This means the handlers are safe to load before ActiveRecord/ActionController constants are resolved, and avoids autoload ordering issues.
 - **Respondable detection at render time.** The concern checks `respond_to?(:render_error)` inside `render_error_envelope` each time an error occurs, not at include time. If `Respondable` is included after `ErrorHandleable`, delegation still works correctly.
-- **`details` key is conditional.** The `details` array is only added to the error envelope when `RecordInvalid` is handled and the error object exposes a `record` with an `errors` object. If `error.record` is `nil` or does not respond to `errors`, `details` is omitted entirely from the JSON.
-- **Handler override pattern.** Because all three handlers (`handle_record_not_found`, `handle_parameter_missing`, `handle_record_invalid`) are public instance methods, subclasses can override any one without re-declaring `rescue_from`. The `rescue_from` dispatch calls the method by name, so Ruby's normal method lookup finds the override automatically.
+- **`details` key is conditional.** `details` is added only when there is something to list: `errors.full_messages` of the record/model behind `RecordInvalid`, `ValidationError`, `RecordNotSaved` and `RecordNotDestroyed` (omitted when the object has no errors or none is attached), and the parameter names for `UnpermittedParameters`.
+- **Generic messages by design.** Database- and parser-level exceptions (`StaleObjectError`, `RecordNotUnique`, `InvalidForeignKey`, `BadRequest`, `ParseError`) render fixed wording rather than `error.message`, which carries SQL fragments, table/column and model names or the offending input. Override the handler if a trusted environment wants the detail.
+- **`UnpermittedParameters` needs `:raise`.** It is only raised with `config.action_controller.action_on_unpermitted_parameters = :raise` (the default logs or ignores).
+- **Trimming never re-adds.** `handle_errors` only removes the concern's own `[exception, handler]` pairs from `rescue_handlers`; a host `rescue_from` for the same exception — declared before or after — is preserved and keeps its precedence.
+- **Handler override pattern.** Because every handler is a public instance method, subclasses can override any one without re-declaring `rescue_from`. The `rescue_from` dispatch calls the method by name, so Ruby's normal method lookup finds the override automatically.
 - **No model concerns, no DB columns.** This is a controller-only concern. It does not touch ActiveRecord models, add scopes, or require any schema changes.
 - **`Respondable` include order.** When pairing with `Respondable`, include `Respondable` before `ErrorHandleable`. Both orderings work (see the delegation note above), but the conventional order communicates intent more clearly and matches the recommended pattern in the source comments.
 - **Parameter name in 400 response.** The 400 message is always `"Parameter missing: <param>"` where `<param>` is `error.param` from `ActionController::ParameterMissing`. The exact symbol name of the missing parameter is always included, making it unambiguous for API clients.

--- a/lib/concerns_on_rails/controllers/error_handleable.rb
+++ b/lib/concerns_on_rails/controllers/error_handleable.rb
@@ -3,18 +3,38 @@ require "concerns_on_rails/support/error_envelope"
 
 module ConcernsOnRails
   module Controllers
-    # Installs `rescue_from` handlers for the three most common controller
-    # exceptions and renders them as the JSON error envelope used by Respondable.
+    # Installs `rescue_from` handlers for the controller exceptions a JSON API
+    # meets in practice and renders each as the error envelope Respondable uses.
     #
     #   class Api::BaseController < ApplicationController
     #     include ConcernsOnRails::Controllers::Respondable      # optional, but recommended
     #     include ConcernsOnRails::Controllers::ErrorHandleable
+    #
+    #     handle_errors except: :stale_object    # optional: let some propagate
     #   end
     #
-    # Handled:
-    #   * ActiveRecord::RecordNotFound          → 404 not_found
-    #   * ActionController::ParameterMissing    → 400 parameter_missing
-    #   * ActiveRecord::RecordInvalid           → 422 record_invalid (with field errors)
+    # Handled (key → exception → status):
+    #   * :not_found                  ActiveRecord::RecordNotFound                 404
+    #   * :parameter_missing          ActionController::ParameterMissing           400
+    #   * :record_invalid             ActiveRecord::RecordInvalid                  422 (+ field errors)
+    #   * :validation_error           ActiveModel::ValidationError                 422 (+ field errors)
+    #   * :record_not_saved           ActiveRecord::RecordNotSaved                 422 (+ field errors, if any)
+    #   * :record_not_destroyed       ActiveRecord::RecordNotDestroyed             422 (+ field errors, if any)
+    #   * :stale_object               ActiveRecord::StaleObjectError               409
+    #   * :record_not_unique          ActiveRecord::RecordNotUnique                409
+    #   * :foreign_key_violation      ActiveRecord::InvalidForeignKey              409
+    #   * :unpermitted_parameters     ActionController::UnpermittedParameters      400 (+ the param names)
+    #   * :invalid_authenticity_token ActionController::InvalidAuthenticityToken   422
+    #   * :bad_request                ActionController::BadRequest                 400
+    #   * :parse_error                ActionDispatch::Http::Parameters::ParseError 400
+    #   * :unknown_format             ActionController::UnknownFormat              406
+    #
+    # Statuses follow Rails' own `rescue_responses` wherever Rails has an
+    # opinion; the two database-constraint races Rails leaves as 500s
+    # (RecordNotUnique, InvalidForeignKey) get the REST-conventional 409.
+    # Messages for database- and parser-level errors are deliberately generic:
+    # the raw messages carry SQL fragments, table/column names, model class
+    # names or the offending input, none of which belongs in an API response.
     #
     # If Respondable is also included on the controller, the handlers delegate
     # to `render_error` so the envelope shape stays in one place. Otherwise the
@@ -25,49 +45,190 @@ module ConcernsOnRails
     module ErrorHandleable
       extend ActiveSupport::Concern
 
+      LABEL = "ConcernsOnRails::Controllers::ErrorHandleable".freeze
+
+      # The envelope `code` is the key; the status is what the handler renders.
+      # Exception names are strings so registration never forces a constant to
+      # load (and a name absent from the host's Rails version is simply never
+      # matched — `rescue_from` safe_constantizes at rescue time).
+      HANDLERS = {
+        not_found: { exception: "ActiveRecord::RecordNotFound",
+                     handler: :handle_record_not_found, status: :not_found },
+        parameter_missing: { exception: "ActionController::ParameterMissing",
+                             handler: :handle_parameter_missing, status: :bad_request },
+        record_invalid: { exception: "ActiveRecord::RecordInvalid",
+                          handler: :handle_record_invalid, status: :unprocessable_entity },
+        validation_error: { exception: "ActiveModel::ValidationError",
+                            handler: :handle_validation_error, status: :unprocessable_entity },
+        record_not_saved: { exception: "ActiveRecord::RecordNotSaved",
+                            handler: :handle_record_not_saved, status: :unprocessable_entity },
+        record_not_destroyed: { exception: "ActiveRecord::RecordNotDestroyed",
+                                handler: :handle_record_not_destroyed, status: :unprocessable_entity },
+        stale_object: { exception: "ActiveRecord::StaleObjectError",
+                        handler: :handle_stale_object, status: :conflict },
+        record_not_unique: { exception: "ActiveRecord::RecordNotUnique",
+                             handler: :handle_record_not_unique, status: :conflict },
+        foreign_key_violation: { exception: "ActiveRecord::InvalidForeignKey",
+                                 handler: :handle_invalid_foreign_key, status: :conflict },
+        unpermitted_parameters: { exception: "ActionController::UnpermittedParameters",
+                                  handler: :handle_unpermitted_parameters, status: :bad_request },
+        invalid_authenticity_token: { exception: "ActionController::InvalidAuthenticityToken",
+                                      handler: :handle_invalid_authenticity_token, status: :unprocessable_entity },
+        bad_request: { exception: "ActionController::BadRequest",
+                       handler: :handle_bad_request, status: :bad_request },
+        parse_error: { exception: "ActionDispatch::Http::Parameters::ParseError",
+                       handler: :handle_parse_error, status: :bad_request },
+        unknown_format: { exception: "ActionController::UnknownFormat",
+                          handler: :handle_unknown_format, status: :not_acceptable }
+      }.freeze
+
       included do
-        rescue_from "ActiveRecord::RecordNotFound",       with: :handle_record_not_found
-        rescue_from "ActionController::ParameterMissing", with: :handle_parameter_missing
-        rescue_from "ActiveRecord::RecordInvalid",        with: :handle_record_invalid
+        # The keys still handled on this controller (trimmed by `handle_errors`).
+        class_attribute :error_handleable_keys, instance_accessor: false, default: HANDLERS.keys
+
+        HANDLERS.each_value do |spec|
+          rescue_from spec[:exception], with: spec[:handler]
+        end
+      end
+
+      class_methods do
+        # Trim the default map: `only:` keeps just those keys, `except:` drops
+        # them. Accepts a symbol or a list; calls accumulate. Removes only the
+        # concern's OWN registrations (matched on exception name AND handler
+        # method), so a `rescue_from` the host declared for the same exception
+        # is untouched — and nothing is ever re-added, so the host's later
+        # declarations keep their precedence. Returns the keys still active.
+        #
+        #   handle_errors except: :stale_object                 # let lock conflicts reach the error tracker
+        #   handle_errors only: %i[not_found parameter_missing record_invalid]
+        def handle_errors(only: nil, except: nil)
+          keep = error_handleable_selection(only: only, except: except)
+          dropped = HANDLERS.filter_map { |key, spec| [spec[:exception], spec[:handler]] unless keep.include?(key) }
+          self.rescue_handlers = rescue_handlers.reject { |entry| dropped.include?(entry) }
+          self.error_handleable_keys = error_handleable_keys & keep
+        end
+
+        # Validates only:/except: and returns the HANDLERS keys to keep.
+        def error_handleable_selection(only:, except:)
+          raise ArgumentError, "#{LABEL}: pass only: or except:, not both" if only && except
+
+          keys = error_handleable_known_keys(Array(only || except))
+          only ? keys : HANDLERS.keys - keys
+        end
+
+        def error_handleable_known_keys(list)
+          keys = list.map(&:to_sym)
+          unknown = keys - HANDLERS.keys
+          return keys if unknown.empty?
+
+          raise ArgumentError,
+                "#{LABEL}: unknown handler key(s) #{unknown.map(&:inspect).join(', ')} — " \
+                "valid keys: #{HANDLERS.keys.map(&:inspect).join(', ')}"
+        end
+        private :error_handleable_selection, :error_handleable_known_keys
       end
 
       def handle_record_not_found(_error)
         # Use a generic message: the raw RecordNotFound message leaks the model
         # class name and the queried attribute/value to API clients. Subclasses
         # can override this method to surface detail in non-production envs.
-        render_error_envelope(
-          message: "Resource not found",
-          code: "not_found",
-          status: :not_found
-        )
+        render_handled_error(:not_found, message: "Resource not found")
       end
 
       def handle_parameter_missing(error)
-        render_error_envelope(
-          message: "Parameter missing: #{error.param}",
-          code: "parameter_missing",
-          status: :bad_request
-        )
+        render_handled_error(:parameter_missing, message: "Parameter missing: #{error.param}")
       end
 
       def handle_record_invalid(error)
-        record = error.respond_to?(:record) ? error.record : nil
-        details = record.respond_to?(:errors) ? record.errors.full_messages : nil
+        render_handled_error(:record_invalid, message: error.message, errors: record_error_details(error))
+      end
 
-        render_error_envelope(
-          message: error.message,
-          code: "record_invalid",
-          status: :unprocessable_entity,
-          errors: details
-        )
+      # `validate!` on a plain ActiveModel::Model (form objects, service inputs).
+      def handle_validation_error(error)
+        model = error.respond_to?(:model) ? error.model : nil
+        render_handled_error(:validation_error, message: error.message, errors: error_messages_of(model))
+      end
+
+      # `save!` refused by a callback abort (`throw :abort`) — the record may or
+      # may not carry errors, so details are attached only when it does.
+      def handle_record_not_saved(error)
+        render_handled_error(:record_not_saved, message: error.message, errors: record_error_details(error))
+      end
+
+      def handle_record_not_destroyed(error)
+        render_handled_error(:record_not_destroyed, message: error.message, errors: record_error_details(error))
+      end
+
+      # Optimistic locking (`lock_version`) lost the race. The raw message names
+      # the model class; the client only needs to know to reload and retry.
+      def handle_stale_object(_error)
+        render_handled_error(:stale_object, message: "Resource was modified by another request; reload and retry")
+      end
+
+      # A unique index caught what a uniqueness validation raced past. The raw
+      # message is the adapter's SQL error — table and column included.
+      def handle_record_not_unique(_error)
+        render_handled_error(:record_not_unique, message: "Resource already exists")
+      end
+
+      def handle_invalid_foreign_key(_error)
+        render_handled_error(:foreign_key_violation, message: "Resource is referenced by other records")
+      end
+
+      # Only raised with `config.action_controller.action_on_unpermitted_parameters = :raise`.
+      def handle_unpermitted_parameters(error)
+        names = error.respond_to?(:params) ? Array(error.params).map(&:to_s) : []
+        render_handled_error(:unpermitted_parameters,
+                             message: "Unpermitted parameters: #{names.join(', ')}",
+                             errors: names.empty? ? nil : names)
+      end
+
+      def handle_invalid_authenticity_token(_error)
+        render_handled_error(:invalid_authenticity_token, message: "Invalid authenticity token")
+      end
+
+      # Malformed query string / form body (bad %-encoding, invalid UTF-8). The
+      # raw message echoes the offending input — never reflect it back.
+      def handle_bad_request(_error)
+        render_handled_error(:bad_request, message: "Bad request")
+      end
+
+      # Unparseable JSON/XML request body. The raw message carries the parser's
+      # excerpt of the body.
+      def handle_parse_error(_error)
+        render_handled_error(:parse_error, message: "Malformed request body")
+      end
+
+      # `respond_to` had no block for the requested format.
+      def handle_unknown_format(_error)
+        render_handled_error(:unknown_format, message: "Requested format is not supported")
       end
 
       private
 
+      # Renders the envelope for a HANDLERS key: code = key, status from the table.
+      def render_handled_error(key, message:, errors: nil)
+        render_error_envelope(message: message, code: key.to_s, status: HANDLERS.fetch(key)[:status], errors: errors)
+      end
+
+      # Kept for subclasses that call it from a handler override.
       def render_error_envelope(message:, code:, status:, errors: nil)
         ConcernsOnRails::Support::ErrorEnvelope.render(
           self, message: message, code: code, status: status, details: errors
         )
+      end
+
+      def record_error_details(error)
+        error_messages_of(error.respond_to?(:record) ? error.record : nil)
+      end
+
+      # `errors.full_messages` when the object has any, else nil so the
+      # envelope omits `details` rather than emitting an empty array.
+      def error_messages_of(object)
+        return nil unless object.respond_to?(:errors)
+
+        messages = object.errors.full_messages
+        messages.empty? ? nil : messages
       end
     end
   end

--- a/spec/concerns/controllers/error_handleable_spec.rb
+++ b/spec/concerns/controllers/error_handleable_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 require "active_support/rescuable"
-require "action_controller/metal/strong_parameters"
+require "action_controller"
+require "action_controller/metal/request_forgery_protection" # defines InvalidAuthenticityToken
+require "support/integration_harness"
 
 describe ConcernsOnRails::Controllers::ErrorHandleable do
   # The real ActionController already pulls in ActiveSupport::Rescuable, but
@@ -141,6 +143,245 @@ describe ConcernsOnRails::Controllers::ErrorHandleable do
         error: { message: "Resource not found", code: "not_found" }
       )
       expect(instance.rendered[:status]).to eq(:not_found)
+    end
+  end
+  describe "expanded exception map" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :error_items, force: true do |t|
+          t.string :name
+          t.integer :lock_version, default: 0, null: false
+        end
+      end
+
+      class ErrorItem < TestModel
+        validates :name, presence: true
+      end
+    end
+
+    after(:each) do
+      ActiveRecord::Base.connection.tables.each do |table|
+        next if table == "schema_migrations"
+
+        ActiveRecord::Base.connection.drop_table(table)
+      end
+      Object.send(:remove_const, :ErrorItem) if Object.const_defined?(:ErrorItem)
+    end
+
+    let(:invalid_item) { ErrorItem.new.tap(&:valid?) }
+
+    def rescue!(error)
+      expect(controller.rescue_with_handler(error)).to be_truthy
+      controller.rendered
+    end
+
+    it "registers every HANDLERS entry by default and exposes the active keys" do
+      registered = controller_class.rescue_handlers
+      described_class::HANDLERS.each_value do |spec|
+        expect(registered).to include([spec[:exception], spec[:handler]])
+      end
+      expect(controller_class.error_handleable_keys).to eq(described_class::HANDLERS.keys)
+    end
+
+    # One representative exception per key; every handler must render code ==
+    # key and the status the HANDLERS table advertises, and be public.
+    it "renders code == key and the table's status for every handler" do
+      samples = {
+        not_found: -> { ActiveRecord::RecordNotFound.new("x") },
+        parameter_missing: -> { ActionController::ParameterMissing.new(:user) },
+        record_invalid: -> { ActiveRecord::RecordInvalid.new(invalid_item) },
+        validation_error: -> { ActiveModel::ValidationError.new(invalid_item) },
+        record_not_saved: -> { ActiveRecord::RecordNotSaved.new("x", invalid_item) },
+        record_not_destroyed: -> { ActiveRecord::RecordNotDestroyed.new("x", invalid_item) },
+        stale_object: -> { ActiveRecord::StaleObjectError.new(invalid_item, "update") },
+        record_not_unique: -> { ActiveRecord::RecordNotUnique.new("x") },
+        foreign_key_violation: -> { ActiveRecord::InvalidForeignKey.new("x") },
+        unpermitted_parameters: -> { ActionController::UnpermittedParameters.new(%w[a]) },
+        invalid_authenticity_token: -> { ActionController::InvalidAuthenticityToken.new },
+        bad_request: -> { ActionController::BadRequest.new("x") },
+        parse_error: -> { ActionDispatch::Http::Parameters::ParseError.new("x") },
+        unknown_format: -> { ActionController::UnknownFormat.new }
+      }
+      expect(samples.keys).to match_array(described_class::HANDLERS.keys)
+
+      samples.each do |key, build|
+        spec = described_class::HANDLERS.fetch(key)
+        expect(controller_class.public_method_defined?(spec[:handler])).to be(true), "#{spec[:handler]} must be public"
+        fresh = controller_class.new
+        expect(fresh.rescue_with_handler(build.call)).to be_truthy, "no handler dispatched for #{key}"
+        expect(fresh.rendered[:status]).to eq(spec[:status]), "#{key}: status"
+        expect(fresh.rendered[:json][:error][:code]).to eq(key.to_s), "#{key}: code"
+      end
+    end
+
+    it "ActiveModel::ValidationError → 422 validation_error with the model's messages" do
+      form_class = Class.new do
+        include ActiveModel::Model
+
+        attr_accessor :email
+
+        validates :email, presence: true
+
+        def self.name
+          "SignupForm"
+        end
+      end
+      form = form_class.new.tap(&:valid?)
+      rendered = rescue!(ActiveModel::ValidationError.new(form))
+      expect(rendered[:status]).to eq(:unprocessable_entity)
+      expect(rendered[:json][:error]).to include(code: "validation_error", details: ["Email can't be blank"])
+      expect(rendered[:json][:error][:message]).to include("Email can't be blank")
+    end
+
+    it "ActiveRecord::RecordNotSaved → 422 record_not_saved, details only when the record has errors" do
+      rendered = rescue!(ActiveRecord::RecordNotSaved.new("Failed to save the record", invalid_item))
+      expect(rendered[:status]).to eq(:unprocessable_entity)
+      expect(rendered[:json][:error]).to eq(
+        message: "Failed to save the record", code: "record_not_saved", details: ["Name can't be blank"]
+      )
+
+      clean = ErrorItem.new(name: "ok")
+      rendered = rescue!(ActiveRecord::RecordNotSaved.new("Failed to save the record", clean))
+      expect(rendered[:json][:error]).to eq(message: "Failed to save the record", code: "record_not_saved")
+    end
+
+    it "ActiveRecord::RecordNotDestroyed → 422 record_not_destroyed" do
+      item = ErrorItem.create!(name: "keep")
+      item.errors.add(:base, "Cannot delete an item with open orders")
+      rendered = rescue!(ActiveRecord::RecordNotDestroyed.new("Failed to destroy the record", item))
+      expect(rendered[:status]).to eq(:unprocessable_entity)
+      expect(rendered[:json][:error]).to include(
+        code: "record_not_destroyed", details: ["Cannot delete an item with open orders"]
+      )
+    end
+
+    it "ActiveRecord::StaleObjectError → 409 stale_object with a generic message (no class name leak)" do
+      item = ErrorItem.create!(name: "v1")
+      rendered = rescue!(ActiveRecord::StaleObjectError.new(item, "update"))
+      expect(rendered[:status]).to eq(:conflict)
+      expect(rendered[:json][:error][:code]).to eq("stale_object")
+      expect(rendered[:json][:error][:message]).not_to include("ErrorItem")
+      expect(rendered[:json][:error]).not_to have_key(:details)
+    end
+
+    it "ActiveRecord::RecordNotUnique → 409 record_not_unique without the SQL" do
+      error = ActiveRecord::RecordNotUnique.new("SQLite3::ConstraintException: UNIQUE constraint failed: error_items.name")
+      rendered = rescue!(error)
+      expect(rendered[:status]).to eq(:conflict)
+      expect(rendered[:json][:error]).to eq(message: "Resource already exists", code: "record_not_unique")
+    end
+
+    it "ActiveRecord::InvalidForeignKey → 409 foreign_key_violation without the SQL" do
+      error = ActiveRecord::InvalidForeignKey.new("PG::ForeignKeyViolation: update or delete on table \"authors\" violates ...")
+      rendered = rescue!(error)
+      expect(rendered[:status]).to eq(:conflict)
+      expect(rendered[:json][:error]).to eq(message: "Resource is referenced by other records", code: "foreign_key_violation")
+    end
+
+    it "ActionController::UnpermittedParameters → 400 unpermitted_parameters listing the params" do
+      rendered = rescue!(ActionController::UnpermittedParameters.new(%w[admin role]))
+      expect(rendered[:status]).to eq(:bad_request)
+      expect(rendered[:json][:error]).to eq(
+        message: "Unpermitted parameters: admin, role", code: "unpermitted_parameters", details: %w[admin role]
+      )
+    end
+
+    it "ActionController::InvalidAuthenticityToken → 422 invalid_authenticity_token" do
+      rendered = rescue!(ActionController::InvalidAuthenticityToken.new)
+      expect(rendered[:status]).to eq(:unprocessable_entity)
+      expect(rendered[:json][:error]).to eq(message: "Invalid authenticity token", code: "invalid_authenticity_token")
+    end
+
+    it "ActionController::BadRequest → 400 bad_request without echoing the offending input" do
+      rendered = rescue!(ActionController::BadRequest.new("Invalid query parameters: invalid %-encoding (%zz<script>)"))
+      expect(rendered[:status]).to eq(:bad_request)
+      expect(rendered[:json][:error]).to eq(message: "Bad request", code: "bad_request")
+    end
+
+    it "ActionDispatch::Http::Parameters::ParseError → 400 parse_error without the parser message" do
+      rendered = rescue!(ActionDispatch::Http::Parameters::ParseError.new("unexpected token at '{\"a\":'"))
+      expect(rendered[:status]).to eq(:bad_request)
+      expect(rendered[:json][:error]).to eq(message: "Malformed request body", code: "parse_error")
+    end
+
+    it "ActionController::UnknownFormat → 406 unknown_format" do
+      rendered = rescue!(ActionController::UnknownFormat.new)
+      expect(rendered[:status]).to eq(:not_acceptable)
+      expect(rendered[:json][:error]).to eq(message: "Requested format is not supported", code: "unknown_format")
+    end
+
+    it "dispatches through the real ActionController stack (rescue_from + JSON body)" do
+      real = IntegrationHarness.build_controller do
+        include ConcernsOnRails::Controllers::ErrorHandleable
+
+        def show
+          raise ActiveRecord::StaleObjectError.new(nil, "update")
+        end
+      end
+      result = IntegrationHarness.dispatch(real, :show)
+      expect(result.status).to eq(409)
+      body = JSON.parse(result.body)
+      expect(body).to eq("success" => false, "error" => { "message" => body.dig("error", "message"), "code" => "stale_object" })
+    end
+  end
+
+  describe ".handle_errors" do
+    it "except: drops the named keys and nothing else" do
+      klass = Class.new(controller_class) { handle_errors except: :stale_object }
+      expect(klass.error_handleable_keys).to eq(described_class::HANDLERS.keys - [:stale_object])
+      expect(klass.rescue_handlers.map(&:first)).not_to include("ActiveRecord::StaleObjectError")
+      expect(klass.rescue_handlers.map(&:first)).to include("ActiveRecord::RecordNotFound", "ActiveRecord::RecordNotUnique")
+      expect(klass.new.rescue_with_handler(ActiveRecord::StaleObjectError.new(nil, "update"))).to be_nil
+    end
+
+    it "only: keeps just the named keys (the pre-expansion trio, say)" do
+      klass = Class.new(controller_class) { handle_errors only: %i[not_found parameter_missing record_invalid] }
+      expect(klass.error_handleable_keys).to eq(%i[not_found parameter_missing record_invalid])
+      registered = klass.rescue_handlers.map(&:first)
+      expect(registered).to include("ActiveRecord::RecordNotFound", "ActionController::ParameterMissing", "ActiveRecord::RecordInvalid")
+      expect(registered).not_to include("ActiveRecord::RecordNotUnique", "ActionController::UnknownFormat")
+    end
+
+    it "is cumulative and accepts a single symbol or a list" do
+      klass = Class.new(controller_class) do
+        handle_errors except: :stale_object
+        handle_errors except: %i[record_not_unique foreign_key_violation]
+      end
+      expect(klass.error_handleable_keys).to eq(
+        described_class::HANDLERS.keys - %i[stale_object record_not_unique foreign_key_violation]
+      )
+    end
+
+    it "leaves a rescue_from the host declared for the same exception untouched" do
+      klass = Class.new(controller_class) do
+        rescue_from "ActiveRecord::StaleObjectError", with: :my_stale_handler
+        handle_errors except: :stale_object
+
+        def my_stale_handler(_error)
+          render json: { mine: true }, status: :conflict
+        end
+      end
+      expect(klass.rescue_handlers).to include(["ActiveRecord::StaleObjectError", :my_stale_handler])
+      expect(klass.rescue_handlers).not_to include(["ActiveRecord::StaleObjectError", :handle_stale_object])
+      instance = klass.new
+      instance.rescue_with_handler(ActiveRecord::StaleObjectError.new(nil, "update"))
+      expect(instance.rendered[:json]).to eq(mine: true)
+    end
+
+    it "does not touch the parent class's registrations" do
+      Class.new(controller_class) { handle_errors except: :not_found }
+      expect(controller_class.error_handleable_keys).to include(:not_found)
+      expect(controller_class.rescue_handlers.map(&:first)).to include("ActiveRecord::RecordNotFound")
+    end
+
+    it "rejects unknown keys with the list of valid ones" do
+      expect { Class.new(controller_class) { handle_errors except: :nope } }
+        .to raise_error(ArgumentError, /unknown handler key.*:nope.*valid keys:.*:not_found/)
+    end
+
+    it "rejects only: and except: together" do
+      expect { Class.new(controller_class) { handle_errors only: :not_found, except: :stale_object } }
+        .to raise_error(ArgumentError, /not both/)
     end
   end
 end


### PR DESCRIPTION
## Summary

ErrorHandleable rescued three exceptions (`RecordNotFound`, `ParameterMissing`, `RecordInvalid`). Everything else a JSON API meets in practice — optimistic-lock conflicts, unique-index races, `validate!` on a form object, a callback-aborted `save!`, malformed JSON bodies, unpermitted params — still surfaced as a 500 or a Rails HTML error page. This PR expands the map to **14 handlers** and adds a `handle_errors only:/except:` macro to trim it.

| Key (= `code`) | Exception | Status | `details` |
|---|---|---|---|
| `not_found` | `ActiveRecord::RecordNotFound` | 404 | — |
| `parameter_missing` | `ActionController::ParameterMissing` | 400 | — |
| `record_invalid` | `ActiveRecord::RecordInvalid` | 422 | `errors.full_messages` |
| `validation_error` **new** | `ActiveModel::ValidationError` | 422 | `model.errors.full_messages` |
| `record_not_saved` **new** | `ActiveRecord::RecordNotSaved` | 422 | record errors, if any |
| `record_not_destroyed` **new** | `ActiveRecord::RecordNotDestroyed` | 422 | record errors, if any |
| `stale_object` **new** | `ActiveRecord::StaleObjectError` | 409 | — |
| `record_not_unique` **new** | `ActiveRecord::RecordNotUnique` | 409 | — |
| `foreign_key_violation` **new** | `ActiveRecord::InvalidForeignKey` | 409 | — |
| `unpermitted_parameters` **new** | `ActionController::UnpermittedParameters` | 400 | the parameter names |
| `invalid_authenticity_token` **new** | `ActionController::InvalidAuthenticityToken` | 422 | — |
| `bad_request` **new** | `ActionController::BadRequest` | 400 | — |
| `parse_error` **new** | `ActionDispatch::Http::Parameters::ParseError` | 400 | — |
| `unknown_format` **new** | `ActionController::UnknownFormat` | 406 | — |

**Design points**

- **Statuses follow Rails' own `rescue_responses`** wherever Rails has an opinion; the two DB-constraint races Rails leaves as 500s get the REST-conventional 409.
- **Generic messages for DB- and parser-level errors** (`"Resource already exists"`, `"Malformed request body"`, …): the raw messages carry SQL fragments, table/column names, model class names or the offending input. Override the public handler if a trusted environment wants detail.
- **`details` only when there is something to list** — `RecordNotSaved` after a `throw :abort` usually has no errors, so no empty `details: []`.
- **Table-driven**: `HANDLERS` (key → exception name, handler, status) drives registration; each handler remains a public override point and renders via `render_handled_error(key, message:, errors:)`.
- **`handle_errors only:/except:`** removes only the concern's own `[exception, handler]` pairs from `rescue_handlers`, so a host `rescue_from` for the same exception is untouched — and it never re-adds, so the host's later declarations keep precedence. Calls accumulate; unknown keys raise listing the valid ones; `error_handleable_keys` exposes what is active.

```ruby
class Api::BaseController < ApplicationController
  include ConcernsOnRails::Controllers::Respondable
  include ConcernsOnRails::Controllers::ErrorHandleable

  handle_errors except: :stale_object     # lock conflicts should page us, not become a quiet 409
end
```

**Behaviour change to be aware of:** apps that include the concern now get 11 more exceptions rescued. An app that relied on, say, `StaleObjectError` propagating to its error tracker should add `handle_errors except: :stale_object` (or `only:` the original trio). Exceptions are registered by name, so a class a given Rails version lacks is simply never matched.

## Docs

- `README.md` — full table, "Trimming the map" section, generic-message rationale, notes.
- `docs/concerns/error-handleable.md` — intro, use cases, Configuration (`handle_errors`, `error_handleable_keys`), full Methods table, new example, notes. Also corrected a pre-existing inaccuracy: the page claimed the 404 message is `error.message`; it has been the generic `"Resource not found"` since 1.22.

## Changelog entry (for `CHANGELOG.md` at release — kept out of this diff so parallel enhancement PRs don't conflict)

```
### Added
- **Controllers::ErrorHandleable**: the exception map grows from 3 to 14 —
  `ActiveModel::ValidationError`, `RecordNotSaved`, `RecordNotDestroyed` (422),
  `StaleObjectError`, `RecordNotUnique`, `InvalidForeignKey` (409),
  `UnpermittedParameters`, `BadRequest`, `ParseError` (400),
  `InvalidAuthenticityToken` (422) and `UnknownFormat` (406). Statuses follow
  Rails' `rescue_responses`; database/parser-level errors render generic
  messages so SQL, schema names and request input never leak. New
  `handle_errors only:/except:` macro trims the map without touching a host
  `rescue_from`; `error_handleable_keys` lists the active keys. Apps that relied
  on one of the new exceptions propagating should `handle_errors except:` it.
```

## Test plan

- [x] +21 examples: every new handler rendered and dispatched via `rescue_with_handler`; a table-driven check that each handler is public and renders `code == key` with the table's status; one dispatch through the real `ActionController` stack (409 JSON); six `handle_errors` cases (except/only/cumulative/host-handler-preserved/parent-untouched/argument errors). Existing 9 examples unchanged.
- [x] Full suite: 1278 examples, 0 failures (98.34%).
- [x] RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
