### PR TITLE
Idempotentable: capture Location/ETag/Link-style response headers and replay them

### DIFF
--- a/README.md
+++ b/README.md
@@ -1848,9 +1848,9 @@ class PaymentsController < ApplicationController
 end
 ```
 
-Per-key lifecycle: claim atomically (`write unless_exist`, TTL `lock_ttl:`) → run action → cache 2xx–4xx responses for `ttl:`; 5xx and raised exceptions release the claim so the client can retry. Replays carry `X-Idempotency-Replayed: true`; duplicates in flight get 409 + `Retry-After`; reusing a key with a **different payload** gets 422 (`idempotency_key_reuse`, fingerprint overridable via `idempotency_fingerprint`).
+Per-key lifecycle: claim atomically (`write unless_exist`, TTL `lock_ttl:`) → run action → cache 2xx–4xx responses for `ttl:`; 5xx and raised exceptions release the claim so the client can retry. Replays carry `X-Idempotency-Replayed: true` **and the original's `Location` / `Content-Location` / `ETag` / `Last-Modified` / `Link` headers** (captured with the cached response — a replayed 201 still says where the resource lives; tune the allow-list with `headers:`, `[]` to capture none); duplicates in flight get 409 + `Retry-After`; reusing a key with a **different payload** gets 422 (`idempotency_key_reuse`, fingerprint overridable via `idempotency_fingerprint`).
 
-**Options**: `*actions` (allow-list, required), `ttl:` (`24.hours`), `lock_ttl:` (`1.minute`), `header:` (`"Idempotency-Key"`), `required:` (`false`).
+**Options**: `*actions` (allow-list, required), `ttl:` (`24.hours`), `lock_ttl:` (`1.minute`), `header:` (`"Idempotency-Key"`), `required:` (`false`), `headers:` (response headers replayed with the cached response; default `%w[Location Content-Location ETag Last-Modified Link]` — an allow-list on purpose: `Set-Cookie`, `Date`, request ids and rate-limit headers describe the original exchange and are never replayed).
 
 **Notes**
 - Cache keys are scoped per `controller#action` and the client key is SHA256-hashed, so the same key on different endpoints never collides.

--- a/docs/concerns/idempotentable.md
+++ b/docs/concerns/idempotentable.md
@@ -24,7 +24,7 @@ end
 
 ## Configuration
 
-### `idempotent_actions(*actions, ttl: 86_400, lock_ttl: 60, header: "Idempotency-Key", required: false)`
+### `idempotent_actions(*actions, ttl: 86_400, lock_ttl: 60, header: "Idempotency-Key", required: false, headers: DEFAULT_REPLAY_HEADERS)`
 
 May be called multiple times to register rules with independent options; the first rule listing the current action wins. All arguments are validated at class-load time (`ArgumentError`).
 
@@ -35,6 +35,7 @@ May be called multiple times to register rules with independent options; the fir
 | `lock_ttl:` | `Duration` or `Integer` | `1.minute` | Lifetime of the in-flight claim. Kept short so a crashed worker cannot wedge a key until `ttl` expires. |
 | `header:` | `String` | `"Idempotency-Key"` | The request header carrying the key. |
 | `required:` | `true`/`false` | `false` | When `true`, a missing key is rejected with 400; when `false`, keyless requests pass through untouched. |
+| `headers:` | `Array<String>` | `%w[Location Content-Location ETag Last-Modified Link]` (`DEFAULT_REPLAY_HEADERS`) | Response headers captured with the cached response and set again on replay, so a replayed `201` still carries its `Location`. Only headers the action actually set are stored (under `record["headers"]`). An allow-list on purpose — `Set-Cookie`, `Date`, request ids and rate-limit headers describe the original exchange and are never replayed. `[]` disables capture; a non-Array or blank name raises `ArgumentError`. |
 
 ### `idempotency_store`
 
