### PR TITLE
Stateable: timestamps: (<state>_at stamping) and per-event before_/after_<event> hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -928,6 +928,25 @@ guard rejects are skipped (not errors). Unlike every other batch verb in this ge
 the guarded `<event>!` method, because that path runs validations via `update!` while a bulk
 `update_all` would silently skip them.
 
+**Timestamps and per-event hooks**
+
+```ruby
+stateable_by :status, states: %i[draft review published archived], default: :draft,
+             timestamps: true,                  # or %i[published archived] — stamps <state>_at
+             transitions: { publish: { from: %i[draft review], to: :published }, archive: { to: :archived } }
+
+article.publish!          # status = "published" AND published_at = Time.current, in ONE update!
+article.archived!         # direct setters and transition_to! stamp too; the default state on create does not
+
+def before_publish  = check_embargo!          # per-event hooks, fired inside the generic pair and the
+def after_publish   = notify_subscribers      # same transaction: before_transition → before_publish →
+                                              # write → after_publish → after_transition
+```
+
+`timestamps:` requires the `<state>_at` columns (checked at class load, one typed migration hint); per-event
+hooks follow the affixed event name (`before_status_publish` with `prefix: true`) and, like the generic hooks,
+fire only for guarded `<event>!` transitions. `Model.stateable_timestamps` lists the stamped states.
+
 **Prefix / suffix** — avoid clashes when the state names overlap with other concerns or scopes:
 
 ```ruby

--- a/docs/concerns/stateable.md
+++ b/docs/concerns/stateable.md
@@ -32,6 +32,7 @@ end
 | Column | Type | Required | Notes |
 |---|---|---|---|
 | _(configured field)_ | `string` | Yes | Stores the current state name as a plain string. |
+| `<state>_at` | `datetime` | With `timestamps:` | One per stamped state (`published_at`, `archived_at`, …). Written with `Time.current` in the same `update!` as the state change. |
 
 ```ruby
 # db/migrate/YYYYMMDDHHMMSS_add_status_to_articles.rb
@@ -61,6 +62,8 @@ stateable_by(field, states:, **options)
 | `transitions:` | `Hash` | `{}` | Named events. Each key is the event name (Symbol); each value is a hash with `:to` (required, Symbol) and optional `:from` (Symbol or Array of Symbols). Omitting `:from` means the transition is allowed from any state. |
 | `prefix:` | `true`, `String`, or `Symbol` | `nil` | Prepended to all generated method/scope names separated by `_`. Pass `true` to use the field name; pass a string/symbol to use a literal prefix. |
 | `suffix:` | `true`, `String`, or `Symbol` | `nil` | Appended to all generated method/scope names separated by `_`. Same coercion rules as `prefix:`. |
+| `timestamps:` | `true` or `Array<Symbol>` | `nil` | Stamp `<state>_at = Time.current` whenever the record is written into that state — guarded `<event>!`, direct `<state>!` and `transition_to!` alike (the default state on create is not stamped; re-entering a state re-stamps it). `true` stamps every state; an Array stamps those states. The columns must exist (`ArgumentError` at class load with a typed migration hint); an undeclared state raises. `Model.stateable_timestamps` lists the stamped states. |
+| `lock:` | `true`/`false` | `false` | Take a row lock and re-check the guard against the fresh row before each guarded transition (closes the check-then-write race). |
 
 **Transition config keys** (values inside the `transitions:` hash):
 
@@ -93,7 +96,7 @@ Shipment.state_open  # => WHERE state = 'open'
 |---|---|
 | `<state>?` (e.g. `draft?`, `published?`) | Predicate — returns `true` if the state column equals this state's string value. |
 | `<state>!` (e.g. `draft!`, `published!`) | Direct setter — calls `update!` with the target state, bypassing all transition guards. |
