### PR TITLE
Cacheable: etag_with — fold request context (locale, fields, role) into the ETag + automatic Vary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1943,6 +1943,8 @@ class Api::ArticlesController < ApplicationController
 
   http_cache_actions :index, :show, max_age: 5.minutes,
                      visibility: :public, vary: "Accept"
+  etag_with :locale                           # the body depends on I18n.locale → folded into the ETag, Vary: Accept-Language
+  etag_with { current_user&.role }            # ...and on who is asking
 
   def show
     @article = Article.find(params[:id])
@@ -1953,7 +1955,7 @@ end
 
 # A matching response then carries:
 #   Cache-Control: public, max-age=300
-#   Vary: Accept
+#   Vary: Accept, Accept-Language
 #   ETag: W/"…"
 #   Last-Modified: Thu, 01 Jan 2026 12:00:00 GMT
 ```
@@ -1961,6 +1963,8 @@ end
 `http_cache_actions` declares the `Cache-Control`/`Vary` policy (emitted via `after_action` — it rides a 304 too); `stale_resource?` sets the ETag/Last-Modified validators and, on a safe request whose precondition matches, sends `304 Not Modified` and returns `false`.
 
 **Options** (`http_cache_actions *actions, …`, repeatable; no actions = catch-all; **last matching rule wins**): `visibility:` (`:private` default | `:public`), `max_age:` (Integer/Duration), `must_revalidate:`, `no_store:` (overrides everything → bare `no-store`), `stale_while_revalidate:`, `vary:` (String or Array, appended to any existing `Vary`).
+
+**ETag context** (`etag_with`, repeatable — the analogue of Rails' class-level `etag { }`): when the representation depends on more than the record — the locale, the requested fields, the caller's role — declare it and the values are folded into the ETag so two representations of one resource never share a validator. Sources are presets (`:locale` → also `Vary: Accept-Language`, `:format` → `Vary: Accept`, `:query`), Symbols naming controller methods, or a block (`instance_exec`'d); `vary:` overrides the implied header(s), `vary: false` suppresses them; nil values are ignored. Per call: `stale_resource?(@article, extras: [params[:fields]])`. An explicit `etag:` stays verbatim only when there is no context to fold in.
 
 **Conditional-GET correctness**
 - Weak ETag `W/"<md5>"` from the resource's cache key (collections fold their members' keys + size); `If-None-Match` is matched with **weak comparison**, honours `*`, and accepts a comma-separated list.

--- a/README.md
+++ b/README.md
@@ -1955,7 +1955,7 @@ end
 
 # A matching response then carries:
 #   Cache-Control: public, max-age=300
-#   Vary: Accept, Accept-Language
+#   Vary: Accept-Language, Accept
 #   ETag: W/"…"
 #   Last-Modified: Thu, 01 Jan 2026 12:00:00 GMT
 ```

--- a/docs/concerns/cacheable.md
+++ b/docs/concerns/cacheable.md
@@ -50,12 +50,27 @@ Declares the policy emitted via `after_action`. Repeatable; rules are inherited 
 | `stale_while_revalidate:` | `nil` | Append `stale-while-revalidate=<seconds>` |
 | `vary:` | `nil` | `String` or `Array` of header names, **appended** (de-duplicated) to any existing `Vary` |
 
+### `etag_with(*sources, vary: nil, &block)`
+
+Declares request context that shapes the representation and therefore belongs in the ETag — the analogue of Rails' class-level `etag { }`. Repeatable; entries accumulate and are folded into every validator `stale_resource?` / `set_cache_validators` writes (`W/"md5(base-etag | value | value …)"`), so two representations of one resource never share an ETag and a client never gets a 304 for a body it has not seen.
+
+| Source | Value folded in | Default `Vary` |
+|---|---|---|
+| `:locale` | `I18n.locale` | `Accept-Language` |
+| `:format` | `request.format` | `Accept` |
+| `:query` | `request.query_string` | — |
+| any other `Symbol` | the controller method of that name (`send`) | — |
+| a block | `instance_exec`'d on the controller | — |
+
+`vary:` (String/Array) replaces the implied header(s) for that call; `vary: false` suppresses them. The `Vary` header is written whenever validators are written and merged (de-duplicated) with the `http_cache_actions` policy. `nil` values are dropped, so an absent context leaves the ETag unchanged. A Symbol that is neither a preset nor a controller method raises `ArgumentError` at request time; an empty call or a non-Symbol source raises at class load. `cacheable_etag_extras` exposes the declared entries.
+
 All option errors raise `ArgumentError` at declaration time (bad `:visibility`, non-positive durations, blank `:vary`, non-boolean flags).
 
 ## Methods
 
