### PR TITLE
Throttleable: if:/unless: skip conditions, rate_limited instrumentation, tightest-rule headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1796,12 +1796,15 @@ class Api::BaseController < ApplicationController
   throttle_by limit: 100, period: 1.minute                          # by IP (default)
   throttle_by limit: 5,   period: 1.minute, only: :create,
               by: -> { current_user&.id || request.remote_ip }
+  throttle_by limit: 1000, period: 1.hour, unless: :staff?          # skip conditions
 end
 ```
 
 Fixed-window counter: the key embeds a floored time bucket (`epoch / period`) so each window starts clean and `X-RateLimit-Reset` is exact.
 
-**Options**: `limit:` (positive integer), `period:` (a `Duration` or seconds), `by:` (discriminator lambda, default per-IP), `only:` / `except:` (mutually exclusive action scoping), `name:` (disambiguates the counter key).
+**Options**: `limit:` (positive integer), `period:` (a `Duration` or seconds), `by:` (discriminator lambda, default per-IP), `only:` / `except:` (mutually exclusive action scoping), `if:` / `unless:` (a Symbol naming a controller method or a callable, evaluated per request — staff accounts, internal IPs, feature flags; both must pass when both given), `name:` (disambiguates the counter key).
+
+When several rules apply to one request the `X-RateLimit-*` headers describe the **tightest** one (fewest requests remaining), so a client sees the budget that runs out first. A throttled request instruments `rate_limited.concerns_on_rails` (payload: `rule`, `discriminator`, `count`, `limit`, `period`, `reset_at`, `retry_after`, `controller`, `action`) via the public `on_rate_limited(rule, result)` hook before the 429 is rendered — subscribe to alert on abusive clients, or override it (call `super` to keep the event).
 
 **Notes**
 - The store MUST support **atomic increment-with-expiry** (`Rails.cache` with `#increment`, or Redis) — a non-atomic store under-counts under concurrency.

--- a/docs/concerns/throttleable.md
+++ b/docs/concerns/throttleable.md
@@ -44,6 +44,8 @@ end
 | `by:` | callable (`Proc`, `lambda`) | `-> { request.remote_ip }` | Discriminator evaluated with `instance_exec` on the controller instance, so `request`, `params`, and helpers such as `current_user` are all in scope. Must respond to `#call`; a plain string or symbol raises `ArgumentError`. |
 | `only:` | `Symbol` or `Array<Symbol>` | `nil` (all actions) | Restricts the rule to the listed action names. Mutually exclusive with `except:`; passing both raises `ArgumentError`. |
 | `except:` | `Symbol` or `Array<Symbol>` | `nil` (no exclusions) | Skips the rule for the listed action names. Mutually exclusive with `only:`. |
+| `if:` | `Symbol` or callable | `nil` (always applies) | Per-request skip condition. A Symbol names a controller method; a callable is `instance_exec`'d on the controller (so `request`, `params`, `current_user` are in scope). The rule applies only when it returns truthy — no counter increment, no headers otherwise. Anything else raises `ArgumentError`. |
+| `unless:` | `Symbol` or callable | `nil` (always applies) | Inverse of `if:` — the rule is skipped when it returns truthy. May be combined with `if:`; both must pass. |
 | `name:` | `Symbol` or `String` | `"rule0"`, `"rule1"`, … | Embedded in the cache key to disambiguate counters when multiple rules share the same discriminator value. Defaults to `"rule#{index}"` based on declaration order. |
 
 `throttleable_store` is a class-level attribute (not a macro argument). It must be assigned before the first throttled request and must support atomic increment-with-expiry — specifically `store.increment(key, 1, expires_in: seconds)`. `Rails.cache` backed by Memcache or Redis satisfies this contract. A store that returns `nil` from `#increment` for a missing key is handled: the concern falls back to `store.write(key, 1, expires_in: period)` and treats the count as `1`.
@@ -63,16 +65,46 @@ end
 
 | Signature | Description |
 |-----------|-------------|
