### PR TITLE
Paginatable + CursorPaginatable: RFC 8288 Link headers (first/prev/next/last)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1477,7 +1477,11 @@ Anything answering `limit`/`offset` is treated as a relation; any other non-`Has
 | `?page=`     | `1`     | Page numbers below 1 are clamped to 1 |
 | `?per_page=` | `25`    | Capped at `max_per_page` (default 200) |
 
-**Response headers**: `X-Total-Count`, `X-Page`, `X-Per-Page`, `X-Total-Pages`.
+**Response headers**: `X-Total-Count`, `X-Page`, `X-Per-Page`, `X-Total-Pages`, and an RFC 8288 `Link`
+header with `first` / `prev` / `next` / `last` URLs rebuilt from the current request (other query params
+preserved; `prev`/`next` only when such a page exists; nothing for an empty collection) — the GitHub
+convention, so clients follow links instead of computing page numbers. Appended to any `Link` header
+already set (Deprecatable, CDN hints). `paginate_by link_header: false` turns it off.
 
 ---
 
@@ -1505,7 +1509,7 @@ end
 | `?per_page=` | `25`    | Capped at `max_per_page` (default 200; `0` disables the cap) |
 | `?order=`    | first preset | With `order_presets:` only — selects a named ordering from the allow-list (unknown names → 400 `invalid_order_preset`) |
 
-**Response headers**: `X-Per-Page`, `X-Count` (rows on **this** page — totals are deliberately not computed), `X-Has-More`, `X-Next-Cursor` (only while more pages exist). With `bidirectional: true`: also `X-Has-Prev`, `X-Prev-Cursor`.
+**Response headers**: `X-Per-Page`, `X-Count` (rows on **this** page — totals are deliberately not computed), `X-Has-More`, `X-Next-Cursor` (only while more pages exist). With `bidirectional: true`: also `X-Has-Prev`, `X-Prev-Cursor`. Plus an RFC 8288 `Link` header: `rel="next"` carries the next-cursor URL, `rel="prev"` the prev-cursor URL (bidirectional), `rel="first"` the current URL with the cursor dropped (once a cursor is in play); `per_page` and the order preset are preserved. `cursor_paginate_by link_header: false` turns it off.
 
 **Notes**
 - The primary key is always appended as a tiebreaker, so duplicate values never skip or repeat rows; ordering columns are chosen **in code** (never from params) and should be `NOT NULL` (a NULL boundary value raises rather than silently dropping rows).

--- a/docs/concerns/cursor-paginatable.md
+++ b/docs/concerns/cursor-paginatable.md
@@ -38,6 +38,7 @@ end
 | `order_param` | Symbol | `:order` | Query param that selects the preset. |
 | `bidirectional` | Boolean | `false` | Mints `X-Prev-Cursor` / `X-Has-Prev` (and `prev_cursor` / `has_prev` in meta) so clients can page backward. Also a per-call override on `cursor_paginated`. |
 | `predicate` | Symbol | `:auto` | Keyset WHERE strategy. `:auto`: row-value tuple `(a, b, id) > (x, y, z)` on PostgreSQL/MySQL/SQLite when all directions are uniform (walks a composite index directly), otherwise the portable OR-expansion. `:row` forces tuples (raises on mixed directions); `:or` forces the expansion. |
+| `link_header:` | Boolean | `true` | Emit the RFC 8288 `Link` header (`next`, `prev` in bidirectional mode, `first`). |
 
 `order:` and `per_page:` can also be passed per call: `cursor_paginated(scope, order: { score: :desc }, per_page: 50)`.
 
@@ -75,6 +76,7 @@ With no arguments: the meta Hash memoized by the last `cursor_paginated` call (n
 | `X-Count` | Rows on **this** page — *not* Paginatable's `X-Total-Count`; totals are deliberately never computed. |
 | `X-Has-More` | `"true"` / `"false"`. |
 | `X-Next-Cursor` | Opaque token for the next page. Only set while more pages exist. |
+| `Link` | RFC 8288 web links: `rel="next"` is the current URL with `cursor=<X-Next-Cursor>` (only while more pages exist), `rel="prev"` the same with the prev cursor (bidirectional mode), `rel="first"` the current URL with `cursor` dropped (once a cursor is in play). `per_page` and the order preset param are preserved. Off with `cursor_paginate_by link_header: false`; skipped without a request. Appended to an existing `Link` header. |
 | `X-Has-Prev` | `"true"` / `"false"` — bidirectional mode only. |
 | `X-Prev-Cursor` | Opaque token for the previous page — bidirectional mode only, set when the page has something before it. |
 
@@ -123,6 +125,7 @@ end
 
 ## Notes & gotchas
 
+- **`Link` header is on by default.** `rel="next"` carries the same token as `X-Next-Cursor`, so a client can follow links instead of assembling URLs; `rel="first"` (cursor dropped) appears once a cursor is in play, `rel="prev"` only in bidirectional mode. URLs come from `request.base_url + request.path` — behind a proxy make sure the forwarded host/proto reach Rails. `cursor_paginate_by link_header: false` disables it.
 - **No database columns required**, but ordering columns should be `NOT NULL`. A NULL value on a page-boundary row raises a descriptive `ArgumentError` instead of silently corrupting the walk; on NULLs-last databases (PostgreSQL ASC), NULL-valued tail rows are skipped by the strict keyset comparison without ever reaching a boundary. Use NOT NULL columns or COALESCE in a view.
 - **Forward-only by default.** `bidirectional: true` adds prev cursors: a backward fetch runs the inverted ordering and flips the page back to canonical order, the `limit+1` probe detects `has_prev`, and cursors are minted only from non-empty pages (an over-walked empty page returns no cursors — clients keep their previous tokens). Direction is pinned inside the token: prev tokens replayed against a forward-only endpoint get a 400, and pre-bidirectional (direction-less) tokens stay valid as forward cursors.
 - **Cursors are readable, not secret.** The token is Base64 JSON — the boundary row's values are visible to anyone holding it. Don't order by sensitive columns (emails, balances). Tampering is detected structurally; HMAC signing is out of scope.

--- a/docs/concerns/paginatable.md
+++ b/docs/concerns/paginatable.md
@@ -34,6 +34,7 @@ end
 |---|---|---|---|
 | `per_page` | Integer | `25` | Default number of records per page when the caller supplies no `?per_page=` param, or supplies a value less than 1. Coerced with `.to_i`. |
 | `max_per_page` | Integer | `200` | Hard upper bound on `per_page`. Any caller-supplied value above this cap is silently reduced to this value. When set to `0` or a negative integer the cap is disabled and any requested `per_page` is honored. Coerced with `.to_i`. |
+| `link_header` | Boolean | `true` | Emit the RFC 8288 `Link` header (`first`/`prev`/`next`/`last`) on every paginated response. Set `false` to send only the `X-*` headers. |
 
 **URL params read from `params`**
 
@@ -67,6 +68,7 @@ The four `X-*` headers set on `response`:
 | `X-Page` | The resolved current page number (always >= 1). |
 | `X-Per-Page` | The resolved per-page value after applying defaults and the cap. |
 | `X-Total-Pages` | `ceil(total / per_page)`. Returns `"0"` when the relation is empty. |
+| `Link` | RFC 8288 web links: `<…?page=1>; rel="first", <…?page=1>; rel="prev", <…?page=3>; rel="next", <…?page=5>; rel="last"`. URLs are the current request's base URL + path with `page` replaced and every other query param preserved. `prev`/`next` appear only when such a page exists (past the end, `prev` points at the last page). Not emitted for an empty collection, when `link_header: false`, or when the controller has no request. Appended to an existing `Link` header, never replacing it. |
 
 ## Examples
 
@@ -139,6 +141,8 @@ end
 
 ## Notes & gotchas
 
+- **`Link` header is on by default.** Every non-empty paginated response carries `first`/`prev`/`next`/`last` links built from `request.base_url + request.path` and the current query string — behind a proxy, make sure `X-Forwarded-Host`/`-Proto` reach Rails (`config.action_dispatch.trusted_proxies`) or the links will name the internal host. `paginate_by link_header: false` disables it; the `X-*` headers are unaffected.
+- **`Link` is appended, not set.** If Deprecatable (or a CDN hint) already put a `Link` header on the response, the pagination links are appended after it with a comma.
 - **No database columns required.** This is a pure controller concern with no model-layer dependency.
 - **In-memory collections are sliced in Ruby.** The whole collection is already in memory by definition, so `paginated(array)` costs one `to_a` plus an `Array#[]` — there is no lazy path. If the data lives in a table, pass the relation so the database does the work.
 - **Relation detection is duck-typed.** Anything answering `limit` and `offset` takes the SQL path; that includes association proxies and model classes, and keeps a `has_many` collection paginating in the database rather than loading it.