-- `stale_resource?(resource = nil, etag: nil, last_modified: nil)` — sets the validators; for a safe (GET/HEAD) request whose precondition matches, sends `304 Not Modified` and returns **false**; otherwise returns **true** (render the body). Mirrors Rails' `stale?` under a non-clashing name.
-- `set_cache_validators(resource = nil, etag:, last_modified:)` — sets `ETag`/`Last-Modified` without short-circuiting; returns the computed `{ etag:, last_modified: }`.
+- `stale_resource?(resource = nil, etag: nil, last_modified: nil, extras: nil)` — sets the validators (with the `etag_with` context and any per-call `extras:` folded into the ETag); for a safe (GET/HEAD) request whose precondition matches, sends `304 Not Modified` and returns **false**; otherwise returns **true** (render the body). Mirrors Rails' `stale?` under a non-clashing name.
+- `set_cache_validators(resource = nil, etag:, last_modified:, extras:)` — sets `ETag`/`Last-Modified` (context folded in, `Vary` merged) without short-circuiting; returns the computed `{ etag:, last_modified: }`. An explicit `etag:` is kept verbatim only when there is no context to fold in.
+- `cache_etag_extras(extra = nil)` — the resolved `etag_with` values for this request plus `extra`, nils dropped; reuse it from a `cache_etag_for` override.
 - `request_matches_cache?(etag:, last_modified:)` — side-effect-free predicate.
 - `cache_etag_for(resource)` / `cache_last_modified_for(resource)` — override points for deriving validators.
 - `apply_http_cache_headers` — the `after_action` (public: `skip_after_action` it, or override).
@@ -89,6 +104,7 @@ end
 
 ## Notes & gotchas
 
+- **Context belongs in the ETag, not just in `Vary`.** `Vary: Accept-Language` tells caches to key on the header, but a client that switches locale and revalidates with its old ETag would still get a 304 unless the locale is part of the validator — `etag_with :locale` does both. Anything that changes the body without changing the record (fields, includes, role-based redaction) should be declared the same way.
 - The method names are deliberately distinct from `ActionController::ConditionalGet`, so this concern coexists with Rails' own `fresh_when`/`stale?`.
 - **Weak validators** signal semantic (not byte-for-byte) equivalence — the right choice for serialized representations that may differ in whitespace/ordering.
 - `no_store: true` overrides `max_age`/`visibility`; pair `:public` caching with care behind shared CDNs and proxies.

--- a/lib/concerns_on_rails/controllers/cacheable.rb
+++ b/lib/concerns_on_rails/controllers/cacheable.rb
@@ -16,6 +16,8 @@ module ConcernsOnRails
     #
     #     http_cache_actions :index, :show, max_age: 5.minutes,
     #                        visibility: :public, vary: "Accept"
+    #     etag_with :locale                       # representation depends on I18n.locale
+    #     etag_with { current_user&.role }        # ...and on who is asking
     #
     #     def show
     #       @article = Article.find(params[:id])
@@ -41,6 +43,12 @@ module ConcernsOnRails
     #   * The 304 is only sent for safe requests (GET/HEAD) and still carries the
     #     validators AND the policy headers (Cache-Control rides the 304, like
     #     Deprecatable's headers ride the 410).