@@ -71,6 +72,7 @@ Cache keys are scoped as `idempotentable:<controller>#<action>:<SHA256(key)>`, s
 | `X-Idempotency-Key` | every keyed request | the raw key, echoed back |
 | `X-Idempotency-Replayed` | original run / replay | `"false"` on the original execution, `"true"` on a replay |
 | `Retry-After` | 409 conflict | the rule's `lock_ttl` in seconds |
+| captured headers | replay | the `headers:` allow-list entries the original response set (default `Location`, `Content-Location`, `ETag`, `Last-Modified`, `Link`), replayed verbatim before the body |
 
 ## Methods
 
@@ -81,7 +83,7 @@ Cache keys are scoped as `idempotentable:<controller>#<action>:<SHA256(key)>`, s
 | `enforce_idempotency(&block)` | The `around_action` entry point. Public so subclasses can override it. |
 | `idempotency_key` | The raw key sent for the matched rule (`nil` when absent). Handy for logging. |
 | `idempotency_fingerprint` | SHA256 digest of the request params (deep-sorted, minus `controller`/`action`/`format`), used to detect key reuse with a different payload. Override for raw-body APIs: `Digest::SHA256.hexdigest(request.raw_post)`. |
-| `replay_idempotent_response(record)` | Renders the cached response. Override to customize replay. |
+| `replay_idempotent_response(record)` | Sets the captured headers (`record["headers"]`, absent on records written before this feature) and renders the cached response. Override to customize replay. |
 | `idempotency_error_response(message:, status:, code:)` | Single funnel for the 400/409/422 outcomes. Delegates to `render_error` when `Respondable` is included, otherwise renders `{ success: false, error: { message:, code: } }` inline. |
 
 ## Examples
@@ -134,6 +136,7 @@ end
 
 ## Notes & gotchas
 
+- **Replayed headers are an allow-list.** Only `headers:` entries (default `Location`, `Content-Location`, `ETag`, `Last-Modified`, `Link`) are captured — a header the action never set is simply not stored, and records written before this feature (no `"headers"` key) replay exactly as before. Add app-specific headers (`headers: DEFAULT_REPLAY_HEADERS + %w[X-Resource-Version]`) rather than widening to everything: cookies, `Date`, request ids and `X-RateLimit-*` describe the *original* exchange.
 - **No default store.** `idempotency_store` is `nil` by default on purpose; the first keyed request raises `ArgumentError` with "no store configured" rather than silently caching per-process. A gem-wide fallback can be set once via `ConcernsOnRails.setup { |c| c.cache_store = -> { Rails.cache } }`.
 - **Atomic `unless_exist` is required for correctness.** With a store whose `unless_exist:` write is not atomic (file store, plain memory store across processes), two concurrent firsts can both claim and both execute — the behavior degrades to best-effort. `ActiveSupport::Cache::NullStore` silently disables idempotency entirely (claims always "succeed", reads return `nil`).
 - **5xx responses and exceptions are retryable by design.** They release the claim and are never cached, so the client's retry re-executes the action. Only 2xx–4xx responses are replayed.

--- a/lib/concerns_on_rails/controllers/idempotentable.rb
+++ b/lib/concerns_on_rails/controllers/idempotentable.rb
@@ -25,7 +25,11 @@ module ConcernsOnRails
     #                   5xx responses and raised exceptions release the claim so
     #                   the client can retry.
     #   * done       -> the cached status/body/content type is replayed with
-    #                   `X-Idempotency-Replayed: true`.
+    #                   `X-Idempotency-Replayed: true`, along with the
+    #                   allow-listed response headers captured from the original
+    #                   (`headers:`, default Location / Content-Location / ETag /
+    #                   Last-Modified / Link — so a replayed 201 still says where
+    #                   the resource lives; `headers: []` disables capture).
     #   * in flight  -> 409 with code "idempotency_conflict" and `Retry-After`.
     #   * same key, different request payload -> 422 "idempotency_key_reuse"
     #     (override `idempotency_fingerprint` to customize payload matching).