--- a/lib/concerns_on_rails.rb
+++ b/lib/concerns_on_rails.rb
@@ -80,6 +80,7 @@ module ConcernsOnRails
     autoload :Encryptor,               "concerns_on_rails/support/encryptor"
     autoload :Affix,                   "concerns_on_rails/support/affix"
     autoload :BatchOps,                "concerns_on_rails/support/batch_ops"
+    autoload :LinkHeader,              "concerns_on_rails/support/link_header"
   end
 
   # Encryption config + error types (Support::Encryptor requires it itself)

--- a/lib/concerns_on_rails/controllers/cursor_paginatable.rb
+++ b/lib/concerns_on_rails/controllers/cursor_paginatable.rb
@@ -2,6 +2,7 @@ require "active_support/concern"
 require "concerns_on_rails/support/error_envelope"
 require "concerns_on_rails/support/scalar_param"
 require "json"
+require "concerns_on_rails/support/link_header"
 require "time" # Time#iso8601(fraction_digits) lives in the stdlib time library
 
 module ConcernsOnRails
@@ -141,6 +142,7 @@ module ConcernsOnRails
         class_attribute :cursor_paginatable_max_per_page, default: DEFAULT_MAX_PER_PAGE
         class_attribute :cursor_paginatable_bidirectional, default: false
         class_attribute :cursor_paginatable_predicate, default: :auto