+    #   * `etag_with` (the analogue of Rails' class-level `etag { }`) folds
+    #     request context into the ETag — locale, requested fields, the current
+    #     user's role — so two representations of one resource never share a
+    #     validator, and each source adds its `Vary` header (`:locale` →
+    #     Accept-Language, `:format` → Accept). Per call: `stale_resource?(r,
+    #     extras: [...])`.
     #
     # Notes:
     #   * `no_store: true` overrides everything (emits the lone `no-store`).
@@ -59,8 +67,18 @@ module ConcernsOnRails
       VALID_VISIBILITY = %i[public private].freeze
       SAFE_METHODS = %w[GET HEAD].freeze
 
+      # `etag_with` presets: the value folded into the ETag and the Vary header
+      # it implies. Any other Symbol names a controller method.
+      ETAG_PRESETS = {
+        locale: { value: -> { I18n.locale if defined?(I18n) }, vary: ["Accept-Language"] },
+        format: { value: -> { request.format.to_s if respond_to?(:request) && request.respond_to?(:format) }, vary: ["Accept"] },
+        query: { value: -> { request.query_string if respond_to?(:request) && request.respond_to?(:query_string) }, vary: [] }
+      }.freeze
+
       included do
         class_attribute :cacheable_rules, instance_accessor: false, default: []
+        # [{ source: Symbol | Proc, vary: [header, ...] }] — see etag_with.
+        class_attribute :cacheable_etag_extras, instance_accessor: false, default: []
         # no_store is applied EARLY as well: rescue_from-rendered errors skip
         # after_action entirely, and for a no_store endpoint (tokens, PII) even
         # the error response must not be stored. Positive freshness policies
@@ -93,7 +111,42 @@ module ConcernsOnRails
           self.cacheable_rules = cacheable_rules + [rule]
         end
 
+        # Declare request context that shapes the representation and therefore
+        # belongs in the ETag: presets (:locale, :format, :query), Symbols naming
+        # controller methods, or a block (instance_exec'd). Repeatable; entries
+        # accumulate and nil values are ignored. `vary:` names the request
+        # headers the context depends on (default: the preset's — Accept-Language
+        # for :locale, Accept for :format; none for methods/blocks); `vary: false`
+        # suppresses it. Emitted whenever validators are written.
+        #
+        #   etag_with :locale, :format
+        #   etag_with :requested_fields, vary: "X-Fields"
+        #   etag_with { current_user&.role }
+        def etag_with(*sources, vary: nil, &block)
+          validate_etag_with!(sources, block)
+
+          vary_list = http_cache_etag_vary_list(vary)
+          entries = sources.map { |source| { source: source, vary: vary_list || ETAG_PRESETS.dig(source, :vary) || [] } }
+          entries << { source: block, vary: vary_list || [] } if block
+          self.cacheable_etag_extras = cacheable_etag_extras + entries
+        end
+
         private
+
+        def validate_etag_with!(sources, block)
+          raise ArgumentError, "#{LABEL}: etag_with needs at least one source or a block" if sources.empty? && block.nil?
+          return if sources.all?(Symbol)
+
+          raise ArgumentError, "#{LABEL}: etag_with sources must be Symbols (a preset or a controller method)"
+        end
+
+        # nil → use the preset default (nil here); false → none ([]); else a validated list.
+        def http_cache_etag_vary_list(vary)
+          return nil if vary.nil?
+          return [] if vary == false
+
+          http_cache_vary(vary)
+        end
 
         def validate_http_cache!(visibility:, max_age:, no_store:, must_revalidate:, stale_while_revalidate:)
           unless VALID_VISIBILITY.include?(visibility)
@@ -163,13 +216,13 @@ module ConcernsOnRails
       # Set ETag/Last-Modified validators for the resource, then — for a safe
       # request whose precondition matches — send 304 and return false. Returns
       # true when the client must be sent a fresh body. Mirrors Rails `stale?`.
