### PR TITLE
ColumnGuard: report every missing column in one error with one combined migration command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,8 +226,10 @@ and may be called multiple times, rather than the `<concern>_by` form.)
 ### Support modules (`lib/concerns_on_rails/support/`)
 
 `ColumnGuard` (schema validation; skips — returns false — when the schema is unreachable
-so models stay loadable during `db:create`/`assets:precompile`; missing-column errors
-append a `bin/rails generate migration` hint typed via the macro's `types:` argument), `ScalarParam` (untrusted
+so models stay loadable during `db:create`/`assets:precompile`; one call reports EVERY
+missing column in a single error, whose `bin/rails generate migration` hint — typed via the
+macro's `types:` argument — adds them all: `Add<Field>To<Table>` for one column,
+`Add<Concern>ColumnsTo<Table>` for several), `ScalarParam` (untrusted
 query-param coercion shared by the paginators/Filterable), `UniqueRetry` (bounded
 `RecordNotUnique` retry), `ErrorEnvelope` (the shared `render_error`-or-inline error
 renderer used by seven controller concerns), `FilterParameterRegistry` (live

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ across all 43 concerns — press <kbd>/</kbd> and type.
 - **Twenty-six model concerns + sixteen controller concerns**, all production-ready
 - **One include, one macro** — no boilerplate, no glue code
 - **Lean dependencies** — only `acts_as_list` (Sortable) and `friendly_id` (Sluggable), and both load **lazily**: an app that never includes those concerns never loads them. Depends on `activerecord`/`actionpack`/`activesupport`, not the full `rails` meta-gem; controller concerns have zero extra deps
-- **Schema-validated configuration** — every macro checks that the configured column exists and raises `ArgumentError` early — with a ready-to-paste `rails generate migration` hint when it doesn't
+- **Schema-validated configuration** — every macro checks that the configured columns exist and raises `ArgumentError` early — listing *every* missing column at once, with one ready-to-paste `rails generate migration` command that adds them all
 - **Composable** — concerns are independent; mix and match per model
 - **Tested like an app, not a snippet** — **1,160 RSpec examples** run against a real database on every CI build
 - **Documented twice** — everything in this README also lives as a per-concern page on the [docs site](https://vsn2015.github.io/concerns_on_rails), searchable and deep-linkable

--- a/lib/concerns_on_rails/models/anonymizable.rb
+++ b/lib/concerns_on_rails/models/anonymizable.rb
@@ -96,7 +96,7 @@ module ConcernsOnRails
           anonymizable_apply_options(stamp, clear_audit_trail)
 
           ensure_columns!(LABEL, fields)
-          ensure_columns!(LABEL, anonymizable_stamp) if anonymizable_stamp
+          ensure_columns!(LABEL, anonymizable_stamp, types: :datetime) if anonymizable_stamp
           self.anonymizable_rules = anonymizable_rules.merge(fields.to_h { |f| [f.to_sym, strategy] })
 
           anonymizable_define_scopes(prefix, suffix)

--- a/lib/concerns_on_rails/support/column_guard.rb
+++ b/lib/concerns_on_rails/support/column_guard.rb
@@ -39,29 +39,52 @@ module ConcernsOnRails
       end
 
       # Same contract, validated against another class (e.g. CounterCacheable
-      # checks the counter column on the *parent* model).
+      # checks the counter column on the *parent* model). Every missing column
+      # is reported in ONE error — a fresh model with five absent columns is one
+      # migration away, not five boot failures.
       def ensure_columns_on!(concern, klass, *fields, types: nil)
         return false unless schema_reachable?(klass)
 
-        fields.flatten.compact.each do |field|
-          next if klass.column_names.include?(field.to_s)
+        missing = fields.flatten.compact.map(&:to_sym).uniq.reject { |field| klass.column_names.include?(field.to_s) }
+        return true if missing.empty?
 
-          raise ArgumentError,
-                "#{concern}: '#{field}' does not exist in the database (table: #{klass.table_name})." \
-                "#{column_migration_hint(klass, field, types)}"
-        end
-        true
+        raise ArgumentError, missing_columns_message(concern, klass, missing, types)
+      end
+
+      # "Concern: 'a' does not exist in the database (table: t). Add it with: …"
+      # for one column; "'a', 'b' and 'c' do not exist … Add them with: …" for
+      # several. The singular wording is unchanged from earlier releases.
+      def missing_columns_message(concern, klass, missing, types)
+        quoted = missing.map { |field| "'#{field}'" }
+        subject = if quoted.size == 1
+                    "#{quoted.first} does not exist"
+                  else
+                    "#{quoted[0..-2].join(', ')} and #{quoted.last} do not exist"
+                  end
+        "#{concern}: #{subject} in the database (table: #{klass.table_name})." \
+          "#{column_migration_hint(klass, missing, types, concern: concern)}"
       end
 
       # " Add it with: bin/rails generate migration AddDeletedAtToArticles
       # deleted_at:datetime" — every missing-column failure becomes a
-      # copy-paste fix. Without a known type the column name goes out bare
-      # (the generator defaults to string).
-      def column_migration_hint(klass, field, types)
-        type = types.is_a?(Hash) ? types[field.to_sym] : types
-        column = [field, type].compact.join(":")
-        " Add it with: bin/rails generate migration " \
-          "Add#{field.to_s.camelize}To#{klass.table_name.to_s.camelize} #{column}"
+      # copy-paste fix. Several columns get ONE command, named after the
+      # concern (AddAddressableColumnsToUsers street:string city:string) since
+      # AddStreetAndCityAndZipAndCountryTo… stops being readable. Without a
+      # known type the column name goes out bare (the generator defaults to
+      # string). Accepts a single field or a list.
+      def column_migration_hint(klass, fields, types, concern: nil)
+        fields = Array(fields)
+        columns = fields.map do |field|
+          type = types.is_a?(Hash) ? types[field.to_sym] : types
+          [field, type].compact.join(":")
+        end
+        table = klass.table_name.to_s.camelize
+        if fields.size == 1
+          " Add it with: bin/rails generate migration Add#{fields.first.to_s.camelize}To#{table} #{columns.first}"
+        else
+          " Add them with: bin/rails generate migration " \
+            "Add#{concern.to_s.demodulize}ColumnsTo#{table} #{columns.join(' ')}"
+        end
       end
 
       # True when the class's table can actually be inspected. Connection

--- a/spec/concerns/models/anonymizable_spec.rb
+++ b/spec/concerns/models/anonymizable_spec.rb
@@ -240,6 +240,18 @@ RSpec.describe ConcernsOnRails::Models::Anonymizable do
     it "raises on a missing column" do
       expect { model_class { anonymizable :nope, with: :redact } }.to raise_error(ArgumentError, /does not exist/)
     end
+
+    it "reports every missing field at once with one combined migration command" do
+      expect { model_class { anonymizable :nope, :nada, with: :redact } }.to raise_error(
+        ArgumentError, /\x27nope\x27 and \x27nada\x27 do not exist.*AddAnonymizableColumnsToAnonUsers nope nada\z/
+      )
+    end
+
+    it "types the stamp column in the migration hint" do
+      expect { model_class { anonymizable :name, with: :redact, stamp: :erased_at } }.to raise_error(
+        ArgumentError, /AddErasedAtToAnonUsers erased_at:datetime\z/
+      )
+    end
   end
 
   describe "Auditable interaction" do

--- a/spec/concerns/models/schedulable_spec.rb
+++ b/spec/concerns/models/schedulable_spec.rb
@@ -190,7 +190,7 @@ describe ConcernsOnRails::Schedulable do
 
           schedulable_by
         end
-      end.to raise_error(ArgumentError, /does not exist/)
+      end.to raise_error(ArgumentError, /'starts_at' and 'ends_at' do not exist/)
     end
 
     it "raises ArgumentError when both starts_at and ends_at are nil" do

--- a/spec/concerns/support/column_guard_spec.rb
+++ b/spec/concerns/support/column_guard_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe ConcernsOnRails::Support::ColumnGuard do
     it "supports per-field types (and generator modifiers) via a types: Hash" do
       expect do
         klass.ensure_columns!("Spec", :nope_at, :token, types: { nope_at: :datetime, token: "string:uniq" })
-      end.to raise_error(ArgumentError, /AddNopeAtToColumnGuardRows nope_at:datetime/)
+      end.to raise_error(ArgumentError, /AddSpecColumnsToColumnGuardRows nope_at:datetime token:string:uniq\z/)
     end
 
     it "emits a bare column name when no type is known (generator defaults to string)" do
@@ -71,6 +71,53 @@ RSpec.describe ConcernsOnRails::Support::ColumnGuard do
         ArgumentError,
         %r{Add it with: bin/rails generate migration AddMysteryToColumnGuardRows mystery\z}
       )
+    end
+  end
+  # One ensure_columns! call used to raise on the FIRST missing column, so a
+  # fresh model with five absent columns meant five boot failures. Now every
+  # missing column is reported at once, with ONE combined migration command.
+  describe "reporting every missing column at once" do
+    it "lists all missing columns in one error, grammatically, with a single combined migration command" do
+      expect do
+        klass.ensure_columns!("ConcernsOnRails::Models::Addressable", :street, :name, :city, :zip,
+                              types: { street: :string, city: :string, zip: "string:index" })
+      end.to raise_error(ArgumentError) { |error|
+        expect(error.message).to eq(
+          "ConcernsOnRails::Models::Addressable: 'street', 'city' and 'zip' do not exist in the database " \
+          "(table: column_guard_rows). Add them with: bin/rails generate migration " \
+          "AddAddressableColumnsToColumnGuardRows street:string city:string zip:string:index"
+        )
+      }
+    end
+
+    it "keeps the single-column wording and generator name unchanged" do
+      expect { klass.ensure_columns!("Spec", :name, :nope, types: :datetime) }.to raise_error(
+        ArgumentError,
+        "Spec: 'nope' does not exist in the database (table: column_guard_rows). " \
+        "Add it with: bin/rails generate migration AddNopeToColumnGuardRows nope:datetime"
+      )
+    end
+
+    it "applies a scalar types: to every missing column and dedupes repeated fields" do
+      expect { klass.ensure_columns!("Spec", :a_at, :b_at, :a_at, types: :datetime) }.to raise_error(
+        ArgumentError,
+        /'a_at' and 'b_at' do not exist.*AddSpecColumnsToColumnGuardRows a_at:datetime b_at:datetime\z/
+      )
+    end
+
+    it "names the combined migration after the concern (demodulized), bare columns when no type is known" do
+      expect { klass.ensure_columns!("ConcernsOnRails::Models::Lockable", :x, :y) }
+        .to raise_error(ArgumentError, %r{Add them with: bin/rails generate migration AddLockableColumnsToColumnGuardRows x y\z})
+    end
+
+    it "works through ensure_columns_on! against another class" do
+      expect { klass.ensure_columns_on!("Spec", klass, :p, :q) }
+        .to raise_error(ArgumentError, /'p' and 'q' do not exist/)
+    end
+
+    it "column_migration_hint still accepts a single field (helper contract)" do
+      expect(klass.column_migration_hint(klass, :deleted_at, :datetime))
+        .to eq(" Add it with: bin/rails generate migration AddDeletedAtToColumnGuardRows deleted_at:datetime")
     end
   end
 end


### PR DESCRIPTION
## Summary

`Support::ColumnGuard#ensure_columns_on!` raised on the **first** missing column. A fresh model whose macro names several absent columns — `addressable_by`, `anonymizable :a, :b, :c`, `lockable_by`, `schedulable_by`, `tokenizable_by` — therefore meant one boot failure per column, each fixed by one migration, then boot again.

Now every missing column in a call is collected and reported in **one** `ArgumentError` with **one** ready-to-paste generator command:

```
ConcernsOnRails::Models::Addressable: 'street', 'city' and 'zip' do not exist in the database (table: users).
Add them with: bin/rails generate migration AddAddressableColumnsToUsers street:string city:string zip:string
```

- **Single-column wording and generator name are unchanged** (`'deleted_at' does not exist … AddDeletedAtToArticles deleted_at:datetime`), so anything matching `/does not exist/` on a one-column failure still matches.
- **Several columns** name the migration after the concern (`Add<Concern>ColumnsTo<Table>`) — `AddStreetAndCityAndZipAndCountryTo…` stops being readable, and Rails' generator only needs the `Add…To<table>` shape to emit `add_column`s.
- Repeated fields are deduped; a scalar `types:` applies to each column, a Hash per field; unknown types go out bare as before.
- `column_migration_hint(klass, field_or_fields, types, concern: nil)` keeps working for a single field.
- **Anonymizable**: the stamp check gains `types: :datetime` — the one `ensure_columns!` call for a concern-owned column that omitted its type, so its hint read `anonymized_at` bare.

Cross-**macro** aggregation (several concerns on one model each missing columns) is deliberately not attempted here — that needs a collect mode and belongs to the adoption-tooling design (`Registry` + `doctor`).

## Docs

- `README.md` — the "Schema-validated configuration" feature bullet.
- `CLAUDE.md` — the `ColumnGuard` support-module note.
(No per-concern docs page documents the helper itself.)

## Changelog entry (for `CHANGELOG.md` at release — kept out of this diff so parallel enhancement PRs don't conflict)

```
### Changed
- **Support::ColumnGuard**: a macro that finds several missing columns now
  reports them all in one `ArgumentError` — `'street', 'city' and 'zip' do not
  exist …` — with a single combined migration command
  (`bin/rails generate migration AddAddressableColumnsToUsers street:string
  city:string zip:string`) instead of failing boot once per column. Single-
  column wording and generator name are unchanged.
### Fixed
- **Models::Anonymizable**: the stamp column's migration hint now carries its
  type (`anonymized_at:datetime`).
```

## Test plan

- [x] +6 ColumnGuard examples: combined message + command (exact string), singular unchanged (exact string), scalar `types:` + dedupe, concern-named migration with bare columns, `ensure_columns_on!` path, `column_migration_hint` single-field contract. +2 Anonymizable examples (combined fields, typed stamp hint).
- [x] Two existing expectations that encoded the first-column-only shape updated: ColumnGuard "per-field types" (now asserts the combined command) and Schedulable "missing starts_at" (both columns missing → `'starts_at' and 'ends_at' do not exist`).
- [x] Full suite: 1265 examples, 0 failures (98.32%).
- [x] RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