+        class_attribute :cursor_paginatable_link_header, default: true
 
         # Real controllers (anything with ActiveSupport::Rescuable) get the 400
         # handlers automatically; bare objects let the errors propagate.
@@ -161,7 +163,7 @@ module ConcernsOnRails
         # max_per_page: 0 (or negative) disables the per_page cap.
         def cursor_paginate_by(order: nil, order_presets: nil, default_preset: nil, order_param: :order,
                                per_page: DEFAULT_PER_PAGE, max_per_page: DEFAULT_MAX_PER_PAGE,
-                               bidirectional: false, predicate: :auto)
+                               bidirectional: false, predicate: :auto, link_header: true)
           self.cursor_paginatable_order = order && CursorPaginatable.normalize_order!(order)
           self.cursor_paginatable_order_presets = order_presets && CursorPaginatable.normalize_presets!(order_presets)
           self.cursor_paginatable_default_preset =
@@ -171,6 +173,7 @@ module ConcernsOnRails
           self.cursor_paginatable_max_per_page = max_per_page.to_i
           self.cursor_paginatable_bidirectional = bidirectional ? true : false
           self.cursor_paginatable_predicate = CursorPaginatable.validate_predicate!(predicate)
+          self.cursor_paginatable_link_header = link_header ? true : false
         end
       end
 
@@ -506,10 +509,30 @@ module ConcernsOnRails
         response.set_header("X-Count", meta[:count].to_s)
         response.set_header("X-Has-More", meta[:has_more].to_s)
         response.set_header("X-Next-Cursor", meta[:next_cursor]) if meta[:next_cursor]
+        apply_cursor_pagination_links(meta)
         return unless meta.key?(:has_prev)
 
         response.set_header("X-Has-Prev", meta[:has_prev].to_s)
         response.set_header("X-Prev-Cursor", meta[:prev_cursor]) if meta[:prev_cursor]
+      end
+
+      # RFC 8288 Link: rel="next" carries the X-Next-Cursor token, rel="prev"
+      # the X-Prev-Cursor one (bidirectional mode), rel="first" is the current
+      # URL with the cursor dropped — emitted once a cursor is in play. Other
+      # query params (per_page, the order preset) are preserved. Skipped when
+      # disabled or without a real request.
+      def apply_cursor_pagination_links(meta)
+        return unless self.class.cursor_paginatable_link_header
+        return unless ConcernsOnRails::Support::LinkHeader.available?(self)
+
+        cursor_url = ->(token) { ConcernsOnRails::Support::LinkHeader.url_for(request, cursor: token) }
+        raw_cursor = params[:cursor]
+        ConcernsOnRails::Support::LinkHeader.append(
+          response,
+          first: ConcernsOnRails::Support::ScalarParam.scalar?(raw_cursor) && !raw_cursor.to_s.empty? ? cursor_url.call(nil) : nil,
+          prev: meta[:prev_cursor] && cursor_url.call(meta[:prev_cursor]),
+          next: meta[:next_cursor] && cursor_url.call(meta[:next_cursor])
+        )
       end
     end
   end