@@ -54,6 +58,11 @@ module ConcernsOnRails
 
       DEFAULT_HEADER = "Idempotency-Key".freeze
       MAX_KEY_LENGTH = 255
+      # Response headers captured with the cached response and set again on
+      # replay. Deliberately an allow-list: Set-Cookie, Date, request ids and
+      # rate-limit headers describe the ORIGINAL exchange and must not be
+      # replayed.
+      DEFAULT_REPLAY_HEADERS = %w[Location Content-Location ETag Last-Modified Link].freeze
       IGNORED_FINGERPRINT_KEYS = %w[controller action format].freeze
 
       included do
@@ -65,26 +74,38 @@ module ConcernsOnRails
       module ClassMethods
         # Declare idempotent actions. `ttl:` is the cached-response lifetime,
         # `lock_ttl:` the in-flight claim lifetime (kept short so a crashed
-        # worker cannot wedge a key), `header:` the request header to read, and
-        # `required:` whether a missing key is a 400. Each call appends a rule;
-        # the first rule listing the current action wins.
-        def idempotent_actions(*actions, ttl: 86_400, lock_ttl: 60, header: DEFAULT_HEADER, required: false)
+        # worker cannot wedge a key), `header:` the request header to read,
+        # `required:` whether a missing key is a 400, and `headers:` the
+        # response headers captured and replayed with the cached response
+        # (default DEFAULT_REPLAY_HEADERS; `[]` to capture none). Each call
+        # appends a rule; the first rule listing the current action wins.
+        def idempotent_actions(*actions, ttl: 86_400, lock_ttl: 60, header: DEFAULT_HEADER, required: false,
+                               headers: DEFAULT_REPLAY_HEADERS)
           actions = actions.flatten.map(&:to_s)
-          validate_idempotent!(actions, ttl: ttl, lock_ttl: lock_ttl, header: header, required: required)
+          validate_idempotent!(actions, ttl: ttl, lock_ttl: lock_ttl, header: header, required: required, headers: headers)
 
-          rule = { actions: actions, ttl: ttl.to_i, lock_ttl: lock_ttl.to_i, header: header.to_s, required: required }
+          rule = { actions: actions, ttl: ttl.to_i, lock_ttl: lock_ttl.to_i, header: header.to_s, required: required,
+                   headers: headers.map(&:to_s) }
           self.idempotency_rules = idempotency_rules + [rule]
         end
 
         private
 
-        def validate_idempotent!(actions, ttl:, lock_ttl:, header:, required:)
+        def validate_idempotent!(actions, ttl:, lock_ttl:, header:, required:, headers:)
           prefix = "ConcernsOnRails::Controllers::Idempotentable"
           raise ArgumentError, "#{prefix}: pass at least one action" if actions.empty?
           raise ArgumentError, "#{prefix}: :ttl must be a positive duration" unless ttl.to_i.positive?
           raise ArgumentError, "#{prefix}: :lock_ttl must be a positive duration" unless lock_ttl.to_i.positive?
           raise ArgumentError, "#{prefix}: :header must be a non-blank String" if header.to_s.strip.empty?
           raise ArgumentError, "#{prefix}: :required must be true or false" unless [true, false].include?(required)
+
+          validate_idempotent_headers!(prefix, headers)
+        end
+
+        def validate_idempotent_headers!(prefix, headers)
+          return if headers.is_a?(Array) && headers.all? { |name| !name.to_s.strip.empty? }
+
+          raise ArgumentError, "#{prefix}: :headers must be an Array of non-blank header names"
         end
       end
 
@@ -124,11 +145,14 @@ module ConcernsOnRails
         Digest::SHA256.hexdigest(JSON.generate(idempotency_deep_sort(filtered)))
       end
 
-      # Public override point for how a cached response is replayed.
+      # Public override point for how a cached response is replayed. Captured
+      # headers (`record["headers"]`, absent on records written before the
+      # feature) are set before the body renders.
       def replay_idempotent_response(record)
         return unless respond_to?(:response) && response
 
         emit_idempotency_replayed_header(true)
