### PR TITLE
Filterable: comparison operators (suffix + bracket form) and type coercion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1512,12 +1512,30 @@ class ArticlesController < ApplicationController
   filter_by :status, :category                                       # ?status=draft → .where(status: 'draft')
   filter_by :published, scope: :published                            # ?published=1 → Article.published
   filter_by :q, with: ->(rel, v) { rel.where("title ILIKE ?", "%#{v}%") }
+  filter_by :price, :created_at, operators: true                     # ?price_gte=10&created_at_lt=2026-01-01
+  filter_by :min_stock, type: :integer, with: ->(rel, v) { rel.where(rel.model.arel_table[:stock].gteq(v)) }
 
   def index
     render json: filtered(Article.all)
   end
 end
 ```
+
+**Operators** (opt-in per filter, direct-where mode only — `operators: true` or a subset like `%i[gte lte]`),
+accepted as a suffix `?price_gte=10` or in bracket form `?price[gte]=10&price[lte]=50`:
+
+| Operator | Param                              | SQL                                   |
+|----------|------------------------------------|---------------------------------------|
+| `not`    | `?status_not=draft`                | `status != 'draft'`                   |
+| `gt` `gte` `lt` `lte` | `?price_gte=10`       | `price >= 10` (cast through the column type) |
+| `in` `not_in` | `?status_in=a,b` or `?status_in[]=a` | `status IN ('a','b')`         |
+| `null`   | `?deleted_at_null=true`            | `deleted_at IS NULL` (`false` → `IS NOT NULL`) |
+| `contains` `starts_with` | `?title_contains=rails` | `title LIKE '%rails%'` (wildcards escaped; ILIKE on PostgreSQL) |
+
+Comparison values are cast the way ActiveRecord casts them (the column's own type), or through `type:`
+(any ActiveModel type name); `type:` also pre-casts the value handed to a `with:` lambda. Blank values
+are skipped and unknown operators / non-scalar values ignored — nothing raises at request time. For
+strict, validated contracts reach for `Permittable`.
 
 **Modes**
 
@@ -1529,7 +1547,7 @@ end
 
 **Notes**
 - Blank params are skipped — unset filters don't narrow the relation.
-- Passing both `:scope` and `:with` raises `ArgumentError`.
+- Passing both `:scope` and `:with` raises `ArgumentError`; so do `operators:` on a `scope:`/`with:` filter, an unknown operator name, or an unknown `type:` — all at class load.
 - Scope mode pairs naturally with `Publishable.published`, `SoftDeletable.active`, `Expirable.active`, etc.
 
 ---

--- a/docs/concerns/filterable.md
+++ b/docs/concerns/filterable.md
@@ -33,7 +33,7 @@ end
 
 ## Configuration
 
-### `filter_by(*fields, scope: nil, with: nil)`
+### `filter_by(*fields, scope: nil, with: nil, type: nil, operators: nil)`
 
 Declares one or more filterable URL params. Multiple fields can be batched in a single call when they share the same mode (direct `where` only — `scope:` and `with:` apply to all fields in the call).
 
@@ -42,6 +42,8 @@ Declares one or more filterable URL params. Multiple fields can be batched in a 
 | `*fields` | One or more `Symbol` | — (required) | The param key(s) to watch. Each becomes a key in `filterable_rules`. At least one field is required or `ArgumentError` is raised. |
 | `scope:` | `Symbol` | `nil` | Name of a model scope to call (`public_send`) when the param is present and non-blank. Mutually exclusive with `with:`. |
 | `with:` | `Proc` / `lambda` | `nil` | A callable with signature `(relation, value)` invoked when the param is present and non-blank. Mutually exclusive with `scope:`. |
+| `type:` | `Symbol` | `nil` | An ActiveModel type name (`:integer`, `:decimal`, `:boolean`, `:date`, `:datetime`, …). Casts comparison-operator values (instead of the column's own type) and pre-casts the value handed to a `with:` lambda. An unknown name raises `ArgumentError` at class load. |
+| `operators:` | `true` or `Array<Symbol>` | `nil` (none) | Direct-where mode only. Enables comparison operators for the field, as a suffix (`?price_gte=10`) or bracket form (`?price[gte]=10`): `not`, `gt`, `gte`, `lt`, `lte`, `in`, `not_in`, `null`, `contains`, `starts_with`. `true` enables all; a list enables a subset; unknown names raise `ArgumentError`. Combining with `scope:`/`with:` raises. |
 
 Passing neither `scope:` nor `with:` activates **direct where mode**: `relation.where(field => value)`.
 
@@ -65,11 +67,36 @@ The method composes all active filters sequentially — each filter receives the
 
 ### Class methods
 
-#### `filter_by(*fields, scope: nil, with: nil)`
+#### `filter_by(*fields, scope: nil, with: nil, type: nil, operators: nil)`
 
 Class-level DSL method that registers filtering rules. Stores rules in the `filterable_rules` class attribute (a `Hash` keyed by `Symbol`). Calling `filter_by` multiple times is additive; each call merges new rules into the existing hash.
 
 ## Examples
+
+**Range, list and text operators on a product catalogue**
+
+```ruby
+class ProductsController < ApplicationController
+  include ConcernsOnRails::Controllers::Filterable
+
+  filter_by :price, :stock, :status, :name, :discontinued_at, operators: true
+  filter_by :created_at, operators: %i[gte lte]                 # only a date window
+  filter_by :min_stock, type: :integer, with: ->(rel, v) { rel.where(rel.model.arel_table[:stock].gteq(v)) }
+
+  def index
+    render json: filtered(Product.all)
+  end
+end
+
+# GET /products?price_gte=20&price_lte=100        → price BETWEEN, cast to the decimal column type
+# GET /products?price[gte]=20&price[lte]=100      → same, bracket form
+# GET /products?status_in=active,draft            → status IN ('active','draft')
+# GET /products?status_not=archived               → status != 'archived'
+# GET /products?discontinued_at_null=true         → discontinued_at IS NULL
+# GET /products?name_contains=100%                → name LIKE '%100\%%' ESCAPE '\'  (wildcards escaped)
+# GET /products?min_stock=5                       → the lambda receives Integer 5, not "5"
+```
+
 
 **Combining direct and scope filters in one controller**
 
@@ -122,6 +149,9 @@ end
 
 ## Notes & gotchas
 
+- **Operators are opt-in and per filter.** Without `operators:`, `?price_gte=10` is just an unknown param and is ignored, exactly as before. With it, both the suffix and the bracket form are read; a bracket key that is not an enabled operator is ignored. `in`/`not_in` accept a comma list or an array; blank items are dropped.
+- **Casting follows ActiveRecord.** `gt`/`gte`/`lt`/`lte` values are cast through the column's attribute type (so `"10"` compares as a decimal against a decimal column, and SQLite's type affinity cannot bite), or through `type:` when given. Equality, `not`, `in` and `null` go through `where`, which casts on its own. A value AR would cast to `nil`/`0` behaves as it would in `where` — nothing raises; use Permittable for validated params.
+- **`contains`/`starts_with` escape LIKE wildcards** (`%`, `_`, `\`) and emit an explicit `ESCAPE '\'` clause; matching is ILIKE on PostgreSQL and the adapter's LIKE elsewhere, exactly like Searchable.
 - **Blank values are always skipped.** Both missing params and params set to an empty string (`""`) are treated identically — the filter is not applied and the relation is not narrowed. This means omitting a query parameter never unintentionally restricts results.
 - **Scope mode ignores the param value.** When `scope:` is used, only the *presence* (and non-blankness) of the param matters; the actual value is discarded. Any truthy string (`"1"`, `"true"`, `"yes"`) triggers the scope equally.
 - **`scope:` and `with:` are mutually exclusive per `filter_by` call.** Declaring both raises `ArgumentError` at class-load time (not at request time), so the misconfiguration is caught immediately during development or test suite startup.