-| `enforce_throttles` | `before_action` entry point. Iterates every applicable rule, increments its counter, sets rate-limit headers, and renders a 429 response if the limit is exceeded. Public so subclasses can call or override it. |
+| `enforce_throttles` | `before_action` entry point. Iterates every applicable rule (action scope **and** `if:`/`unless:`), increments its counter, and renders a 429 if a limit is exceeded — emitting that rule's headers and `on_rate_limited`. When every rule passes, the `X-RateLimit-*` headers describe the **tightest** rule (fewest remaining). Public so subclasses can call or override it. |
+| `on_rate_limited(rule, result)` | Public override point + instrumentation seam, run once per throttled request before the body is rendered. Default: `ActiveSupport::Notifications.instrument("rate_limited.concerns_on_rails", controller:, action:, rule:, discriminator:, count:, limit:, period:, reset_at:, retry_after:)`. Override to alert or block; call `super` to keep the event. |
 | `throttled_response(rule, result)` | Renders the 429 body. Public override point. By default renders `{ success: false, error: { message: "...", code: "rate_limited" } }` with `status: :too_many_requests`. If `Respondable` is also included the call is delegated to `render_error`. Override this method to customize the body format. |
 
 ### Class methods
 
 | Signature | Description |
 |-----------|-------------|
-| `throttle_by(limit:, period:, by: nil, only: nil, except: nil, name: nil)` | Declares a rate-limit rule and appends it to `throttleable_rules`. Raises `ArgumentError` immediately if any argument is invalid. |
+| `throttle_by(limit:, period:, by: nil, only: nil, except: nil, if: nil, unless: nil, name: nil)` | Declares a rate-limit rule and appends it to `throttleable_rules`. Raises `ArgumentError` immediately if any argument is invalid. |
 
 ## Examples
+
+**Skip conditions and alerting on throttled clients**
+
+```ruby
+class Api::BaseController < ApplicationController
+  include ConcernsOnRails::Controllers::Throttleable
+  self.throttleable_store = Rails.cache
+
+  throttle_by limit: 60,  period: 1.minute, unless: :staff?                      # staff are never throttled
+  throttle_by limit: 5,   period: 1.minute, only: :create,
+              by: -> { current_user&.id || request.remote_ip },
+              if: -> { Flipper.enabled?(:strict_create_limits) }                 # feature-flagged rule
+
+  private
+
+  def staff?
+    current_user&.staff?
+  end
+end
+
+# config/initializers/throttling.rb
+ActiveSupport::Notifications.subscribe("rate_limited.concerns_on_rails") do |event|
+  p = event.payload
+  Rails.logger.warn("rate limited #{p[:discriminator]} on #{p[:controller]}##{p[:action]} (#{p[:rule]}: #{p[:count]}/#{p[:limit]})")
+end
+```
+
+A request that trips the 5-per-minute `create` rule while the 60-per-minute rule still has room gets `X-RateLimit-Limit: 5`, `X-RateLimit-Remaining: 0` and `Retry-After`; a request that passes both gets the headers of whichever rule has fewer requests left.
+
 
 **Global IP-based limit on an API base controller:**
 
@@ -131,7 +163,10 @@ end
 
 - **Action name matching is string-based.** `only: :create` is stored as `["create"]` and compared against `action_name.to_s`. Symbols and strings in the array are both accepted at declaration time.
 