-| `<event>!` (e.g. `publish!`, `archive!`) | Guarded transition — raises `InvalidTransition` if the current state is not in the transition's `:from` list. Calls `update!` on success. |
+| `<event>!` (e.g. `publish!`, `archive!`) | Guarded transition — raises `InvalidTransition` if the current state is not in the transition's `:from` list. Calls `update!` on success, inside one transaction with the hooks: `before_transition(event, from, to)` → `before_<event>` → write → `after_<event>` → `after_transition(event, from, to)`. Per-event hooks are plain instance methods, looked up by the affixed event name (`before_status_publish` with `prefix: true`) and skipped when undefined; a raising hook rolls the state change back. |
 | `may_<event>?` (e.g. `may_publish?`, `may_archive?`) | Guard predicate — returns `true` if the guarded transition is currently allowed, without mutating state. |
 | `transition_to!(state)` | Moves to any declared state by name (Symbol or String), bypassing transition guards. Raises `InvalidTransition` for undeclared states. |
 
@@ -167,6 +170,8 @@ ticket.transition_to!(:nope)
 
 ## Notes & gotchas
 
+- **Stamping is per write, not per create.** `timestamps:` writes `<state>_at` only when a state method runs (`publish!`, `published!`, `transition_to!`, `transition_all`); a record created in the default state has a `nil` stamp until it is explicitly moved. Re-entering a state re-stamps it and leaves the other stamps alone — `published_at` answers "when was it last published".
+- **Per-event hooks fire only for guarded transitions**, exactly like `before_transition`/`after_transition`; direct setters and `transition_to!` bypass both. `transition_all` fires them once per record.
 - **`ArgumentError` at class load time** — `stateable_by` validates eagerly. Errors are raised when the class is loaded, not at runtime. The following all raise `ArgumentError`:
   - The configured column does not exist in the schema (message: `does not exist in the database`).
   - `states:` is empty.

--- a/lib/concerns_on_rails/models/stateable.rb
+++ b/lib/concerns_on_rails/models/stateable.rb
@@ -31,8 +31,20 @@ module ConcernsOnRails
     #
     # Plus a generic `transition_to!(state)`.
     #
-    # Options for stateable_by: default:, transitions:, prefix:, suffix:, lock:
-    # (prefix:/suffix: take `true` to use the field name, or a literal string/symbol).
+    # Per-event hooks: define `before_<event>` / `after_<event>` (affixed like the
+    # event method — `before_status_publish` with prefix: true) and they fire
+    # around that guarded transition, inside the generic before_transition /
+    # after_transition pair and the same transaction.
+    #
+    # `timestamps: true` (or a list of states) stamps `<state>_at = Time.current`
+    # in the same write as the state change — guarded events, direct setters
+    # and transition_to! alike — so "when was it published / archived?" needs no
+    # callback. The columns are checked at macro time (typed :datetime in the
+    # migration hint); the default state is not stamped on create.
+    #
+    # Options for stateable_by: default:, transitions:, prefix:, suffix:, lock:,
+    # timestamps: (prefix:/suffix: take `true` to use the field name, or a
+    # literal string/symbol).
     #
     # Notes:
     #   * String columns only (store the state name) — not integer-backed like Rails enum.
@@ -53,7 +65,7 @@ module ConcernsOnRails
       class InvalidTransition < StandardError; end
 
       # Valid stateable_by keyword options (everything besides field/states:).
-      OPTIONS = %i[default transitions prefix suffix lock].freeze
+      OPTIONS = %i[default transitions prefix suffix lock timestamps].freeze
 
       included do
         class_attribute :stateable_field, instance_accessor: false
@@ -63,6 +75,8 @@ module ConcernsOnRails
         class_attribute :stateable_prefix, instance_accessor: false
         class_attribute :stateable_suffix, instance_accessor: false
         class_attribute :stateable_lock, instance_accessor: false, default: false
+        # States whose `<state>_at` column is stamped on every explicit write.
+        class_attribute :stateable_timestamps, instance_accessor: false, default: []
       end
 
       # Move to any declared state by name, bypassing transition guards.
@@ -70,11 +84,12 @@ module ConcernsOnRails
         state = state.to_sym
         raise InvalidTransition, "#{LABEL}: '#{state}' is not a declared state" unless self.class.stateable_states.include?(state)
 