--- a/lib/concerns_on_rails/controllers/filterable.rb
+++ b/lib/concerns_on_rails/controllers/filterable.rb
@@ -110,7 +110,10 @@ module ConcernsOnRails
 
       def apply_filter(relation, field, value, options)
         if options[:with]
-          options[:with].call(relation, filter_cast(relation, field, value, options))
+          # `type:` pre-casts a with: lambda's value; the column's own type must
+          # NOT, or every existing lambda on a column-backed param silently
+          # starts receiving true / a Time where it used to get "1" / "2020-01-02".
+          options[:with].call(relation, options[:type] ? options[:type].cast(value) : value)
         elsif options[:scope]
           relation.public_send(options[:scope])
         elsif filterable_scalar?(value)

--- a/lib/concerns_on_rails/controllers/filterable.rb
+++ b/lib/concerns_on_rails/controllers/filterable.rb
@@ -1,4 +1,5 @@
 require "active_support/concern"
+require "active_model/type"
 require "concerns_on_rails/support/scalar_param"
 
 module ConcernsOnRails
@@ -8,6 +9,22 @@ module ConcernsOnRails
     #   filter_by :status, :category                         # ?status=draft       -> .where(status: 'draft')
     #   filter_by :published, scope: :published              # ?published=1        -> .published
     #   filter_by :q, with: ->(rel, v) { rel.where(...) }    # ?q=foo              -> lambda is called