-- **First-exceeding rule wins.** Rules are evaluated in declaration order. The first rule whose counter exceeds its limit renders the 429 body and returns immediately — subsequent rules are not evaluated for that request.
+- **First-exceeding rule wins.** Rules are evaluated in declaration order. The first rule whose counter exceeds its limit emits its headers, runs `on_rate_limited`, renders the 429 body and returns immediately — subsequent rules are not evaluated (or incremented) for that request.
+- **Headers describe the tightest passing rule.** When several rules apply and all pass, the `X-RateLimit-*` headers come from the rule with the fewest requests remaining (`limit - count`), not from the last one declared — the client sees the budget that will run out first.
+- **`if:`/`unless:` are evaluated per request, before the counter.** A skipped rule increments nothing and emits nothing, exactly like one skipped by `only:`/`except:`. Conditions run on the controller instance (`send` for a Symbol, `instance_exec` for a callable), so a raising condition propagates like any before_action error.
+- **Instrumentation fires only on a 429.** `rate_limited.concerns_on_rails` is emitted once per throttled request from `enforce_throttles`, independently of `throttled_response` — overriding the body keeps the event; override `on_rate_limited` (with or without `super`) to change or drop it.
 
 - **`X-RateLimit-Remaining` floors at zero.** Once a counter surpasses the limit the header reads `"0"`, never a negative value. `Retry-After` is only set on responses that exceed the limit.
 

--- a/lib/concerns_on_rails/controllers/throttleable.rb
+++ b/lib/concerns_on_rails/controllers/throttleable.rb
@@ -16,7 +16,13 @@ module ConcernsOnRails
     #     throttle_by limit: 100, period: 1.minute                          # by IP (default)
     #     throttle_by limit: 5,   period: 1.minute, only: :create,
     #                 by: -> { current_user&.id || request.remote_ip }
+    #     throttle_by limit: 1000, period: 1.hour, unless: :staff?          # skip conditions
     #   end
+    #
+    # When several rules apply to one request the X-RateLimit-* headers
+    # describe the TIGHTEST one (fewest requests remaining). A throttled
+    # request instruments "rate_limited.concerns_on_rails" (see
+    # `on_rate_limited`, the override point) before the 429 is rendered.
     #
     # Fixed-window counter: the key embeds a floored time bucket
     # (`epoch / period`) so each window starts clean and `X-RateLimit-Reset` is
@@ -42,10 +48,18 @@ module ConcernsOnRails
       module ClassMethods
         # Declare a rate-limit rule. `limit` requests per `period` (a Duration or
         # seconds), bucketed by `by:` (a callable, default per-IP). `only:`/
-        # `except:` scope it to a subset of actions (mutually exclusive). `name:`
-        # disambiguates the counter key when several rules share a discriminator.
-        def throttle_by(limit:, period:, by: nil, only: nil, except: nil, name: nil)
-          validate_throttle!(limit: limit, period: period, by: by, only: only, except: except)
+        # `except:` scope it to a subset of actions (mutually exclusive). `if:`/
+        # `unless:` (a Symbol naming a controller method, or a callable
+        # instance_exec'd on the controller) skip the rule per request — staff
+        # accounts, internal IPs, feature flags; both may be given, and both must
+        # pass. `name:` disambiguates the counter key when several rules share a
+        # discriminator.
+        def throttle_by(limit:, period:, by: nil, only: nil, except: nil, name: nil, if: nil, unless: nil)
+          # `if`/`unless` are keywords, so the parameters are read via binding.
+          if_condition = binding.local_variable_get(:if)
+          unless_condition = binding.local_variable_get(:unless)
+          validate_throttle!(limit: limit, period: period, by: by, only: only, except: except,
+                             if_condition: if_condition, unless_condition: unless_condition)
 
           rule = {
             limit: limit,
@@ -53,6 +67,8 @@ module ConcernsOnRails
             by: by || DEFAULT_DISCRIMINATOR,
             only: only && Array(only).map(&:to_s),
             except: except && Array(except).map(&:to_s),
+            if: if_condition,
+            unless: unless_condition,
             name: (name || "rule#{throttleable_rules.size}").to_s
           }
           self.throttleable_rules = throttleable_rules + [rule]
@@ -60,12 +76,21 @@ module ConcernsOnRails
 
         private
 