-      def stale_resource?(resource = nil, etag: nil, last_modified: nil)
+      def stale_resource?(resource = nil, etag: nil, last_modified: nil, extras: nil)
         # Unsafe methods get neither a 304 nor validators: a POST response must
         # not advertise an ETag a client could replay against GET (pre-1.22 the
         # validators were written before the safe-method check).
         return true unless http_cache_safe_request?
 
-        validators = set_cache_validators(resource, etag: etag, last_modified: last_modified)
+        validators = set_cache_validators(resource, etag: etag, last_modified: last_modified, extras: extras)
         return true unless request_matches_cache?(etag: validators[:etag], last_modified: validators[:last_modified])
 
         http_cache_send_not_modified
@@ -177,12 +230,26 @@ module ConcernsOnRails
       end
 
       # Set the ETag/Last-Modified response headers (no short-circuit). Returns
-      # the computed { etag:, last_modified: } pair.
-      def set_cache_validators(resource = nil, etag: nil, last_modified: nil)
+      # the computed { etag:, last_modified: } pair. Class-level `etag_with`
+      # values and per-call `extras:` are folded into the ETag (an explicit
+      # `etag:` stays verbatim only when there are none), and the sources' Vary
+      # headers are merged into the response.
+      def set_cache_validators(resource = nil, etag: nil, last_modified: nil, extras: nil)
         etag ||= cache_etag_for(resource) unless resource.nil?
         last_modified ||= cache_last_modified_for(resource) unless resource.nil?
+        context = cache_etag_extras(extras)
+        etag = http_cache_combine_etag(etag, context) if etag && context.any?
         http_cache_write_validators(etag, last_modified)
+        http_cache_write_etag_vary
         { etag: etag, last_modified: last_modified }
+      end
+
+      # The resolved `etag_with` values for this request plus `extra`, nils
+      # dropped. Public so an override of cache_etag_for can reuse it.
+      def cache_etag_extras(extra = nil)
+        values = self.class.cacheable_etag_extras.map { |entry| http_cache_resolve_extra(entry[:source]) }
+        values.concat(Array(extra)) unless extra.nil?
+        values.compact
       end
 
       # Side-effect-free: does the request's precondition match these validators?
@@ -210,6 +277,29 @@ module ConcernsOnRails
       end
 
       private
+
+      def http_cache_resolve_extra(source)
+        return instance_exec(&source) if source.is_a?(Proc)
+        return instance_exec(&ETAG_PRESETS[source][:value]) if ETAG_PRESETS.key?(source)
+        return send(source) if respond_to?(source, true)
+
+        raise ArgumentError,
+              "#{LABEL}: etag_with #{source.inspect} is neither a preset (#{ETAG_PRESETS.keys.map(&:inspect).join(', ')}) " \
+              "nor a controller method"
+      end
+
+      # Re-hash the base validator with the context so distinct representations
+      # of one resource get distinct (still weak) ETags.
+      def http_cache_combine_etag(etag, context)
+        http_cache_weak_etag(([etag] + context).join("|"))
+      end
+
+      def http_cache_write_etag_vary
+        return unless respond_to?(:response) && response
+
+        headers = self.class.cacheable_etag_extras.flat_map { |entry| entry[:vary] }.uniq
+        response.set_header("Vary", http_cache_merge_vary(headers)) if headers.any?
+      end
 
       def http_cache_write_validators(etag, last_modified)
         return unless respond_to?(:response) && response

--- a/spec/concerns/controllers/cacheable_spec.rb
+++ b/spec/concerns/controllers/cacheable_spec.rb
@@ -16,7 +16,10 @@ describe ConcernsOnRails::Controllers::Cacheable do
     end
   end
 
-  FakeCacheRequest = Struct.new(:request_method, :headers) unless defined?(FakeCacheRequest)
+  # format/query_string are here so the :format and :query etag_with presets
+  # actually fold a VALUE; without them both lambdas' respond_to? guards
+  # short-circuit and only their Vary side gets exercised.
+  FakeCacheRequest = Struct.new(:request_method, :headers, :format, :query_string) unless defined?(FakeCacheRequest)
 
   let(:base_class) do
     Class.new(FakeController) do