-        update!(self.class.stateable_field => state.to_s)
+        update!(stateable_write_attributes(state.to_s))
       end
 
       # Transition lifecycle hooks — override in the model. Fired by guarded
       # <event>! transitions (not by direct <state>! setters or transition_to!).
+      # Per-event `before_<event>` / `after_<event>` methods fire inside them.
       def before_transition(_event, _from, _to); end
       def after_transition(_event, _from, _to); end
 
@@ -137,7 +152,19 @@ module ConcernsOnRails
           self.stateable_prefix = stateable_affix(options[:prefix])
           self.stateable_suffix = stateable_affix(options[:suffix])
           self.stateable_lock = options[:lock] ? true : false
+          self.stateable_timestamps = stateable_timestamp_states(options[:timestamps])
           ensure_columns!(LABEL, stateable_field, types: :string)
+        end
+
+        # timestamps: true => every state; an Array => those states (validated
+        # against states: in stateable_validate!); nil/false => none.
+        def stateable_timestamp_states(option)
+          case option
+          when nil, false then []
+          when true then stateable_states
+          when Array then option.map(&:to_sym)
+          else raise ArgumentError, "#{LABEL}: timestamps: must be true or an Array of states"
+          end
         end
 
         def stateable_affix(option)
@@ -155,7 +182,18 @@ module ConcernsOnRails
             raise ArgumentError, "#{LABEL}: default '#{stateable_default}' is not a declared state"
           end
 
+          stateable_validate_timestamps!
           stateable_transitions.each { |event, config| stateable_validate_transition!(event, config) }
+        end
+
+        # Unknown states first (a config typo), then the `<state>_at` columns —
+        # all missing ones in one typed migration hint.
+        def stateable_validate_timestamps!
+          unknown = stateable_timestamps - stateable_states
+          raise ArgumentError, "#{LABEL}: timestamps: references unknown states: #{unknown.join(', ')}" if unknown.any?
+          return if stateable_timestamps.empty?
+
+          ensure_columns!(LABEL, stateable_timestamps.map { |state| :"#{state}_at" }, types: :datetime)
         end
 
         def stateable_validate_transition!(event, config)
@@ -176,7 +214,7 @@ module ConcernsOnRails
             name = stateable_method_name(state)
             scope name, -> { where(field => value) }
             define_method("#{name}?") { self[field].to_s == value }
-            define_method("#{name}!") { update!(field => value) }
+            define_method("#{name}!") { update!(stateable_write_attributes(value)) }
           end
         end
 
@@ -187,7 +225,7 @@ module ConcernsOnRails
             to = config.fetch(:to).to_s
             name = stateable_method_name(event)
             define_method("may_#{name}?") { from.empty? || from.include?(self[field].to_s) }
-            define_method("#{name}!") { stateable_perform_transition!(field, to, from, event) }
+            define_method("#{name}!") { stateable_perform_transition!(field, to, from, event, name) }
           end
         end
 
@@ -209,28 +247,43 @@ module ConcernsOnRails
       # With `lock: true` the guard is re-checked under a row lock (with_lock
       # reloads, so the state read is the committed one) — closing the
       # check-then-write race between two concurrent transitions.
-      def stateable_perform_transition!(field, to, from, event)
+      def stateable_perform_transition!(field, to, from, event, name)
         if self.class.stateable_lock && persisted?
-          with_lock { stateable_execute_transition!(field, to, from, event) }
+          with_lock { stateable_execute_transition!(field, to, from, event, name) }
         else
-          stateable_execute_transition!(field, to, from, event)
+          stateable_execute_transition!(field, to, from, event, name)
         end
       end
 
       # Hooks and the state write share ONE transaction, so a raising
-      # after_transition rolls the state change back instead of leaving it
-      # committed with the side effect half-done (SoftDeletable's pattern).
-      def stateable_execute_transition!(field, to, from, event)
+      # after_transition (or after_<event>) rolls the state change back instead
+      # of leaving it committed with the side effect half-done (SoftDeletable's
+      # pattern). Order: before_transition → before_<event> → write →
+      # after_<event> → after_transition.
+      def stateable_execute_transition!(field, to, from, event, name)
         current = self[field].to_s
         raise InvalidTransition, "#{self.class.name}: cannot #{event} from '#{self[field]}'" unless from.empty? || from.include?(current)
 
         result = false
         transaction do
           before_transition(event, current, to)