+    #
+    # Direct-where filters can opt into comparison operators, accepted either as
+    # a suffix (`?price_gte=10`) or in bracket form (`?price[gte]=10`):
+    #
+    #   filter_by :price, :stock, operators: true            # every operator below
+    #   filter_by :created_at, operators: %i[gte lte]        # a subset
+    #
+    #   not · gt · gte · lt · lte · in · not_in (comma list or array) ·
+    #   null (true/false) · contains · starts_with (LIKE, wildcards escaped)
+    #
+    # Comparison values are cast the way ActiveRecord casts them — through the
+    # column's own attribute type — or through `type:` (any ActiveModel type
+    # name: :integer, :decimal, :boolean, :date, :datetime, ...). `type:` also
+    # pre-casts the value handed to a `with:` lambda. Blank values are skipped,
+    # unknown operators and non-scalar values are ignored; nothing here raises
+    # at request time — for strict, validated params use Permittable.
     #
     # Usage:
     #   class ArticlesController < ApplicationController
@@ -22,24 +39,60 @@ module ConcernsOnRails
     module Filterable
       extend ActiveSupport::Concern
 
+      LABEL = "ConcernsOnRails::Controllers::Filterable".freeze
+      OPERATORS = %i[not gt gte lt lte in not_in null contains starts_with].freeze
+      COMPARISONS = { gt: :gt, gte: :gteq, lt: :lt, lte: :lteq }.freeze
+      LIKE_ESCAPE = "\\".freeze
+
       included do
         class_attribute :filterable_rules, default: {}
       end
 
-      class_methods do
+      module ClassMethods
         # Declare one or more filterable params. Modes are mutually exclusive
         # per call; pass either `scope:` or `with:`, or neither (direct where).
-        def filter_by(*fields, scope: nil, with: nil)
-          raise ArgumentError, "ConcernsOnRails::Controllers::Filterable: at least one field is required" if fields.empty?
+        # `operators:` (true or a list) is direct-where only; `type:` applies to
+        # direct-where comparisons and to `with:` lambdas.
+        def filter_by(*fields, scope: nil, with: nil, type: nil, operators: nil)
+          raise ArgumentError, "#{LABEL}: at least one field is required" if fields.empty?
+          raise ArgumentError, "#{LABEL}: pass either :scope or :with, not both" if scope && with
 
-          raise ArgumentError, "ConcernsOnRails::Controllers::Filterable: pass either :scope or :with, not both" if scope && with
+          operators = filterable_normalize_operators(operators, direct: scope.nil? && with.nil?)
+          type = filterable_normalize_type(type)
 
           new_rules = filterable_rules.dup
           fields.each do |field|