+        (record["headers"] || {}).each { |name, value| response.set_header(name, value) }
         options = { body: record["body"], status: record["status"] }
         options[:content_type] = record["content_type"] if record["content_type"]
         render(options)
@@ -195,7 +219,20 @@ module ConcernsOnRails
 
         record = { "state" => "done", "status" => status, "body" => idempotency_response_body,
                    "content_type" => idempotency_response_content_type, "fingerprint" => fingerprint }
+        headers = idempotency_response_headers(rule)
+        record["headers"] = headers unless headers.empty?
         store.write(cache_key, record, expires_in: rule[:ttl])
+      end
+
+      # The rule's allow-listed headers that the action actually set, as a
+      # plain name => value Hash (store-serializable).
+      def idempotency_response_headers(rule)
+        return {} unless respond_to?(:response) && response.respond_to?(:headers)
+
+        rule[:headers].each_with_object({}) do |name, captured|
+          value = response.headers[name]
+          captured[name] = value.to_s unless value.nil?
+        end
       end
 
       def idempotency_resolve_existing(store, cache_key, rule, fingerprint)

--- a/spec/concerns/controllers/idempotentable_spec.rb
+++ b/spec/concerns/controllers/idempotentable_spec.rb
@@ -352,4 +352,77 @@ describe ConcernsOnRails::Controllers::Idempotentable do
       expect { declare { idempotent_actions :create, required: "yes" } }.to raise_error(ArgumentError, /:required/)
     end
   end
+  describe "response header capture" do
+    def perform_with_headers(controller, headers, status: 201, body: '{"id":1}')
+      controller.enforce_idempotency do
+        controller.response.status = status
+        controller.response.body = body
+        controller.response.content_type = "application/json"
+        headers.each { |name, value| controller.response.set_header(name, value) }
+      end
+    end
+
+    it "stores the default allow-list (Location, Content-Location, ETag, Last-Modified, Link) and replays it" do
+      klass = idempotent_class(store) { idempotent_actions :create }
+      first = instance(klass, key: "loc-1")
+      perform_with_headers(first, { "Location" => "/payments/42", "ETag" => 'W/"abc"',
+                                    "X-Request-Id" => "req-1", "Set-Cookie" => "session=1" })
+      expect(store.data.values.first["headers"]).to eq("Location" => "/payments/42", "ETag" => 'W/"abc"')
+
+      replay = instance(klass, key: "loc-1")
+      expect(perform(replay, status: 500)).to eq(0)
+      expect(replay.rendered[:status]).to eq(201)
+      expect(replay.response.headers["Location"]).to eq("/payments/42")
+      expect(replay.response.headers["ETag"]).to eq('W/"abc"')
+      expect(replay.response.headers).not_to have_key("X-Request-Id")
+      expect(replay.response.headers).not_to have_key("Set-Cookie")
+      expect(replay.response.headers["X-Idempotency-Replayed"]).to eq("true")
+    end
+
+    it "headers: replaces the allow-list" do
+      klass = idempotent_class(store) { idempotent_actions :create, headers: %w[X-Resource-Version] }
+      perform_with_headers(instance(klass, key: "v-1"), { "Location" => "/x/1", "X-Resource-Version" => "7" })
+      expect(store.data.values.first["headers"]).to eq("X-Resource-Version" => "7")
+
+      replay = instance(klass, key: "v-1")
+      perform(replay)
+      expect(replay.response.headers["X-Resource-Version"]).to eq("7")
+      expect(replay.response.headers).not_to have_key("Location")
+    end
+
+    it "headers: [] disables capture entirely" do
+      klass = idempotent_class(store) { idempotent_actions :create, headers: [] }
+      perform_with_headers(instance(klass, key: "n-1"), { "Location" => "/x/1" })
+      expect(store.data.values.first).not_to have_key("headers")
+
+      replay = instance(klass, key: "n-1")
+      perform(replay)
+      expect(replay.response.headers).not_to have_key("Location")
+    end
+
+    it "omits the headers key when no allow-listed header was set, and replays a pre-upgrade record without it" do
+      klass = idempotent_class(store) { idempotent_actions :create }
+      perform(instance(klass, key: "old-1"))
+      expect(store.data.values.first).not_to have_key("headers")
+
+      store.data.each_value { |record| record.delete("headers") } # a record written before this feature
+      replay = instance(klass, key: "old-1")
+      expect { perform(replay) }.not_to raise_error
+      expect(replay.rendered[:status]).to eq(201)
+    end
+
+    it "normalizes header names to strings and records them on the rule" do
+      klass = idempotent_class(store) { idempotent_actions :create, headers: [:Location, "ETag"] }
+      expect(klass.idempotency_rules.first[:headers]).to eq(%w[Location ETag])
+      expect(idempotent_class(store) { idempotent_actions :create }.idempotency_rules.first[:headers])
+        .to eq(described_class::DEFAULT_REPLAY_HEADERS)
+    end
+
+    it "rejects a non-Array or a blank header name" do
+      expect { idempotent_class(store) { idempotent_actions :create, headers: "Location" } }
+        .to raise_error(ArgumentError, /:headers must be an Array of non-blank header names/)
+      expect { idempotent_class(store) { idempotent_actions :create, headers: ["Location", " "] } }
+        .to raise_error(ArgumentError, /:headers must be an Array of non-blank header names/)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