-          result = update!(field => to)
+          stateable_event_hook(:"before_#{name}")
+          result = update!(stateable_write_attributes(to))
+          stateable_event_hook(:"after_#{name}")
           after_transition(event, current, to)
         end
         result
+      end
+
+      def stateable_event_hook(method_name)
+        send(method_name) if respond_to?(method_name, true)
+      end
+
+      # The state column plus, when the state is stamped, its `<state>_at`.
+      def stateable_write_attributes(state)
+        attributes = { self.class.stateable_field => state }
+        attributes[:"#{state}_at"] = Time.current if self.class.stateable_timestamps.include?(state.to_sym)
+        attributes
       end
     end
   end

--- a/spec/concerns/models/stateable_spec.rb
+++ b/spec/concerns/models/stateable_spec.rb
@@ -368,4 +368,220 @@ describe ConcernsOnRails::Stateable do
       expect(ArchivableOrder.transition_all(:archive)).to eq(0)
     end
   end
+  describe "timestamps: (<state>_at stamping)" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :stamped_posts, force: true do |t|
+          t.string :status
+          t.datetime :draft_at
+          t.datetime :review_at
+          t.datetime :published_at
+          t.datetime :archived_at
+        end
+        create_table :partially_stamped_posts, force: true do |t|
+          t.string :status
+          t.datetime :published_at
+        end
+      end
+    end
+
+    let(:stamped) do
+      Class.new(TestModel) do
+        self.table_name = "stamped_posts"
+        include ConcernsOnRails::Stateable
+
+        stateable_by :status, states: %i[draft review published archived], default: :draft, timestamps: true,
+                              transitions: { submit: { from: :draft, to: :review },
+                                             publish: { from: %i[draft review], to: :published },
+                                             archive: { to: :archived } }
+      end
+    end
+
+    it "stamps <state>_at in the same write as a guarded transition" do
+      post = stamped.create!
+      travel_to(Time.utc(2026, 3, 1, 12)) { post.publish! }
+      post.reload
+      expect(post.published_at).to eq(Time.utc(2026, 3, 1, 12))
+      expect(post.review_at).to be_nil
+    end
+
+    it "stamps for direct setters and transition_to! too" do
+      post = stamped.create!
+      travel_to(Time.utc(2026, 3, 2, 9)) { post.archived! }
+      expect(post.reload.archived_at).to eq(Time.utc(2026, 3, 2, 9))
+      travel_to(Time.utc(2026, 3, 3, 9)) { post.transition_to!(:review) }
+      expect(post.reload.review_at).to eq(Time.utc(2026, 3, 3, 9))
+    end
+
+    it "does not stamp the default state on create — only explicit state writes stamp" do
+      expect(stamped.create!.draft_at).to be_nil
+    end
+
+    it "re-stamps on re-entry and leaves the other stamps alone" do
+      post = stamped.create!
+      travel_to(Time.utc(2026, 3, 1, 12)) { post.publish! }
+      travel_to(Time.utc(2026, 3, 5, 12)) { post.archive! }
+      travel_to(Time.utc(2026, 3, 9, 12)) { post.transition_to!(:published) }
+      post.reload
+      expect(post.published_at).to eq(Time.utc(2026, 3, 9, 12))
+      expect(post.archived_at).to eq(Time.utc(2026, 3, 5, 12))
+    end
+
+    it "stamps through transition_all" do
+      eligible = stamped.create!
+      skipped = stamped.create!(status: "archived")
+      travel_to(Time.utc(2026, 4, 1)) { expect(stamped.transition_all(:publish)).to eq(1) }
+      expect(eligible.reload.published_at).to eq(Time.utc(2026, 4, 1))
+      expect(skipped.reload.published_at).to be_nil
+    end
+
+    it "timestamps: with a list stamps only those states" do
+      partial = Class.new(TestModel) do
+        self.table_name = "partially_stamped_posts"
+        include ConcernsOnRails::Stateable
+
+        stateable_by :status, states: %i[draft published archived], default: :draft, timestamps: %i[published],
+                              transitions: { publish: { from: :draft, to: :published }, archive: { to: :archived } }
+      end
+      post = partial.create!
+      travel_to(Time.utc(2026, 3, 1)) { post.publish! }
+      expect(post.reload.published_at).to eq(Time.utc(2026, 3, 1))
+      expect { post.archive! }.not_to raise_error # no archived_at column and not listed
+      expect(post.reload.archived?).to be(true)
+      expect(partial.stateable_timestamps).to eq(%i[published])
+    end
+
+    it "exposes the stamped states (every state with timestamps: true)" do
+      expect(stamped.stateable_timestamps).to eq(%i[draft review published archived])
+      expect(Ticket.stateable_timestamps).to eq([])
+    end
+
+    it "requires the <state>_at columns with a typed migration hint" do
+      expect do
+        Class.new(TestModel) do
+          self.table_name = "partially_stamped_posts"
+          include ConcernsOnRails::Stateable
+
+          stateable_by :status, states: %i[draft published], timestamps: true
+        end
+      end.to raise_error(ArgumentError, /draft_at.*does not exist.*draft_at:datetime/)
+    end
+
+    it "rejects timestamps: naming an undeclared state, or a value that is neither true nor an Array" do
+      expect do
+        Class.new(TestModel) do
+          self.table_name = "partially_stamped_posts"
+          include ConcernsOnRails::Stateable
+
+          stateable_by :status, states: %i[draft published], timestamps: %i[published nope]
+        end
+      end.to raise_error(ArgumentError, /timestamps: references unknown states: nope/)
+
+      expect do
+        Class.new(TestModel) do
+          self.table_name = "partially_stamped_posts"
+          include ConcernsOnRails::Stateable
+
+          stateable_by :status, states: %i[draft published], timestamps: "yes"
+        end
+      end.to raise_error(ArgumentError, /timestamps: must be true or an Array of states/)
+    end
+  end
+
+  describe "per-event hooks (before_<event> / after_<event>)" do
+    let(:klass) do
+      Class.new(TestModel) do
+        self.table_name = "tickets"
+        include ConcernsOnRails::Stateable
+
+        stateable_by :status, states: %i[draft published archived], default: :draft,
+                              transitions: { publish: { from: :draft, to: :published }, archive: { to: :archived } }
+
+        attr_reader :log
+
+        def before_transition(event, from, to)
+          (@log ||= []) << [:before_transition, event, from, to]
+        end
+
+        def after_transition(event, from, to)
+          (@log ||= []) << [:after_transition, event, from, to]
+        end
+
+        def before_publish
+          (@log ||= []) << :before_publish
+        end
+
+        def after_publish
+          (@log ||= []) << :after_publish
+        end
+      end
+    end
+
+    it "fires generic → specific before the write and specific → generic after, only for the matching event" do
+      ticket = klass.create!
+      ticket.publish!
+      expect(ticket.log).to eq(
+        [[:before_transition, :publish, "draft", "published"], :before_publish,
+         :after_publish, [:after_transition, :publish, "draft", "published"]]
+      )
+
+      ticket.instance_variable_set(:@log, nil)
+      ticket.archive!
+      expect(ticket.log).to eq(
+        [[:before_transition, :archive, "published", "archived"], [:after_transition, :archive, "published", "archived"]]
+      )
+    end
+
+    it "shares the transaction — a raising after_<event> rolls the state change back" do
+      failing = Class.new(klass) do
+        def after_publish
+          raise "boom"
+        end
+      end
+      ticket = failing.create!
+      expect { ticket.publish! }.to raise_error("boom")
+      expect(ticket.reload.draft?).to be(true)
+    end
+
+    it "uses the affixed event name for the hook (prefix: true → before_status_publish)" do
+      affixed = Class.new(TestModel) do
+        self.table_name = "tickets"
+        include ConcernsOnRails::Stateable
+
+        stateable_by :status, states: %i[draft published], default: :draft, prefix: true,
+                              transitions: { publish: { from: :draft, to: :published } }
+
+        attr_reader :log
+
+        def before_status_publish
+          (@log ||= []) << :before_status_publish
+        end
+
+        def before_publish
+          (@log ||= []) << :wrong_hook
+        end
+      end
+      ticket = affixed.create!
+      ticket.status_publish!
+      expect(ticket.log).to eq([:before_status_publish])
+    end
+
+    it "does not fire for direct setters or transition_to!" do
+      ticket = klass.create!
+      ticket.published!
+      ticket.transition_to!(:archived)
+      expect(ticket.log).to be_nil
+    end
+
+    it "fires once per record through transition_all" do
+      klass.create!
+      klass.create!
+      calls = 0
+      counting = Class.new(klass) do
+        define_method(:after_publish) { calls += 1 }
+      end
+      expect(counting.transition_all(:publish)).to eq(2)
+      expect(calls).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Two things every real state machine grows within a week of adoption:

**1. `timestamps:` — "when did it enter this state?"**

```ruby
stateable_by :status, states: %i[draft review published archived], default: :draft,
             timestamps: true,                        # or %i[published archived]
             transitions: { publish: { from: %i[draft review], to: :published }, archive: { to: :archived } }

article.publish!       # status = "published" AND published_at = Time.current — one update!
article.archived!      # direct setters, transition_to! and transition_all stamp too
```

- Stamps `<state>_at = Time.current` in the **same `update!`** as the state change, so there is no window where the state is set but the stamp is not.
- The default state is **not** stamped on create; re-entering a state re-stamps it and leaves the other stamps alone (`published_at` answers "when was it *last* published").
- Columns are checked at class load with a typed `:datetime` migration hint, **after** the states are validated — a typo in `timestamps: %i[publsihed]` reads as an unknown state, not a missing column.
- `Model.stateable_timestamps` lists the stamped states.

**2. Per-event hooks `before_<event>` / `after_<event>`**

```ruby
def before_publish = check_embargo!
def after_publish  = notify_subscribers
```

- Plain instance methods, looked up by the **affixed** event name (`before_status_publish` with `prefix: true`), skipped when undefined.
- Fire inside the generic pair and the same transaction: `before_transition → before_<event> → write → after_<event> → after_transition`. A raising hook rolls the state change back.
- Like the generic hooks, guarded transitions only — direct setters and `transition_to!` bypass them; `transition_all` fires them once per record.