-            new_rules[field.to_sym] = { scope: scope, with: with }
+            new_rules[field.to_sym] = { scope: scope, with: with, type: type, operators: operators }
           end
           self.filterable_rules = new_rules
         end
+
+        def filterable_normalize_operators(operators, direct:)
+          return nil if operators.nil? || operators == false
+          raise ArgumentError, "#{LABEL}: operators: only apply to direct-where filters (not scope:/with:)" unless direct
+
+          operators == true ? OPERATORS : filterable_operator_list(operators)
+        end
+
+        def filterable_operator_list(operators)
+          list = Array(operators).map(&:to_sym)
+          unknown = list - OPERATORS
+          return list if unknown.empty?
+
+          raise ArgumentError,
+                "#{LABEL}: unknown operator(s) #{unknown.map(&:inspect).join(', ')} — " \
+                "valid: #{OPERATORS.map(&:inspect).join(', ')}"
+        end
+
+        # Resolved eagerly so a typo fails at class load, not on the first request.
+        def filterable_normalize_type(type)
+          return nil if type.nil?
+
+          ActiveModel::Type.lookup(type.to_sym)
+        rescue ArgumentError
+          raise ArgumentError, "#{LABEL}: type: #{type.inspect} is not an ActiveModel type (try :integer, :decimal, :date, ...)"
+        end
+        private :filterable_normalize_operators, :filterable_operator_list, :filterable_normalize_type
       end
 
       # Apply all declared filters to a relation based on params. Blank values
@@ -47,9 +100,8 @@ module ConcernsOnRails
       def filtered(relation)
         self.class.filterable_rules.each do |field, options|
           value = params[field]
-          next if value.blank?
-
-          relation = apply_filter(relation, field, value, options)
+          relation = apply_filter(relation, field, value, options) unless value.blank?
+          relation = apply_filter_operator_suffixes(relation, field, options) if options[:operators]
         end
         relation
       end
@@ -58,17 +110,104 @@ module ConcernsOnRails
 
       def apply_filter(relation, field, value, options)
         if options[:with]
-          options[:with].call(relation, value)
+          options[:with].call(relation, filter_cast(relation, field, value, options))
         elsif options[:scope]
           relation.public_send(options[:scope])
         elsif filterable_scalar?(value)
           relation.where(field => value)
+        elsif options[:operators] && value.respond_to?(:each_pair)
+          apply_filter_operator_hash(relation, field, value, options)
         else
           # A nested/structured param (e.g. ?status[gt]=5) in direct-where mode
           # would raise TypeError ("can't quote Hash") and surface as a 500.
-          # Ignore it instead — hash/array shaping must go through a `with:` lambda.
+          # Ignore it instead — hash/array shaping must go through a `with:`
+          # lambda or `operators:`.
           relation
         end