@@ -33,9 +36,9 @@ describe ConcernsOnRails::Controllers::Cacheable do
     end
   end
 
-  def instance(klass, action: "show", method: "GET", headers: {}, params: {})
+  def instance(klass, action: "show", method: "GET", headers: {}, params: {}, format: nil, query_string: nil)
     controller = klass.new(params: params)
-    request = FakeCacheRequest.new(method, headers)
+    request = FakeCacheRequest.new(method, headers, format, query_string)
     controller.define_singleton_method(:request) { request }
     controller.define_singleton_method(:action_name) { action }
     controller
@@ -223,6 +226,19 @@ describe ConcernsOnRails::Controllers::Cacheable do
     it "is deterministic — the same context yields the same ETag" do
       klass = cacheable_class { etag_with :locale }
       expect(etag_of(instance(klass))).to eq(etag_of(instance(klass)))
+    end
+
+    it "folds the :format and :query preset VALUES, not just their Vary" do
+      formats = cacheable_class { etag_with :format }
+      json = etag_of(instance(formats, format: "application/json"))
+      xml = etag_of(instance(formats, format: "application/xml"))
+      expect(json).not_to eq(xml)
+      expect(etag_of(instance(formats, format: "application/json"))).to eq(json)
+
+      queries = cacheable_class { etag_with :query }
+      first = etag_of(instance(queries, query_string: "page=1"))
+      second = etag_of(instance(queries, query_string: "page=2"))
+      expect(first).not_to eq(second)
     end
 
     it "accepts a block (instance_exec'd) and a Symbol naming a controller method" do

--- a/spec/concerns/controllers/cacheable_spec.rb
+++ b/spec/concerns/controllers/cacheable_spec.rb
@@ -187,4 +187,136 @@ describe ConcernsOnRails::Controllers::Cacheable do
         .to raise_error(ArgumentError, /:no_store/)
     end
   end