-        def validate_throttle!(limit:, period:, by:, only:, except:)
+        def validate_throttle!(limit:, period:, by:, only:, except:, if_condition:, unless_condition:)
           prefix = "ConcernsOnRails::Controllers::Throttleable"
           raise ArgumentError, "#{prefix}: :limit must be a positive integer" unless positive_integer?(limit)
           raise ArgumentError, "#{prefix}: :period must be a positive duration" unless period.to_i.positive?
           raise ArgumentError, "#{prefix}: :by must be callable" unless callable_or_nil?(by)
           raise ArgumentError, "#{prefix}: pass either :only or :except, not both" if only && except
+
+          validate_throttle_condition!(prefix, :if, if_condition)
+          validate_throttle_condition!(prefix, :unless, unless_condition)
+        end
+
+        def validate_throttle_condition!(prefix, option, value)
+          return if value.nil? || value.is_a?(Symbol) || value.respond_to?(:call)
+
+          raise ArgumentError, "#{prefix}: :#{option} must be a Symbol or callable"
         end
 
         def positive_integer?(value)
@@ -78,17 +103,40 @@ module ConcernsOnRails
       end
 
       # Public so subclasses can override. Applies each in-scope rule; the first
-      # rule that exceeds its limit halts the request with a 429.
+      # rule that exceeds its limit emits its headers, instruments the event and
+      # halts the request with a 429. When every rule passes, the headers
+      # describe the tightest one (fewest remaining).
       def enforce_throttles
+        applied = []
         self.class.throttleable_rules.each do |rule|
           next unless throttle_rule_applies?(rule)
 
           result = register_throttle_hit(rule)
-          emit_throttle_headers(rule, result)
+          applied << [rule, result]
+          next unless result[:count] > rule[:limit]
 
-          return throttled_response(rule, result) if result[:count] > rule[:limit]
+          emit_throttle_headers(rule, result)
+          on_rate_limited(rule, result)
+          return throttled_response(rule, result)
         end
+        emit_tightest_throttle_headers(applied)
         nil
+      end
+
+      # Public override point + instrumentation seam, run once per throttled
+      # request before the 429 body is rendered. Default: emit
+      # "rate_limited.concerns_on_rails" with the rule name, discriminator,
+      # count/limit/period, reset_at/retry_after and controller/action — the
+      # hook for alerting on abusive clients or logging. Call super to keep the
+      # event when overriding.
+      def on_rate_limited(rule, result)
+        ActiveSupport::Notifications.instrument(
+          "rate_limited.concerns_on_rails",
+          controller: throttle_controller_name, action: throttle_action_name,
+          rule: rule[:name], discriminator: result[:discriminator],
+          count: result[:count], limit: rule[:limit], period: rule[:period],
+          reset_at: result[:reset_at], retry_after: result[:retry_after]
+        )
       end
 
       # Public override point for the 429 body.
@@ -104,6 +152,10 @@ module ConcernsOnRails
       private
 
       def throttle_rule_applies?(rule)
+        throttle_action_in_scope?(rule) && throttle_conditions_pass?(rule)
+      end
+
+      def throttle_action_in_scope?(rule)
         action = throttle_action_name
         return rule[:only].include?(action) if rule[:only]
         return !rule[:except].include?(action) if rule[:except]
@@ -111,19 +163,42 @@ module ConcernsOnRails
         true
       end
 
+      # if: must be truthy and unless: falsy; a Symbol names a controller
+      # method, a callable is instance_exec'd (so `request`/`current_user` work).
+      def throttle_conditions_pass?(rule)
+        return false if rule[:if] && !throttle_evaluate_condition(rule[:if])
+        return false if rule[:unless] && throttle_evaluate_condition(rule[:unless])
+
+        true
+      end
+
+      def throttle_evaluate_condition(condition)
+        condition.is_a?(Symbol) ? send(condition) : instance_exec(&condition)
+      end
+
       def register_throttle_hit(rule)
         store = throttle_store!
         now = Time.now.to_i
         window = now / rule[:period]
         reset_at = (window + 1) * rule[:period]