+      end
+
+      # ?price[gte]=10&price[lte]=50 — unknown keys are ignored.
+      def apply_filter_operator_hash(relation, field, hash, options)
+        hash.each do |key, raw|
+          operator = key.to_s.to_sym
+          next unless options[:operators].include?(operator)
+
+          relation = apply_filter_operator(relation, field, operator, raw, options)
+        end
+        relation
+      end
+
+      # ?price_gte=10 — one param per declared operator.
+      def apply_filter_operator_suffixes(relation, field, options)
+        options[:operators].each do |operator|
+          raw = params[:"#{field}_#{operator}"]
+          next if raw.blank?
+
+          relation = apply_filter_operator(relation, field, operator, raw, options)
+        end
+        relation
+      end
+
+      def apply_filter_operator(relation, field, operator, raw, options)
+        case operator
+        when :in, :not_in then apply_filter_list(relation, field, operator, raw)
+        when :null then apply_filter_null(relation, field, raw)
+        when :contains, :starts_with then apply_filter_like(relation, field, operator, raw)
+        when :not then ConcernsOnRails::Support::ScalarParam.scalar?(raw) ? relation.where.not(field => raw) : relation
+        else apply_filter_comparison(relation, field, operator, raw, options)
+        end
+      end
+
+      def apply_filter_comparison(relation, field, operator, raw, options)
+        return relation unless ConcernsOnRails::Support::ScalarParam.scalar?(raw)
+
+        column = relation.model.arel_table[field]
+        relation.where(column.public_send(COMPARISONS.fetch(operator), filter_cast(relation, field, raw, options)))
+      end
+
+      def apply_filter_list(relation, field, operator, raw)
+        list = filterable_list(raw)
+        return relation if list.nil?
+
+        operator == :in ? relation.where(field => list) : relation.where.not(field => list)
+      end
+
+      # A comma list ("a, b") or an array (?status_in[]=a) of scalars → the
+      # cleaned list, or nil when unsafe or empty.
+      def filterable_list(raw)
+        list = raw.is_a?(Array) ? raw : raw.to_s.split(",")
+        return nil unless ConcernsOnRails::Support::ScalarParam.where_safe?(list)
+
+        list = list.map { |item| item.is_a?(String) ? item.strip : item }.reject { |item| item.to_s.empty? }
+        list.empty? ? nil : list
+      end
+
+      def apply_filter_null(relation, field, raw)
+        return relation unless ConcernsOnRails::Support::ScalarParam.scalar?(raw)
+
+        ActiveModel::Type::Boolean.new.cast(raw) ? relation.where(field => nil) : relation.where.not(field => nil)
+      end
+
+      # LIKE with the user's wildcards escaped — with an explicit ESCAPE clause,
+      # since SQLite has no default escape character (Searchable does the same).
+      # Arel `matches` is ILIKE on PostgreSQL and the adapter's LIKE elsewhere.
+      def apply_filter_like(relation, field, operator, raw)
+        return relation unless ConcernsOnRails::Support::ScalarParam.scalar?(raw)
+
+        escaped = relation.model.sanitize_sql_like(raw.to_s, LIKE_ESCAPE)
+        pattern = operator == :contains ? "%#{escaped}%" : "#{escaped}%"
+        relation.where(relation.model.arel_table[field].matches(pattern, LIKE_ESCAPE))
+      end
+
+      # `type:` wins; otherwise the column's own attribute type (what
+      # `where(field => value)` would use); a virtual field passes through raw.
+      def filter_cast(relation, field, value, options)
+        return options[:type].cast(value) if options[:type]
+
+        model = relation.model
+        return value unless model.respond_to?(:attribute_types) && model.attribute_types.key?(field.to_s)
+
+        model.type_for_attribute(field.to_s).cast(value)
       end
 
       # Scalars (and arrays of scalars, which AR turns into `IN (...)`) are safe

--- a/spec/concerns/controllers/filterable_spec.rb
+++ b/spec/concerns/controllers/filterable_spec.rb
@@ -253,6 +253,36 @@ describe ConcernsOnRails::Controllers::Filterable do
       expect(klass.new(params: { since: (Time.zone.today + 2).iso8601 }).filtered(Product.order(:id)).pluck(:name)).to eq([])
     end
 
+    it "hands a with: lambda the RAW value when no type: is declared, even on a real column" do
+      # The param name matches a column, but without type: the lambda must
+      # still receive the String it always did — an existing lambda comparing
+      # v == "1" or doing string work must not silently stop matching.
+      seen = nil
+      probe = Class.new(FakeController) do
+        include ConcernsOnRails::Controllers::Filterable
+
+        filter_by :stock, with: lambda { |rel, v|
+          seen = v
+          rel
+        }
+      end
+      probe.new(params: { stock: "5" }).filtered(Product.all)
+      expect(seen).to eq("5")
+      expect(seen).to be_a(String)
+
+      seen_date = nil
+      dates = Class.new(FakeController) do
+        include ConcernsOnRails::Controllers::Filterable
+
+        filter_by :discontinued_at, with: lambda { |rel, v|
+          seen_date = v
+          rel
+        }
+      end
+      dates.new(params: { discontinued_at: "2020-01-02" }).filtered(Product.all)
+      expect(seen_date).to eq("2020-01-02")
+    end
+
     it "records the rule so the configuration is introspectable" do
       expect(controller_class.filterable_rules[:price]).to include(operators: described_class::OPERATORS, type: nil)
     end