--- a/lib/concerns_on_rails/controllers/paginatable.rb
+++ b/lib/concerns_on_rails/controllers/paginatable.rb
@@ -1,5 +1,6 @@
 require "active_support/concern"
 require "concerns_on_rails/support/scalar_param"
+require "concerns_on_rails/support/link_header"
 
 module ConcernsOnRails
   module Controllers
@@ -23,6 +24,12 @@ module ConcernsOnRails
     #   def search
     #     render json: paginated(ExternalCatalog.search(params[:q]))
     #   end
+    #
+    # Every paginated response also carries an RFC 8288 `Link` header with
+    # first/prev/next/last URLs rebuilt from the current request (other query
+    # params preserved) — the GitHub convention, so clients can follow links
+    # instead of computing page numbers. `paginate_by link_header: false` turns
+    # it off.
     module Paginatable
       extend ActiveSupport::Concern
 
@@ -33,15 +40,18 @@ module ConcernsOnRails
       included do
         class_attribute :paginatable_per_page, default: DEFAULT_PER_PAGE
         class_attribute :paginatable_max_per_page, default: DEFAULT_MAX_PER_PAGE
+        class_attribute :paginatable_link_header, default: true
       end
 
       class_methods do
-        # Configure the default page size and the hard cap on per_page.
+        # Configure the default page size, the hard cap on per_page, and whether
+        # the RFC 8288 Link header is emitted.
         # Example:
-        #   paginate_by per_page: 50, max_per_page: 500
-        def paginate_by(per_page: DEFAULT_PER_PAGE, max_per_page: DEFAULT_MAX_PER_PAGE)
+        #   paginate_by per_page: 50, max_per_page: 500, link_header: false
+        def paginate_by(per_page: DEFAULT_PER_PAGE, max_per_page: DEFAULT_MAX_PER_PAGE, link_header: true)
           self.paginatable_per_page = per_page.to_i
           self.paginatable_max_per_page = max_per_page.to_i
+          self.paginatable_link_header = link_header ? true : false
         end
       end
 
@@ -70,6 +80,7 @@ module ConcernsOnRails
 
         @paginatable_meta = { total: total, page: page, per_page: per_page, total_pages: total_pages }
         set_pagination_headers(**@paginatable_meta)
+        set_pagination_links(page: page, total_pages: total_pages)
         records
       end
 
@@ -147,6 +158,30 @@ module ConcernsOnRails
         response.set_header("X-Page", page.to_s)
         response.set_header("X-Per-Page", per_page.to_s)
         response.set_header("X-Total-Pages", total_pages.to_s)
+      end
+
+      # Link: <…?page=1>; rel="first", <…?page=1>; rel="prev", <…?page=3>;
+      # rel="next", <…?page=5>; rel="last". prev/next only when such a page
+      # exists; past the end, prev points at the last page. Nothing is emitted
+      # for an empty collection, when disabled, or without a real request.
+      def set_pagination_links(page:, total_pages:)
+        return unless pagination_links_applicable?(total_pages)
+
+        page_url = ->(number) { ConcernsOnRails::Support::LinkHeader.url_for(request, page: number) }
+        ConcernsOnRails::Support::LinkHeader.append(
+          response,
+          first: page_url.call(1),
+          prev: page > 1 ? page_url.call([page - 1, total_pages].min) : nil,
+          next: page < total_pages ? page_url.call(page + 1) : nil,
+          last: page_url.call(total_pages)
+        )
+      end
+
+      def pagination_links_applicable?(total_pages)
+        return false unless self.class.paginatable_link_header && total_pages.positive?
+        return false unless respond_to?(:response) && response
+
+        ConcernsOnRails::Support::LinkHeader.available?(self)
       end
     end
   end