A replayed response carried only the cached **status, body and content type**. A retried `create` therefore got its `201` back **without the `Location`** the original response had — the one header a client of an idempotent POST most needs (Stripe replays it; ours dropped it).

`idempotent_actions … headers:` now names the response headers captured with the cached response and set again on replay, before the body renders:

```ruby
idempotent_actions :create, ttl: 24.hours                          # default allow-list below
idempotent_actions :create, headers: DEFAULT_REPLAY_HEADERS + %w[X-Resource-Version]
idempotent_actions :create, headers: []                            # capture nothing
```

- **Default allow-list** `DEFAULT_REPLAY_HEADERS = %w[Location Content-Location ETag Last-Modified Link]` — deliberately an allow-list, not "everything": `Set-Cookie`, `Date`, request ids and `X-RateLimit-*` describe the *original* exchange and must not be replayed.
- **Only headers the action actually set are stored** (`record["headers"]`), so the record stays small and **records written before this feature** (no such key) replay exactly as before.
- Replay happens inside `replay_idempotent_response`, the existing public override point.
- Validation: a non-Array or blank header name raises `ArgumentError` at class load; names are normalized to strings and recorded on the rule.

## Docs

- `README.md` — lifecycle sentence and the Options line.
- `docs/concerns/idempotentable.md` — signature, `headers:` config row, response-headers table row, `replay_idempotent_response` row, Notes bullet.

## Changelog entry (for `CHANGELOG.md` at release — kept out of this diff so parallel enhancement PRs don't conflict)

```
### Added
- **Controllers::Idempotentable**: replays now carry the original response's
  `Location`, `Content-Location`, `ETag`, `Last-Modified` and `Link` headers
  (captured with the cached response), so a retried `create` still says where
  the resource lives. `idempotent_actions … headers:` tunes the allow-list
  (`[]` to capture none). Records written before this release replay
  unchanged.
```

## Test plan

- [x] +6 examples: default allow-list captured and replayed while `X-Request-Id`/`Set-Cookie` are not; `headers:` replaces the list; `headers: []` stores and replays nothing; no `"headers"` key when nothing allow-listed was set, and a pre-upgrade record replays cleanly; symbol names normalized and recorded on the rule; non-Array / blank name rejected.
- [x] Full suite: 1263 examples, 0 failures (98.33%).
- [x] RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