--- a/spec/concerns/controllers/filterable_spec.rb
+++ b/spec/concerns/controllers/filterable_spec.rb
@@ -124,4 +124,169 @@ describe ConcernsOnRails::Controllers::Filterable do
       end.to raise_error(ArgumentError, /pass either :scope or :with, not both/)
     end
   end
+  describe "operators and type coercion" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :products, force: true do |t|
+          t.string :name
+          t.string :status
+          t.decimal :price, precision: 10, scale: 2
+          t.integer :stock
+          t.datetime :discontinued_at
+        end
+      end
+
+      class Product < TestModel
+        self.table_name = "products"
+      end
+
+      Product.create!(name: "Lamp 100% cotton shade", status: "active", price: 10, stock: 5)
+      Product.create!(name: "Desk", status: "active", price: 250.5, stock: 0, discontinued_at: Time.zone.now)
+      Product.create!(name: "Chair", status: "archived", price: 99.99, stock: 12)
+      Product.create!(name: "Lampshade", status: "draft", price: 30, stock: 1)
+    end
+
+    after(:each) { Object.send(:remove_const, :Product) if Object.const_defined?(:Product) }
+
+    let(:controller_class) do
+      Class.new(FakeController) do
+        include ConcernsOnRails::Controllers::Filterable
+
+        filter_by :price, :stock, :status, :name, :discontinued_at, operators: true
+      end
+    end
+
+    def names(params)
+      controller_class.new(params: params).filtered(Product.order(:id)).pluck(:name)
+    end
+
+    it "keeps plain equality working" do
+      expect(names(status: "active")).to eq(["Lamp 100% cotton shade", "Desk"])
+    end
+
+    it "supports gt / gte / lt / lte with the suffix form, cast through the column type" do
+      expect(names(price_gte: "30")).to eq(%w[Desk Chair Lampshade])
+      expect(names(price_gt: "30")).to eq(%w[Desk Chair])
+      expect(names(price_lt: "30")).to eq(["Lamp 100% cotton shade"])
+      expect(names(price_lte: "30")).to eq(["Lamp 100% cotton shade", "Lampshade"])
+      expect(names(price_gte: "20", price_lte: "100")).to eq(%w[Chair Lampshade])
+    end
+
+    it "supports the bracket form ?price[gte]=…&price[lte]=…" do
+      expect(names(price: { gte: "20", lte: "100" })).to eq(%w[Chair Lampshade])
+    end
+
+    it "supports not / in / not_in (comma list or array)" do
+      expect(names(status_not: "active")).to eq(%w[Chair Lampshade])
+      expect(names(status_in: "archived,draft")).to eq(%w[Chair Lampshade])
+      expect(names(status_in: %w[archived draft])).to eq(%w[Chair Lampshade])
+      expect(names(status_not_in: "archived, draft")).to eq(["Lamp 100% cotton shade", "Desk"])
+    end
+
+    it "supports null=true/false" do
+      expect(names(discontinued_at_null: "true")).to eq(["Lamp 100% cotton shade", "Chair", "Lampshade"])
+      expect(names(discontinued_at_null: "false")).to eq(["Desk"])
+      expect(names(discontinued_at_null: "0")).to eq(["Desk"])
+    end
+
+    it "supports contains / starts_with with LIKE wildcards escaped" do
+      expect(names(name_contains: "amp")).to eq(["Lamp 100% cotton shade", "Lampshade"])
+      expect(names(name_starts_with: "Lamp")).to eq(["Lamp 100% cotton shade", "Lampshade"])
+      expect(names(name_contains: "100%")).to eq(["Lamp 100% cotton shade"])
+      expect(names(name_contains: "100% c")).to eq(["Lamp 100% cotton shade"])
+      expect(names(name_contains: "_")).to eq([])
+    end
+
+    it "casts comparison values through the column type (integer column, string param)" do
+      expect(names(stock_gte: "5")).to eq(["Lamp 100% cotton shade", "Chair"])
+      expect(names(stock_lt: "1")).to eq(["Desk"])
+    end
+
+    it "skips blank operator values and ignores non-scalar ones" do
+      expect(names(price_gte: "")).to eq(["Lamp 100% cotton shade", "Desk", "Chair", "Lampshade"])
+      expect(names(price_gte: { nested: "1" })).to eq(["Lamp 100% cotton shade", "Desk", "Chair", "Lampshade"])
+      expect(names(status_in: [{ x: 1 }])).to eq(["Lamp 100% cotton shade", "Desk", "Chair", "Lampshade"])
+    end
+
+    it "ignores unknown bracket keys and, without operators:, ignores suffix params entirely" do
+      expect(names(price: { between: "1,2" })).to eq(["Lamp 100% cotton shade", "Desk", "Chair", "Lampshade"])
+
+      plain = Class.new(FakeController) do
+        include ConcernsOnRails::Controllers::Filterable
+
+        filter_by :price
+      end
+      expect(plain.new(params: { price_gte: "30" }).filtered(Product.all).count).to eq(4)
+    end
+
+    it "honours an operator subset" do
+      subset = Class.new(FakeController) do
+        include ConcernsOnRails::Controllers::Filterable
+
+        filter_by :price, operators: %i[gte]
+      end
+      expect(subset.new(params: { price_gte: "30", price_lte: "50" }).filtered(Product.order(:id)).pluck(:name))
+        .to eq(%w[Desk Chair Lampshade])
+    end
+
+    it "type: overrides the cast and pre-casts the value handed to a with: lambda" do
+      klass = Class.new(FakeController) do
+        include ConcernsOnRails::Controllers::Filterable
+
+        filter_by :min_stock, type: :integer, with: ->(rel, v) { rel.where(rel.model.arel_table[:stock].gteq(v)) }
+        filter_by :since, type: :date, with: ->(rel, v) { rel.where("discontinued_at >= ?", v) }
+      end
+      seen = nil
+      probe = Class.new(FakeController) do
+        include ConcernsOnRails::Controllers::Filterable
+
+        filter_by :min_stock, type: :integer, with: lambda { |rel, v|
+          seen = v
+          rel
+        }
+      end
+      probe.new(params: { min_stock: "5" }).filtered(Product.all)
+      expect(seen).to eq(5)
+
+      expect(klass.new(params: { min_stock: "5" }).filtered(Product.order(:id)).pluck(:name)).to eq(["Lamp 100% cotton shade", "Chair"])
+      expect(klass.new(params: { since: (Time.zone.today - 1).iso8601 }).filtered(Product.order(:id)).pluck(:name)).to eq(["Desk"])
+      expect(klass.new(params: { since: (Time.zone.today + 2).iso8601 }).filtered(Product.order(:id)).pluck(:name)).to eq([])
+    end
+
+    it "records the rule so the configuration is introspectable" do
+      expect(controller_class.filterable_rules[:price]).to include(operators: described_class::OPERATORS, type: nil)
+    end
+
+    describe "configuration errors" do
+      it "rejects operators: with scope: or with:" do
+        expect do
+          Class.new(FakeController) do
+            include ConcernsOnRails::Controllers::Filterable
+
+            filter_by :status, scope: :published, operators: true
+          end
+        end.to raise_error(ArgumentError, /operators: only apply to direct-where filters/)
+      end
+
+      it "rejects unknown operator names, listing the valid ones" do
+        expect do
+          Class.new(FakeController) do
+            include ConcernsOnRails::Controllers::Filterable
+
+            filter_by :price, operators: %i[gte between]
+          end
+        end.to raise_error(ArgumentError, /unknown operator\(s\) :between.*valid: :not, :gt/)
+      end
+
+      it "rejects an unknown type:" do
+        expect do
+          Class.new(FakeController) do
+            include ConcernsOnRails::Controllers::Filterable
+
+            filter_by :price, type: :money
+          end
+        end.to raise_error(ArgumentError, /type: :money is not an ActiveModel type/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Direct-where filters could only do equality; anything else — a price range, a status list, "not archived", "discontinued IS NULL", a title search — meant a `with:` lambda per field. Filters can now **opt into operators**:

```ruby
filter_by :price, :stock, :status, :name, operators: true      # all of them
filter_by :created_at, operators: %i[gte lte]                  # a subset
filter_by :min_stock, type: :integer, with: ->(rel, v) { … }   # lambda receives Integer 5, not "5"
```

Accepted as a suffix or in bracket form:

| Operator | Param | SQL |
|---|---|---|
| `not` | `?status_not=draft` | `status != 'draft'` |
| `gt` `gte` `lt` `lte` | `?price_gte=10` / `?price[gte]=10&price[lte]=50` | `price >= 10` (cast through the column type) |
| `in` `not_in` | `?status_in=a,b` or `?status_in[]=a` | `status IN ('a','b')` |
| `null` | `?deleted_at_null=true` | `deleted_at IS NULL` (`false` → `IS NOT NULL`) |
| `contains` `starts_with` | `?title_contains=rails` | `title LIKE '%rails%' ESCAPE '\'` (wildcards escaped; ILIKE on PostgreSQL) |

**Design points**

- **Casting follows ActiveRecord.** Comparison values go through the column's own attribute type (so `"10"` compares as a decimal against a decimal column and SQLite's type affinity cannot bite); `type:` (any ActiveModel type name) overrides that and also **pre-casts the value handed to a `with:` lambda**. Equality/`not`/`in`/`null` go through `where`, which casts on its own.
- **Opt-in per filter, direct-where only.** Without `operators:`, `?price_gte=10` is ignored exactly as before — zero behaviour change for existing apps.
- **Nothing raises at request time**: blank values skipped, unknown bracket keys and non-scalar values ignored (the 1.22 `where_safe?` guard applies to lists). Strict, validated contracts remain Permittable's job.
- **Configuration errors raise at class load**: `operators:` on a `scope:`/`with:` filter, an unknown operator (message lists the valid ones), an unknown `type:`.
- `filterable_rules[field]` now carries `type:`/`operators:` for introspection.
- LIKE escaping uses an explicit `ESCAPE '\'` clause (SQLite has no default escape character) — the Searchable approach.
- `class_methods do` → `module ClassMethods` (RuboCop `Metrics/BlockLength`; Stateable precedent).