+  describe "ETag extras (etag_with) and automatic Vary" do
+    def etag_of(controller)
+      controller.stale_resource?(resource)
+      controller.response.headers["ETag"]
+    end
+
+    it "folds a :locale preset into the ETag and adds Vary: Accept-Language" do
+      klass = cacheable_class { etag_with :locale }
+      en = de = nil
+      I18n.with_locale(:en) { en = etag_of(instance(klass)) }
+      I18n.with_locale(:de) { de = etag_of(instance(klass)) }
+
+      expect(en).to match(%r{\AW/"[0-9a-f]{32}"\z})
+      expect(en).not_to eq(de)
+      expect(en).not_to eq(etag) # no longer the bare resource ETag
+      expect(instance(klass).tap { |c| c.stale_resource?(resource) }.response.headers["Vary"]).to eq("Accept-Language")
+    end
+
+    it "does not send 304 for a validator minted under another locale" do
+      klass = cacheable_class { etag_with :locale }
+      en = nil
+      I18n.with_locale(:en) { en = etag_of(instance(klass)) }
+
+      I18n.with_locale(:de) do
+        c = instance(klass, headers: { "If-None-Match" => en })
+        expect(c.stale_resource?(resource)).to be(true)
+      end
+      I18n.with_locale(:en) do
+        c = instance(klass, headers: { "If-None-Match" => en })
+        expect(c.stale_resource?(resource)).to be(false)
+      end
+    end
+
+    it "is deterministic — the same context yields the same ETag" do
+      klass = cacheable_class { etag_with :locale }
+      expect(etag_of(instance(klass))).to eq(etag_of(instance(klass)))
+    end
+
+    it "accepts a block (instance_exec'd) and a Symbol naming a controller method" do
+      klass = cacheable_class do
+        etag_with :requested_fields
+        etag_with { params[:role] }
+
+        def requested_fields
+          params[:fields]
+        end
+      end
+      a = etag_of(instance(klass, params: { fields: "id,title", role: "admin" }))
+      b = etag_of(instance(klass, params: { fields: "id", role: "admin" }))
+      c = etag_of(instance(klass, params: { fields: "id,title", role: "guest" }))
+      d = etag_of(instance(klass, params: { fields: "id,title", role: "admin" }))
+      expect([a, b, c].uniq.size).to eq(3)
+      expect(d).to eq(a)
+      expect(instance(klass).tap { |x| x.stale_resource?(resource) }.response.headers).not_to have_key("Vary")
+    end
+
+    it "ignores nil extras so an absent context leaves the ETag alone" do
+      klass = cacheable_class { etag_with { params[:missing] } }
+      expect(etag_of(instance(klass))).to eq(etag)
+    end
+
+    it "supports per-call extras: merged after the class-level ones" do
+      klass = cacheable_class
+      plain = etag_of(instance(klass))
+      c = instance(klass)
+      c.stale_resource?(resource, extras: ["v2"])
+      with_extra = c.response.headers["ETag"]
+      expect(with_extra).not_to eq(plain)
+
+      again = instance(klass)
+      again.stale_resource?(resource, extras: ["v2"])
+      expect(again.response.headers["ETag"]).to eq(with_extra)
+    end
+
+    it "combines an explicit etag: with extras (and keeps it verbatim without extras)" do
+      klass = cacheable_class { etag_with :locale }
+      c = instance(klass)
+      c.stale_resource?(etag: %(W/"custom"))
+      expect(c.response.headers["ETag"]).to match(%r{\AW/"[0-9a-f]{32}"\z})
+      expect(c.response.headers["ETag"]).not_to eq(%(W/"custom"))
+
+      bare = instance(cacheable_class)
+      bare.stale_resource?(etag: %(W/"custom"))
+      expect(bare.response.headers["ETag"]).to eq(%(W/"custom"))
+    end
+
+    it ":format varies on Accept, vary: overrides a preset default and vary: false suppresses it" do
+      c = instance(cacheable_class { etag_with :format })
+      c.stale_resource?(resource)
+      expect(c.response.headers["Vary"]).to eq("Accept")
+
+      c = instance(cacheable_class { etag_with :locale, vary: %w[Accept-Language X-Locale] })
+      c.stale_resource?(resource)
+      expect(c.response.headers["Vary"]).to eq("Accept-Language, X-Locale")
+
+      c = instance(cacheable_class { etag_with :locale, vary: false })
+      c.stale_resource?(resource)
+      expect(c.response.headers).not_to have_key("Vary")
+    end
+
+    it "merges etag_with Vary with the http_cache_actions policy Vary, de-duplicated" do
+      klass = cacheable_class do
+        http_cache_actions :show, max_age: 60, vary: %w[Accept Accept-Language]
+        etag_with :locale
+      end
+      c = instance(klass)
+      c.stale_resource?(resource)
+      c.apply_http_cache_headers
+      expect(c.response.headers["Vary"]).to eq("Accept-Language, Accept")
+    end
+
+    it "does not touch validators or Vary on an unsafe request" do
+      c = instance(cacheable_class { etag_with :locale }, method: "POST")
+      expect(c.stale_resource?(resource)).to be(true)
+      expect(c.response.headers).not_to have_key("ETag")
+      expect(c.response.headers).not_to have_key("Vary")
+    end
+
+    it "exposes the declared extras and validates the macro" do
+      klass = cacheable_class { etag_with :locale, :format }
+      expect(klass.cacheable_etag_extras.map { |e| e[:source] }).to eq(%i[locale format])
+
+      expect { cacheable_class { etag_with } }.to raise_error(ArgumentError, /etag_with needs at least one source or a block/)
+      expect { cacheable_class { etag_with "locale" } }.to raise_error(ArgumentError, /sources must be Symbols/)
+      expect { cacheable_class { etag_with :locale, vary: "" } }.to raise_error(ArgumentError, /:vary must be/)
+    end
+
+    it "raises a clear error at request time for a Symbol that is neither a preset nor a controller method" do
+      c = instance(cacheable_class { etag_with :nope })
+      expect { c.stale_resource?(resource) }.to raise_error(ArgumentError, /etag_with :nope.*neither a preset.*nor a controller method/)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