--- a/lib/concerns_on_rails/support/link_header.rb
+++ b/lib/concerns_on_rails/support/link_header.rb
@@ -1,0 +1,45 @@
+require "rack/utils"
+
+module ConcernsOnRails
+  module Support
+    # RFC 8288 `Link` response header for the paginators: rebuilds the current
+    # request URL with a few query params changed (`page=3`, `cursor=…`) and
+    # appends `<url>; rel="next"` entries to the response — never clobbering a
+    # Link header something else already set (Deprecatable's rel="deprecation",
+    # CDN preload hints). Shared by Paginatable and CursorPaginatable.
+    module LinkHeader
+      module_function
+
+      # True when the controller has a request the URLs can be rebuilt from.
+      # The dependency-free FakeController has none, so emission is skipped.
+      def available?(controller)
+        return false unless controller.respond_to?(:request)
+
+        request = controller.request
+        %i[base_url path query_parameters].all? { |reader| request.respond_to?(reader) }
+      end
+
+      # The request's URL with `overrides` merged into its query string (a nil
+      # value or a key in `drop:` removes that param). Existing params keep
+      # their order; nested params survive via Rack's nested-query encoding.
+      def url_for(request, drop: [], **overrides)
+        query = request.query_parameters.to_h.transform_keys(&:to_s)
+        overrides.each { |key, value| value.nil? ? query.delete(key.to_s) : query[key.to_s] = value.to_s }
+        Array(drop).each { |key| query.delete(key.to_s) }
+
+        base = "#{request.base_url}#{request.path}"
+        query.empty? ? base : "#{base}?#{Rack::Utils.build_nested_query(query)}"
+      end
+
+      # `links` is { rel => url }; nil urls are skipped and nothing is set when
+      # none remain. Appends to an existing Link header, comma-separated.
+      def append(response, links)
+        entries = links.filter_map { |rel, url| %(<#{url}>; rel="#{rel}") if url }
+        return if entries.empty?
+
+        existing = response.headers["Link"]
+        response.set_header("Link", [existing, entries.join(", ")].reject { |part| part.nil? || part.empty? }.join(", "))
+      end
+    end
+  end
+end

--- a/spec/concerns/controllers/cursor_paginatable_spec.rb
+++ b/spec/concerns/controllers/cursor_paginatable_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "support/integration_harness"
 require "active_support/rescuable"
 
 # NOTE: FakeController cannot simulate performed?/double-render; the concern's
@@ -725,6 +726,64 @@ describe ConcernsOnRails::Controllers::CursorPaginatable do
       from_relation = make_controller.cursor_paginated(Item.all)
 
       expect(from_class.map(&:id)).to eq(from_relation.map(&:id))
+    end
+  end
+  describe "RFC 8288 Link header (through the real ActionController stack)" do
+    def cursor_link_controller(**macro)
+      IntegrationHarness.build_controller do
+        include ConcernsOnRails::Controllers::CursorPaginatable
+
+        cursor_paginate_by(order: { created_at: :asc }, per_page: 20, **macro)
+
+        define_method(:index) { render json: cursor_paginated(Item.all).map(&:id) }
+      end
+    end
+
+    def links(result)
+      header = result.header("Link")
+      return {} unless header
+
+      header.split(", ").to_h { |entry| entry.match(/\A<(.+)>; rel="(.+)"\z/).captures.reverse }
+    end
+
+    it "emits next (with the X-Next-Cursor token) on the first page, and no first/prev" do
+      result = IntegrationHarness.dispatch(cursor_link_controller, :index, query: "per_page=20")
+      token = result.header("X-Next-Cursor")
+      expect(token).to be_present
+      expect(links(result)).to eq("next" => "http://example.org/?per_page=20&cursor=#{token}")
+    end
+
+    it "emits first (cursor dropped) once a cursor is in play, and no next on the last page" do
+      first = IntegrationHarness.dispatch(cursor_link_controller, :index, query: "per_page=20")
+      second = IntegrationHarness.dispatch(cursor_link_controller, :index, query: "per_page=20&cursor=#{first.header('X-Next-Cursor')}")
+      expect(links(second).keys).to match_array(%w[first next])
+      expect(links(second)["first"]).to eq("http://example.org/?per_page=20")
+
+      third = IntegrationHarness.dispatch(cursor_link_controller, :index, query: "per_page=20&cursor=#{second.header('X-Next-Cursor')}")
+      expect(third.header("X-Has-More")).to eq("false")
+      expect(links(third).keys).to eq(%w[first])
+    end
+
+    it "adds prev in bidirectional mode, preserving the order preset param" do
+      klass = cursor_link_controller(bidirectional: true, order: nil, order_presets: { oldest: { created_at: :asc } })
+      first = IntegrationHarness.dispatch(klass, :index, query: "order=oldest&per_page=20")
+      second = IntegrationHarness.dispatch(klass, :index, query: "order=oldest&per_page=20&cursor=#{first.header('X-Next-Cursor')}")
+      expect(links(second).keys).to match_array(%w[first prev next])
+      expect(links(second)["prev"]).to eq("http://example.org/?order=oldest&per_page=20&cursor=#{second.header('X-Prev-Cursor')}")
+    end
+
+    it "can be switched off with cursor_paginate_by link_header: false" do
+      result = IntegrationHarness.dispatch(cursor_link_controller(link_header: false), :index, query: "per_page=20")
+      expect(result.header("Link")).to be_nil
+      expect(result.header("X-Next-Cursor")).to be_present
+    end
+
+    it "is skipped silently when the controller has no request (bare harness)" do
+      c = make_controller(per_page: 5)
+      c.class.cursor_paginate_by(order: { created_at: :asc })
+      c.cursor_paginated(Item.all)
+      expect(c.response.headers).not_to have_key("Link")
+      expect(c.response.headers["X-Has-More"]).to eq("true")
     end
   end
 end

--- a/spec/concerns/controllers/paginatable_spec.rb
+++ b/spec/concerns/controllers/paginatable_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "support/integration_harness"
 
 describe ConcernsOnRails::Controllers::Paginatable do
   before do
@@ -222,6 +223,89 @@ describe ConcernsOnRails::Controllers::Paginatable do
       records = controller.paginated(Widget.all)
       expect(records).to be_a(ActiveRecord::Relation)
       expect(records.to_sql).to match(/LIMIT/i)
+    end
+  end
+
+  describe "RFC 8288 Link header (through the real ActionController stack)" do
+    def link_controller(&extra)
+      IntegrationHarness.build_controller do
+        include ConcernsOnRails::Controllers::Paginatable
+
+        class_eval(&extra) if extra
+
+        define_method(:index) { render json: paginated(Widget.order(:id)).map(&:id) }
+      end
+    end
+
+    def links(result)
+      header = result.header("Link")
+      return {} unless header
+
+      header.split(", ").to_h { |entry| entry.match(/\A<(.+)>; rel="(.+)"\z/).captures.reverse }
+    end
+
+    it "emits first/prev/next/last relative to the current page, preserving the other query params" do
+      result = IntegrationHarness.dispatch(link_controller, :index, query: "page=2&per_page=10&q=abc")
+      expect(links(result)).to eq(
+        "first" => "http://example.org/?page=1&per_page=10&q=abc",
+        "prev" => "http://example.org/?page=1&per_page=10&q=abc",
+        "next" => "http://example.org/?page=3&per_page=10&q=abc",
+        "last" => "http://example.org/?page=5&per_page=10&q=abc"
+      )
+    end
+
+    it "omits prev on the first page and next on the last page" do
+      first = IntegrationHarness.dispatch(link_controller, :index, query: "per_page=10")
+      expect(links(first).keys).to match_array(%w[first next last])
+      expect(links(first)["next"]).to eq("http://example.org/?per_page=10&page=2")
+
+      last = IntegrationHarness.dispatch(link_controller, :index, query: "page=5&per_page=10")
+      expect(links(last).keys).to match_array(%w[first prev last])
+    end
+
+    it "points prev at the last page when the requested page is past the end" do
+      result = IntegrationHarness.dispatch(link_controller, :index, query: "page=99&per_page=10")
+      expect(links(result)).to include("prev" => "http://example.org/?page=5&per_page=10", "last" => "http://example.org/?page=5&per_page=10")
+      expect(links(result)).not_to have_key("next")
+    end
+
+    it "emits no Link header for an empty collection" do
+      Widget.delete_all
+      result = IntegrationHarness.dispatch(link_controller, :index, query: "per_page=10")
+      expect(result.header("Link")).to be_nil
+      expect(result.header("X-Total-Count")).to eq("0")
+    end
+
+    it "can be switched off with paginate_by link_header: false" do
+      klass = link_controller { paginate_by link_header: false }
+      result = IntegrationHarness.dispatch(klass, :index, query: "page=2&per_page=10")
+      expect(result.header("Link")).to be_nil
+      expect(result.header("X-Page")).to eq("2")
+    end
+
+    it "appends to a Link header something else already set (Deprecatable, CDN hints)" do
+      klass = link_controller do
+        before_action { response.set_header("Link", '<https://docs.example.com/v2>; rel="deprecation"') }
+      end
+      result = IntegrationHarness.dispatch(klass, :index, query: "page=2&per_page=10")
+      expect(result.header("Link")).to start_with('<https://docs.example.com/v2>; rel="deprecation", <http://example.org/?page=1')
+    end
+
+    it "works for in-memory collections too" do
+      klass = IntegrationHarness.build_controller do
+        include ConcernsOnRails::Controllers::Paginatable
+
+        define_method(:index) { render json: paginated((1..30).to_a) }
+      end
+      result = IntegrationHarness.dispatch(klass, :index, query: "page=1&per_page=10")
+      expect(links(result)["last"]).to eq("http://example.org/?page=1&per_page=10".sub("page=1", "page=3"))
+    end
+
+    it "is skipped silently when the controller has no request (bare harness)" do
+      controller = controller_class.new(params: { page: 2, per_page: 10 })
+      controller.paginated(Widget.all)
+      expect(controller.response.headers).not_to have_key("Link")
+      expect(controller.response.headers["X-Page"]).to eq("2")
     end
   end
 end

--- a/spec/concerns/support/link_header_spec.rb
+++ b/spec/concerns/support/link_header_spec.rb
@@ -1,0 +1,63 @@
+require "spec_helper"
+require "concerns_on_rails/support/link_header"
+
+RSpec.describe ConcernsOnRails::Support::LinkHeader do
+  FakeLinkRequest = Struct.new(:base_url, :path, :query_parameters) unless defined?(FakeLinkRequest)
+
+  let(:request) do
+    FakeLinkRequest.new("https://api.example.com", "/v1/articles",
+                        ActiveSupport::HashWithIndifferentAccess.new("page" => "2", "per_page" => "10", "q" => "a b"))
+  end
+  let(:response) { FakeResponse.new }
+
+  describe ".url_for" do
+    it "rebuilds the current URL with overrides merged into the query, preserving order and encoding" do
+      expect(described_class.url_for(request, page: 3))
+        .to eq("https://api.example.com/v1/articles?page=3&per_page=10&q=a+b")
+    end
+
+    it "drops keys given as nil overrides or via drop:, and omits the '?' when nothing is left" do
+      expect(described_class.url_for(request, page: nil, drop: %i[per_page q])).to eq("https://api.example.com/v1/articles")
+      expect(described_class.url_for(request, drop: :q)).to eq("https://api.example.com/v1/articles?page=2&per_page=10")
+    end
+
+    it "adds a key the request did not carry" do
+      bare = FakeLinkRequest.new("http://localhost:3000", "/items", ActiveSupport::HashWithIndifferentAccess.new)
+      expect(described_class.url_for(bare, cursor: "abc")).to eq("http://localhost:3000/items?cursor=abc")
+    end
+
+    it "keeps nested params intact" do
+      nested = FakeLinkRequest.new("http://h", "/p", ActiveSupport::HashWithIndifferentAccess.new("filter" => { "state" => "open" }))
+      expect(described_class.url_for(nested, page: 2)).to eq("http://h/p?filter%5Bstate%5D=open&page=2")
+    end
+  end
+
+  describe ".append" do
+    it "serializes rels as RFC 8288 web links, skipping nil urls" do
+      described_class.append(response, first: "http://h/p?page=1", prev: nil, next: "http://h/p?page=3")
+      expect(response.headers["Link"]).to eq('<http://h/p?page=1>; rel="first", <http://h/p?page=3>; rel="next"')
+    end
+
+    it "appends to an existing Link header instead of clobbering it" do
+      response.set_header("Link", '<https://docs.example.com/v2>; rel="deprecation"')
+      described_class.append(response, next: "http://h/p?page=2")
+      expect(response.headers["Link"])
+        .to eq('<https://docs.example.com/v2>; rel="deprecation", <http://h/p?page=2>; rel="next"')
+    end
+
+    it "sets nothing when every url is nil" do
+      described_class.append(response, next: nil, prev: nil)
+      expect(response.headers).not_to have_key("Link")
+    end
+  end
+
+  describe ".available?" do
+    it "is true only for a controller whose request exposes base_url, path and query_parameters" do
+      with_request = Struct.new(:request).new(request)
+      expect(described_class.available?(with_request)).to be(true)
+      expect(described_class.available?(FakeController.new)).to be(false)
+      expect(described_class.available?(Struct.new(:request).new(nil))).to be(false)
+      expect(described_class.available?(Struct.new(:request).new(Object.new))).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Clients of both paginators had to assemble the next-page URL themselves from `X-Page`/`X-Total-Pages` or `X-Next-Cursor`. Every paginated response now also carries an **RFC 8288 `Link` header** — the GitHub convention — with URLs rebuilt from the current request (`base_url` + `path`, every other query param preserved):

| Concern | rels |
|---|---|
| Paginatable | `first`, `prev`, `next`, `last` (`page=N`). `prev`/`next` only when such a page exists; past the end `prev` points at the last page; nothing for an empty collection. |
| CursorPaginatable | `next` (`cursor=<X-Next-Cursor>` while more pages exist), `prev` in bidirectional mode, `first` (cursor dropped) once a cursor is in play. `per_page` and the order preset are preserved. |

```
Link: <http://api.example.com/articles?page=1&per_page=10&q=abc>; rel="first",
      <http://api.example.com/articles?page=1&per_page=10&q=abc>; rel="prev",
      <http://api.example.com/articles?page=3&per_page=10&q=abc>; rel="next",
      <http://api.example.com/articles?page=5&per_page=10&q=abc>; rel="last"
```

**Design**

- New **`Support::LinkHeader`** (autoloaded, shared): `available?(controller)` — a request exposing `base_url`/`path`/`query_parameters` (the dependency-free `FakeController` has none, so emission is silently skipped); `url_for(request, drop:, **overrides)` — Rack nested-query encoding, nested params survive, nil/`drop:` removes a key; `append(response, rels)` — **never clobbers** an existing `Link` (Deprecatable's `rel="deprecation"`, CDN hints), appends after it.
- Both macros gain **`link_header: true`**; `paginate_by link_header: false` / `cursor_paginate_by link_header: false` opt out. The `X-*` headers are unchanged either way.
- Behaviour change to be aware of: on by default, so every non-empty paginated response grows by one header. Behind a proxy the URLs name whatever host Rails sees — the docs note `trusted_proxies`/forwarded headers.

**Merge note:** this PR and #40 (Paginatable arrays) both touch `paginatable.rb` (header comment, `paginate_by`, `paginated`). Whichever merges second needs a trivial rebase — I'll do it in the loop as soon as one lands.

## Docs

- `README.md` — both "Response headers" lines.
- `docs/concerns/paginatable.md` — `link_header` config row, `Link` header row, two Notes bullets (proxy/host, append semantics).
- `docs/concerns/cursor-paginatable.md` — `link_header:` config row, `Link` header row, Notes bullet.

## Changelog entry (for `CHANGELOG.md` at release — kept out of this diff so parallel enhancement PRs don't conflict)

```
### Added
- **Controllers::Paginatable / CursorPaginatable**: RFC 8288 `Link` response
  header — `first`/`prev`/`next`/`last` page URLs for Paginatable, `next`
  (+ `prev` in bidirectional mode, `first` once a cursor is in play) for
  CursorPaginatable — rebuilt from the current request with every other query
  param preserved and appended to any existing `Link` header. Opt out with
  `link_header: false` on either macro. Backed by the new shared
  `Support::LinkHeader`.
```

## Test plan

- [x] `spec/concerns/support/link_header_spec.rb` (+8): URL rebuild with ordering/encoding, nil/`drop:` removal, adding a key, nested params, RFC 8288 serialization, append-to-existing, all-nil no-op, `available?` matrix.
- [x] Paginatable (+7, real ActionController via `IntegrationHarness`): full rel set on a middle page with other params preserved, first/last-page omissions, past-the-end `prev`, empty collection → no header, `link_header: false`, appended after a pre-set `Link`, bare-harness skip.
- [x] CursorPaginatable (+5): `next` with the `X-Next-Cursor` token on page 1, `first` once a cursor is in play and no `next` on the last page, `prev` in bidirectional mode with an order preset preserved, `link_header: false`, bare-harness skip.
- [x] Full suite: 1277 examples, 0 failures (98.34%). RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