-        key = "throttleable:#{rule[:name]}:#{throttle_discriminator(rule)}:#{window}"
+        discriminator = throttle_discriminator(rule)
+        key = "throttleable:#{rule[:name]}:#{discriminator}:#{window}"
 
         # Atomic increment-with-expiry. Some stores return nil on the first
         # increment of a missing key — seed it to 1 in that case.
         count = store.increment(key, 1, expires_in: rule[:period])
         count ||= seed_throttle_key(store, key, rule[:period])
 
-        { count: count.to_i, reset_at: reset_at, retry_after: [reset_at - now, 0].max }
+        { count: count.to_i, reset_at: reset_at, retry_after: [reset_at - now, 0].max, discriminator: discriminator }
+      end
+
+      # Several rules, one set of headers: the client should see the budget
+      # that will run out first, not whichever rule happened to be declared last.
+      def emit_tightest_throttle_headers(applied)
+        return if applied.empty?
+
+        rule, result = applied.min_by { |candidate, outcome| candidate[:limit] - outcome[:count] }
+        emit_throttle_headers(rule, result)
       end
 
       # Seed with unless_exist so two concurrent first hits can't both write 1
@@ -175,6 +250,10 @@ module ConcernsOnRails
 
       def throttle_action_name
         respond_to?(:action_name) ? action_name.to_s : nil
+      end
+
+      def throttle_controller_name
+        self.class.respond_to?(:controller_path) ? self.class.controller_path : self.class.name
       end
     end
   end

--- a/spec/concerns/controllers/throttleable_spec.rb
+++ b/spec/concerns/controllers/throttleable_spec.rb
@@ -146,4 +146,155 @@ describe ConcernsOnRails::Controllers::Throttleable do
       end.to raise_error(ArgumentError, /:only or :except/)
     end
   end