The ETag derived from the resource's cache key alone. When the body also depends on the **request** — `I18n.locale` (Localizable), sparse fieldsets (Includable's `?fields=`), the caller's role — two different representations of one record shared a validator, and a client that switched locale and revalidated got a **304 for a body it had never seen**. `Vary` alone does not fix that: it keys shared caches on the header, but the client's own `If-None-Match` still matches the old ETag.

`etag_with` is the analogue of Rails' class-level `etag { }`:

```ruby
class Api::ArticlesController < ApplicationController
  include ConcernsOnRails::Controllers::Cacheable

  http_cache_actions :index, :show, max_age: 5.minutes, visibility: :public, vary: "Accept"
  etag_with :locale                    # I18n.locale → folded into the ETag, Vary: Accept-Language
  etag_with :requested_fields          # a controller method
  etag_with { current_user&.role }     # a block, instance_exec'd

  def show
    @article = Article.find(params[:id])
    return unless stale_resource?(@article, extras: [params[:include]])   # per-call context too
    render json: @article
  end
end
```

| Source | Value folded in | Default `Vary` |
|---|---|---|
| `:locale` | `I18n.locale` | `Accept-Language` |
| `:format` | `request.format` | `Accept` |
| `:query` | `request.query_string` | — |
| any other `Symbol` | the controller method of that name | — |
| a block | `instance_exec`'d on the controller | — |

**Design points**

- Values are folded into every validator `stale_resource?` / `set_cache_validators` writes: `W/"md5(base-etag | v | v …)"` — still weak, still deterministic. `nil` values are dropped, so an absent context leaves the ETag exactly as before (zero change for apps that don't declare anything).
- Each source contributes its implied `Vary`; `vary:` on the call overrides, `vary: false` suppresses. Written whenever validators are written and **merged, de-duplicated, with the `http_cache_actions` policy** (after_action) — order-independent.
- An explicit `etag:` stays verbatim only when there is no context to fold in (with context it is combined, as Rails does).
- Unsafe requests still get neither validators nor `Vary` (the 1.22 guard).
- A Symbol that is neither a preset nor a controller method raises a clear `ArgumentError` at request time (methods may be defined after the macro); an empty call, a non-Symbol source or a blank `vary:` raise at class load. `cacheable_etag_extras` exposes the declared entries; `cache_etag_extras(extra)` (public) resolves them for the current request so a `cache_etag_for` override can reuse it.

## Docs

- `README.md` — example lines, the resulting `Vary`, an "ETag context" paragraph.
- `docs/concerns/cacheable.md` — new `etag_with` section with the source table, updated method signatures, `cache_etag_extras`, a Notes bullet on why context belongs in the ETag and not only in `Vary`.

## Changelog entry (for `CHANGELOG.md` at release — kept out of this diff so parallel enhancement PRs don't conflict)

```
### Added
- **Controllers::Cacheable**: `etag_with` folds request context into the ETag —
  presets `:locale` / `:format` / `:query`, controller-method Symbols, or a
  block — so locale-, fieldset- or role-dependent representations of one
  resource never share a validator; each source adds its implied `Vary`
  (`Accept-Language`, `Accept`; `vary:` overrides, `vary: false` suppresses),
  merged with the `http_cache_actions` policy. `stale_resource?` /
  `set_cache_validators` gain a per-call `extras:`.
```

## Test plan

- [x] +12 examples: `:locale` changes the ETag and adds `Vary: Accept-Language`; no 304 for a validator minted under another locale (and a 304 under the same one); determinism; block + method sources with no `Vary`; nil ignored; per-call `extras:`; explicit `etag:` combined with context vs verbatim without; `:format`, `vary:` override and `vary: false`; merge with the policy `Vary`, de-duplicated; unsafe request untouched; introspection + three class-load validations; request-time error for an unknown Symbol.
- [x] Full suite: 1269 examples, 0 failures (98.31%).
- [x] RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