No behaviour change for models that declare neither.

## Docs

- `README.md` — new "Timestamps and per-event hooks" block in the Stateable section.
- `docs/concerns/stateable.md` — `<state>_at` columns row, `timestamps:` and `lock:` config rows (the latter was undocumented in the table), hook order in the `<event>!` row, two Notes bullets.

## Changelog entry (for `CHANGELOG.md` at release — kept out of this diff so parallel enhancement PRs don't conflict)

```
### Added
- **Models::Stateable**: `stateable_by … timestamps: true` (or a list of
  states) stamps `<state>_at = Time.current` in the same write as the state
  change, for guarded events, direct setters, `transition_to!` and
  `transition_all`; the columns are checked at class load. Per-event hooks
  `before_<event>` / `after_<event>` fire inside the generic
  `before_transition` / `after_transition` pair and the same transaction.
```

## Test plan

- [x] +14 examples: stamping via guarded event, direct setter, `transition_to!` and `transition_all`; default not stamped on create; re-entry re-stamps only that state; a state subset leaves unlisted states unstamped; introspection; missing column → typed hint; unknown state and bad option type rejected. Hook order and event isolation; raising `after_<event>` rolls back; affixed hook name (and the un-affixed one is ignored); setters/`transition_to!` bypass; once per record via `transition_all`.
- [x] Full suite: 1271 examples, 0 failures (98.30%).
- [x] RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