+  describe "conditional rules (if: / unless:)" do
+    it "skips a rule whose if: callable is falsy — no counter, no headers" do
+      c = controller(store: store) { throttle_by limit: 1, period: 60, if: -> { params[:staff] != "1" } }
+      c.params[:staff] = "1"
+      c.enforce_throttles
+      c.enforce_throttles
+
+      expect(c.rendered).to be_nil
+      expect(c.response.headers["X-RateLimit-Limit"]).to be_nil
+    end
+
+    it "applies a rule whose if: callable is truthy" do
+      klass = throttled_class(store) { throttle_by limit: 1, period: 60, if: -> { params[:staff] != "1" } }
+      travel_to Time.utc(2026, 1, 1, 12, 0, 0) do
+        first = instance(klass)
+        second = instance(klass)
+        [first, second].each(&:enforce_throttles)
+        expect(second.rendered[:status]).to eq(:too_many_requests)
+      end
+    end
+
+    it "accepts a Symbol naming a controller method for if: and unless:" do
+      klass = throttled_class(store) do
+        throttle_by limit: 1, period: 60, unless: :internal_client?, name: "public"
+
+        def internal_client?
+          request.remote_ip.start_with?("10.")
+        end
+      end
+      travel_to Time.utc(2026, 1, 1, 12, 0, 0) do
+        internal = [instance(klass, remote_ip: "10.0.0.5"), instance(klass, remote_ip: "10.0.0.5")]
+        internal.each(&:enforce_throttles)
+        expect(internal.map(&:rendered)).to eq([nil, nil])
+
+        external = [instance(klass, remote_ip: "8.8.8.8"), instance(klass, remote_ip: "8.8.8.8")]
+        external.each(&:enforce_throttles)
+        expect(external.last.rendered[:status]).to eq(:too_many_requests)
+      end
+    end
+
+    it "requires BOTH conditions to pass when if: and unless: are given together" do
+      c = controller(store: store) do
+        throttle_by limit: 1, period: 60, if: -> { true }, unless: -> { true }
+      end
+      c.enforce_throttles
+      expect(c.response.headers["X-RateLimit-Limit"]).to be_nil
+    end
+
+    it "composes with only:/except:" do
+      c = controller(store: store, action: "index") { throttle_by limit: 1, period: 60, only: :index, if: -> { false } }
+      c.enforce_throttles
+      expect(c.response.headers["X-RateLimit-Limit"]).to be_nil
+    end
+
+    it "rejects a non-callable, non-Symbol if:/unless:" do
+      expect { throttled_class(store) { throttle_by limit: 1, period: 60, if: "nope" } }
+        .to raise_error(ArgumentError, /:if must be a Symbol or callable/)
+      expect { throttled_class(store) { throttle_by limit: 1, period: 60, unless: 42 } }
+        .to raise_error(ArgumentError, /:unless must be a Symbol or callable/)
+    end
+  end
+
+  describe "instrumentation" do
+    def capture_events
+      events = []
+      subscriber = ActiveSupport::Notifications.subscribe("rate_limited.concerns_on_rails") do |*args|
+        events << ActiveSupport::Notifications::Event.new(*args)
+      end
+      yield
+      events
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+    end
+
+    it "emits rate_limited.concerns_on_rails ONLY when a request is throttled, with the rule details" do
+      klass = throttled_class(store) { throttle_by limit: 1, period: 60, name: "login" }
+
+      travel_to Time.utc(2026, 1, 1, 12, 0, 0) do
+        events = capture_events do
+          instance(klass, remote_ip: "5.5.5.5", action: "create").enforce_throttles
+          instance(klass, remote_ip: "5.5.5.5", action: "create").enforce_throttles
+        end
+
+        expect(events.size).to eq(1)
+        payload = events.first.payload
+        expect(payload).to include(
+          rule: "login", discriminator: "5.5.5.5", count: 2, limit: 1, period: 60, action: "create"
+        )
+        expect(payload[:retry_after]).to be_between(1, 60)
+        expect(payload[:reset_at]).to eq(Time.utc(2026, 1, 1, 12, 1, 0).to_i)
+        expect(payload).to have_key(:controller)
+      end
+    end
+
+    it "still emits when throttled_response is overridden (the event lives in enforce_throttles)" do
+      klass = throttled_class(store) do
+        throttle_by limit: 1, period: 60
+
+        def throttled_response(_rule, _result)
+          render json: { custom: true }, status: :too_many_requests
+        end
+      end
+      events = capture_events do
+        2.times { instance(klass, remote_ip: "6.6.6.6").enforce_throttles }
+      end
+      expect(events.size).to eq(1)
+    end
+  end
+
+  describe "headers with several applicable rules" do
+    it "reflect the tightest rule (fewest remaining), not the last declared" do
+      c = controller(store: store) do
+        throttle_by limit: 3,  period: 60, name: "burst"
+        throttle_by limit: 10, period: 60, name: "sustained"
+      end
+      c.enforce_throttles
+
+      expect(c.response.headers["X-RateLimit-Limit"]).to eq("3")
+      expect(c.response.headers["X-RateLimit-Remaining"]).to eq("2")
+    end
+
+    it "switch to whichever rule is tighter as counters diverge" do
+      klass = throttled_class(store) do
+        throttle_by limit: 100, period: 60, name: "per_ip"
+        throttle_by limit: 2, period: 3600, name: "per_hour"
+      end
+      travel_to Time.utc(2026, 1, 1, 12, 0, 0) do
+        first = instance(klass, remote_ip: "7.7.7.7")
+        first.enforce_throttles
+        expect(first.response.headers["X-RateLimit-Limit"]).to eq("2")
+        expect(first.response.headers["X-RateLimit-Remaining"]).to eq("1")
+        expect(first.response.headers["X-RateLimit-Reset"]).to eq(Time.utc(2026, 1, 1, 13, 0, 0).to_i.to_s)
+      end
+    end
+
+    it "on a 429 carry the exceeded rule's limit, zero remaining and Retry-After" do
+      klass = throttled_class(store) do
+        throttle_by limit: 100, period: 60, name: "per_ip"
+        throttle_by limit: 1, period: 60, name: "strict"
+      end
+      travel_to Time.utc(2026, 1, 1, 12, 0, 0) do
+        first = instance(klass, remote_ip: "8.8.4.4")
+        second = instance(klass, remote_ip: "8.8.4.4")
+        [first, second].each(&:enforce_throttles)
+        expect(second.rendered[:status]).to eq(:too_many_requests)
+        expect(second.response.headers["X-RateLimit-Limit"]).to eq("1")
+        expect(second.response.headers["X-RateLimit-Remaining"]).to eq("0")
+        expect(second.response.headers["Retry-After"]).to eq("60")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Three small, related gaps a real API hits within a week of adopting Throttleable. (The queue item was "standard rate-limit headers" — those already exist: `X-RateLimit-Limit/Remaining/Reset` + `Retry-After`, the de-facto standard GitHub and friends use; the IETF `RateLimit` structured-field draft is still moving, so it is deliberately not added.)