## Docs

- `README.md` — two new example lines, an **Operators** table + casting paragraph, notes.
- `docs/concerns/filterable.md` — signature, `type:`/`operators:` config rows, a catalogue example block with the URL → SQL mapping, three Notes bullets.

## Changelog entry (for `CHANGELOG.md` at release — kept out of this diff so parallel enhancement PRs don't conflict)

```
### Added
- **Controllers::Filterable**: `filter_by … operators: true` (or a subset) adds
  comparison operators to direct-where filters — `not`, `gt`, `gte`, `lt`,
  `lte`, `in`, `not_in`, `null`, `contains`, `starts_with` — read as a suffix
  (`?price_gte=10`) or in bracket form (`?price[gte]=10`). Values are cast
  through the column's own type, or through the new `type:` option, which also
  pre-casts the value handed to a `with:` lambda. Opt-in per filter; existing
  filters are unchanged.
```

## Test plan

- [x] +15 examples: plain equality unchanged; gt/gte/lt/lte (suffix and bracket) against a decimal column; not/in/not_in (comma list and array); null true/false/0; contains/starts_with with `%` and `_` escaped (a literal `100%` matches only the row containing it); casting through an integer column; blank/non-scalar/unknown-key handling; no-`operators:` backward compatibility; operator subset; `type:` with `with:` lambdas (Integer and Date); rule introspection; three configuration errors.
- [x] Full suite: 1272 examples, 0 failures (98.35%).
- [x] RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