**1. `if:` / `unless:` skip conditions.** There was no way to exempt a caller. `throttle_by … if:/unless:` takes a Symbol (controller method) or a callable (`instance_exec`'d, so `request` / `current_user` resolve), evaluated per request **before** the counter — staff accounts, internal IPs, feature flags. Both may be given; both must pass. Mirrors Rails 7.2's `rate_limit`, which forwards `if:`/`unless:` to `before_action`. Anything else raises `ArgumentError` at declaration.

```ruby
throttle_by limit: 60, period: 1.minute, unless: :staff?
throttle_by limit: 5,  period: 1.minute, only: :create, if: -> { Flipper.enabled?(:strict_create_limits) }
```

**2. `rate_limited.concerns_on_rails` instrumentation.** Nothing told you someone was being throttled. A throttled request now instruments the event (payload: `controller`, `action`, `rule`, `discriminator`, `count`, `limit`, `period`, `reset_at`, `retry_after`) via a new public `on_rate_limited(rule, result)` hook — the Deprecatable `on_deprecated_access` pattern — before the 429 is rendered and independently of `throttled_response`, so overriding the body keeps the event; override the hook (with or without `super`) to alert, block or drop it.

**3. Headers describe the tightest rule.** With several rules, each one overwrote the `X-RateLimit-*` headers, so the client saw whichever rule was declared **last**. They now describe the passing rule with the fewest requests remaining — the budget that runs out first. A 429 still carries the exceeded rule's headers and `Retry-After`.

Additive detail: `result` (passed to `throttled_response`) gains `:discriminator`.

## Docs

- `README.md` — options line (`if:`/`unless:`), example line, a paragraph on tightest-rule headers + instrumentation.
- `docs/concerns/throttleable.md` — Configuration rows, Methods (`enforce_throttles` semantics, new `on_rate_limited`), signature, a new first example (skip conditions + subscriber), four Notes bullets.

## Changelog entry (for `CHANGELOG.md` at release — kept out of this diff so parallel enhancement PRs don't conflict)

```
### Added
- **Controllers::Throttleable**: `throttle_by … if:/unless:` per-request skip
  conditions (Symbol method or callable; both must pass), mirroring Rails 7.2's
  `rate_limit`. A throttled request instruments `rate_limited.concerns_on_rails`
  (rule, discriminator, count/limit/period, reset_at/retry_after, controller,
  action) through the new public `on_rate_limited(rule, result)` hook.
### Changed
- **Controllers::Throttleable**: with several applicable rules the
  `X-RateLimit-*` headers now describe the tightest passing rule (fewest
  remaining) instead of the last one declared. `result[:discriminator]` is now
  available to `throttled_response`.
```

## Test plan

- [x] +11 examples: `if:` falsy skips (no counter, no headers) / truthy applies; Symbol conditions for `unless:` with internal vs external IPs; both conditions must pass; composition with `only:`; invalid condition types raise. Event emitted only on a 429 with the full payload; still emitted when `throttled_response` is overridden. Tightest-rule headers on first hit, as counters diverge across periods (checks `X-RateLimit-Reset`), and the exceeded rule's headers + `Retry-After: 60` on a 429.
- [x] Full suite: 1268 examples, 0 failures (98.33%).
- [x] RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
