### PR TITLE
Auditable: gem-wide audit_actor fallback, actor: false opt-out, Symbol actors

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ instead of per controller class:
 # config/initializers/concerns_on_rails.rb
 ConcernsOnRails.setup do |config|
   config.cache_store = -> { Rails.cache }   # fallback for Throttleable / Idempotentable
+  config.audit_actor = -> { Current.user&.id } # fallback "by" for every Auditable model
 end
 
 # Encryptable's key lives in its own config (see the Encryptable section):
@@ -1174,9 +1175,12 @@ class Product < ApplicationRecord
 
   auditable_by :price, :status                       # default column :audit_log
   # auditable_by :price, into: :history,
-  #              actor: -> { Current.user&.email },  # stamps "by" on each entry
+  #              actor: -> { Current.user&.email },  # stamps "by" on each entry (or actor: :updated_by_id)
   #              max_entries: 50                     # keep the newest 50
 end
+
+# Or set the actor once for every audited model — models without actor: use it, actor: false opts out:
+ConcernsOnRails.setup { |config| config.audit_actor = -> { Current.user&.id } }
 
 product.update!(price: 200)
 product.audit_trail
@@ -1188,7 +1192,7 @@ product.clear_audit_trail!                 # wipe the column (skips callbacks)
 
 One entry is recorded **per changed field per save** (creates record `"from" => nil`), appended in the same `INSERT`/`UPDATE` via `before_save` — zero extra queries.
 
-**Options**: `into:` (`:audit_log`), `actor:` (callable, `instance_exec`'d on the record; `"by"` omitted when absent), `max_entries:` (`200`; keeps the newest N, `nil` = unlimited), `max_value_length:` (`nil`; truncates long String `from`/`to` values to the first N characters + `…`).
+**Options**: `into:` (`:audit_log`), `actor:` (a callable `instance_exec`'d on the record, or a Symbol naming a record method such as `:updated_by_id`; defaults to the gem-wide `config.audit_actor`, `false` opts out of it; `"by"` omitted when it resolves to nil), `max_entries:` (`200`; keeps the newest N, `nil` = unlimited), `max_value_length:` (`nil`; truncates long String `from`/`to` values to the first N characters + `…`).
 
 **Notes**
 - Writes that skip callbacks (`update_column(s)`, `touch`, `increment!`) are **not** audited; `save(validate: false)` is.

--- a/docs/concerns/auditable.md
+++ b/docs/concerns/auditable.md
@@ -52,7 +52,7 @@ Configures the tracked fields and the audit column. Every column (tracked fields
 |--------|------|---------|-------------|
 | `*fields` | one or more `Symbol`s | — (required) | The attributes to track. Tracking the audit column itself raises `ArgumentError`. |
 | `into:` | `Symbol` | `:audit_log` | The text column the JSON history is written to. |
-| `actor:` | callable or `nil` | `nil` | Evaluated with `instance_exec` on the record at save time; its return value is stamped as `"by"` on each entry. Must respond to `#call`. |
+| `actor:` | callable, `Symbol`, `false` or `nil` | `nil` (→ gem-wide `config.audit_actor`) | Who is stamped as `"by"`. A callable is `instance_exec`'d on the record at save time; a Symbol names a record method (`:updated_by_id`). `nil` falls back to `ConcernsOnRails.config.audit_actor`, resolved per save; `false` opts this model out of that fallback. Anything else raises `ArgumentError`. |
 | `max_entries:` | positive `Integer` or `nil` | `200` | Keeps only the newest N entries (oldest are trimmed). `nil` disables trimming. |
 | `max_value_length:` | positive `Integer` or `nil` | `nil` | When set, `from`/`to` **String** values longer than the limit are stored as their first N characters plus a trailing `…` marker. Non-string values are never truncated. |
 
@@ -66,7 +66,7 @@ One entry is recorded **per changed tracked field per save**; all entries of one
 
 - Keys are strings; `audit_trail` returns exactly what `JSON.parse` produces.
 - `"at"` is ISO8601 UTC, second precision.
-- `"by"` is **omitted entirely** when no actor is configured or the actor returns `nil`.
+- `"by"` is **omitted entirely** when no actor resolves — none on the model, none gem-wide (or `actor: false`) — or the actor returns `nil`.
 - Values are JSON-coerced: `Time`/`DateTime`/`TimeWithZone` → ISO8601 UTC strings, `Date` → ISO8601, `BigDecimal` → plain numeric string (`"19.99"`, precision-safe), `Symbol` → `String`; everything else passes through `as_json`.
 - There is **no built-in length cap** on `from`/`to` — by default a change to a large text field stores both full values. Set `max_value_length:` to bound entry size explicitly (e.g. `max_value_length: 120` stores `"first 120 chars…"`); truncation runs after coercion and applies only to `String` values.
 
@@ -83,7 +83,18 @@ One entry is recorded **per changed tracked field per save**; all entries of one
 
 ### Class-level configuration readers
 
-`auditable_fields`, `auditable_into`, `auditable_actor`, `auditable_max_entries`.
+`auditable_fields`, `auditable_into`, `auditable_actor` (`nil` when relying on the gem-wide fallback, `false` when opted out), `auditable_max_entries`.
+
+### Gem-wide actor
+
+```ruby
+# config/initializers/concerns_on_rails.rb
+ConcernsOnRails.setup do |config|
+  config.audit_actor = -> { Current.user&.id }   # must respond to #call; instance_exec'd on the record
+end
+```
+
+Every audited model that passes no `actor:` stamps this value; a model-level `actor:` wins, and `actor: false` records no `"by"` for that model. The fallback is read per save, so an initializer that runs after the model loads still applies.
 
 ## Examples
 
@@ -129,7 +140,7 @@ order.audited_changes_since(1.day.ago).map { |e| "#{e['field']}: #{e['from']} �
 - **Not concurrency-safe.** The read-modify-write of the JSON column means two simultaneous saves of the same row are last-writer-wins for the entries added in that race.
 - **Entries build on the persisted trail.** New entries are appended to the column's *database* value, so a save aborted by a later callback can't duplicate entries when retried. The flip side: assigning the audit column by hand in the same save as a tracked change is ignored — use `clear_audit_trail!` to reset the trail.
 - **Non-finite floats are stored as strings.** `NaN`/`Infinity` in a tracked float column serialize as `"NaN"`/`"Infinity"` instead of raising inside `before_save`.
-- **The actor proc runs on the record.** It is `instance_exec`'d, so both globals (`Current.user`) and the record's own attributes are in scope. Exceptions raised inside the proc propagate (fail-fast).
+- **The actor proc runs on the record.** It is `instance_exec`'d — the gem-wide one too — so both globals (`Current.user`) and the record's own attributes are in scope; a Symbol actor is sent to the record. Exceptions raised inside propagate (fail-fast). The resolved value is JSON-coerced like any entry value, so a Hash such as `{ id:, type: }` works.
 - **Non-goals**: no reify/undo, no who-dunnit queries across models, no association tracking — reach for [`paper_trail`](https://github.com/paper-trail-gem/paper_trail) or [`audited`](https://github.com/collectiveidea/audited) when you need a real audit store.
 
 ## Changed in 1.22.0

--- a/lib/concerns_on_rails/configuration.rb
+++ b/lib/concerns_on_rails/configuration.rb
@@ -14,8 +14,23 @@ module ConcernsOnRails
   # #write(expires_in:, unless_exist:) / #delete for idempotency. There is
   # still no in-process default on purpose — a non-atomic store silently
   # under-counts, so the host must opt in explicitly (just once, here).
+  #
+  # `audit_actor` is the fallback actor for Models::Auditable: a callable,
+  # instance_exec'd on the record at save time, whose value is stamped as
+  # "by" on every audit entry of every model that passes no `actor:` of its
+  # own (`auditable_by ..., actor: -> { ... }` still wins; `actor: false` opts
+  # a model out). Typically `-> { Current.user&.id }`.
   class Configuration
     attr_accessor :cache_store
+    attr_reader :audit_actor
+
+    def audit_actor=(value)
+      unless value.nil? || value.respond_to?(:call)
+        raise ArgumentError, "ConcernsOnRails.config.audit_actor must be callable (respond to #call) or nil"
+      end
+
+      @audit_actor = value
+    end
 
     # The fallback store with any callable resolved (per lookup, so a Proc
     # reading Rails.cache follows a swapped-out cache in tests). nil when the

--- a/lib/concerns_on_rails/models/auditable.rb
+++ b/lib/concerns_on_rails/models/auditable.rb
@@ -27,6 +27,12 @@ module ConcernsOnRails
     #   product.audited_changes_since(1.day.ago)
     #   product.clear_audit_trail!                 # wipe the column (skips callbacks)
     #
+    # Actor resolution ("by"): a model's `actor:` (a callable instance_exec'd
+    # on the record, or a Symbol naming a record method) wins; otherwise the
+    # gem-wide fallback `ConcernsOnRails.setup { |c| c.audit_actor = -> {
+    # Current.user&.id } }` applies to every audited model at once; `actor:
+    # false` opts one model out of that fallback.
+    #
     # Notes:
     #   * One entry per changed field per save; creates record `"from" => nil`.
     #     "by" is omitted entirely when no actor is configured (or it returns nil).
@@ -103,7 +109,14 @@ module ConcernsOnRails
           unless positive_integer_or_nil?(max_value_length)
             raise ArgumentError, "#{LABEL}: max_value_length must be a positive Integer or nil"
           end
-          raise ArgumentError, "#{LABEL}: actor must be callable (respond to #call)" unless actor.nil? || actor.respond_to?(:call)
+          return if auditable_valid_actor?(actor)
+
+          raise ArgumentError,
+                "#{LABEL}: actor must be callable (respond to #call), a Symbol naming a record method, nil or false"
+        end
+
+        def auditable_valid_actor?(actor)
+          actor.nil? || actor == false || actor.is_a?(Symbol) || actor.respond_to?(:call)
         end
 
         def positive_integer_or_nil?(value)
@@ -199,11 +212,18 @@ module ConcernsOnRails
         end
       end
 
+      # Model-level actor: first (false = explicitly none), then the gem-wide
+      # fallback, resolved per save so an initializer that runs later still
+      # applies. Symbols call the record's method; callables are instance_exec'd.
       def auditable_resolve_actor
         actor = self.class.auditable_actor
-        return nil unless actor
+        return nil if actor == false
 
-        auditable_json_value(instance_exec(&actor))
+        actor = ConcernsOnRails.config.audit_actor if actor.nil?
+        return nil if actor.nil?
+
+        value = actor.is_a?(Symbol) ? send(actor) : instance_exec(&actor)
+        auditable_json_value(value)
       end
 
       # from/to pipeline: JSON coercion, then opt-in truncation.

--- a/spec/concerns/configuration_spec.rb
+++ b/spec/concerns/configuration_spec.rb
@@ -21,6 +21,15 @@ RSpec.describe "ConcernsOnRails.setup / Configuration" do
     expect(calls).to eq(2)
   end
 
+  it "stores a callable audit_actor (the Auditable fallback) and rejects anything else" do
+    actor = -> { "ops@example.com" }
+    ConcernsOnRails.setup { |config| config.audit_actor = actor }
+    expect(ConcernsOnRails.config.audit_actor).to equal(actor)
+    expect { ConcernsOnRails.config.audit_actor = :not_a_proc }.to raise_error(ArgumentError, /audit_actor must be callable/)
+    ConcernsOnRails.config.audit_actor = nil
+    expect(ConcernsOnRails.config.audit_actor).to be_nil
+  end
+
   it "resolves to nil when nothing is configured" do
     expect(ConcernsOnRails.config.resolved_cache_store).to be_nil
   end

--- a/spec/concerns/models/auditable_spec.rb
+++ b/spec/concerns/models/auditable_spec.rb
@@ -415,4 +415,84 @@ describe ConcernsOnRails::Auditable do
       expect(p.reload.audit_trail.map { |e| e["to"] }).to eq([1])
     end
   end
+  describe "actor defaults (gem-wide audit_actor, actor: false, Symbol actors)" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :audited_docs, force: true do |t|
+          t.string :title
+          t.string :editor_email
+          t.text :audit_log
+        end
+      end
+    end
+
+    after { ConcernsOnRails.config.audit_actor = nil }
+
+    def doc_class(**options)
+      Class.new(TestModel) do
+        self.table_name = "audited_docs"
+        include ConcernsOnRails::Auditable
+
+        auditable_by :title, **options
+      end
+    end
+
+    it "falls back to the gem-wide audit_actor when the model passes no actor:" do
+      ConcernsOnRails.setup { |c| c.audit_actor = -> { "system@example.com" } }
+      doc = doc_class.create!(title: "a")
+      expect(doc.audit_trail.last["by"]).to eq("system@example.com")
+    end
+
+    it "instance_execs the gem-wide actor on the record (record attributes and globals in scope)" do
+      ConcernsOnRails.setup { |c| c.audit_actor = -> { editor_email } }
+      doc = doc_class.create!(title: "a", editor_email: "e@x.com")
+      expect(doc.audit_trail.last["by"]).to eq("e@x.com")
+    end
+
+    it "lets a model-level actor: win over the gem-wide default" do
+      ConcernsOnRails.setup { |c| c.audit_actor = -> { "global" } }
+      doc = doc_class(actor: -> { "local" }).create!(title: "a")
+      expect(doc.audit_trail.last["by"]).to eq("local")
+    end
+
+    it "actor: false opts one model out of the gem-wide default" do
+      ConcernsOnRails.setup { |c| c.audit_actor = -> { "global" } }
+      doc = doc_class(actor: false).create!(title: "a")
+      expect(doc.audit_trail.last).not_to have_key("by")
+      expect(doc.class.auditable_actor).to be(false)
+    end
+
+    it "actor: with a Symbol calls that method on the record (by omitted when it returns nil)" do
+      doc = doc_class(actor: :editor_email).create!(title: "a", editor_email: "sym@x.com")
+      expect(doc.audit_trail.last["by"]).to eq("sym@x.com")
+
+      blank = doc_class(actor: :editor_email).create!(title: "b")
+      expect(blank.audit_trail.last).not_to have_key("by")
+    end
+
+    it "resolves the gem-wide actor lazily, per save" do
+      doc = doc_class.create!(title: "a")
+      expect(doc.audit_trail.last).not_to have_key("by")
+
+      ConcernsOnRails.setup { |c| c.audit_actor = -> { "later" } }
+      doc.update!(title: "b")
+      expect(doc.audit_trail.last["by"]).to eq("later")
+    end
+
+    it "JSON-coerces the resolved actor (a Hash of ids is fine)" do
+      ConcernsOnRails.setup { |c| c.audit_actor = -> { { id: 7, type: :User } } }
+      doc = doc_class.create!(title: "a")
+      expect(doc.audit_trail.last["by"]).to eq("id" => 7, "type" => "User")
+    end
+
+    it "rejects an actor: that is neither callable, a Symbol, nil nor false" do
+      expect { doc_class(actor: "nope") }.to raise_error(ArgumentError, /actor must be callable.*Symbol.*nil or false/)
+    end
+
+    it "rejects a non-callable gem-wide audit_actor when it is set" do
+      expect { ConcernsOnRails.setup { |c| c.audit_actor = "nope" } }
+        .to raise_error(ArgumentError, /audit_actor must be callable/)
+      expect(ConcernsOnRails.config.audit_actor).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Every audited model had to repeat `actor: -> { Current.user&.email }`, and a model that forgot it silently recorded entries with no `"by"`. Real apps have **one** actor source, so it can now be set once:

```ruby
# config/initializers/concerns_on_rails.rb
ConcernsOnRails.setup do |config|
  config.cache_store = -> { Rails.cache }
  config.audit_actor = -> { Current.user&.id }   # fallback "by" for every Auditable model
end

class Product < ApplicationRecord
  auditable_by :price, :status                  # uses the gem-wide actor
end
class ImportRow < ApplicationRecord
  auditable_by :status, actor: false            # explicitly no "by" for this model
end
class Invoice < ApplicationRecord
  auditable_by :total_cents, actor: :updated_by_id   # a record method / column
end
```

- **`config.audit_actor`** — the fallback for every model that passes no `actor:` (the `cache_store` pattern: class-level wins). Read **per save**, so an initializer that runs after the model class loads still applies; `instance_exec`'d on the record exactly like a model-level actor. Setting a non-callable raises at configuration time.
- **`actor: false`** opts one model out of the fallback.
- **`actor: :symbol`** calls that method on the record — the common "we already store who edited it" case; `"by"` is omitted when it returns `nil`.
- The resolved value is JSON-coerced like any entry value, so `-> { { id: Current.user.id, type: "User" } }` works.
- Validation: an `actor:` that is neither callable, Symbol, `nil` nor `false` raises at class load (the existing "actor must be callable" wording is preserved for anyone matching on it).

No behaviour change for apps that configure nothing.

## Docs

- `README.md` — the `ConcernsOnRails.setup` block gains `audit_actor`; the Auditable example and Options line cover the fallback, `false` and Symbols.
- `docs/concerns/auditable.md` — `actor:` row, the `"by"` note, a new "Gem-wide actor" section, the actor-proc note.

## Changelog entry (for `CHANGELOG.md` at release — kept out of this diff so parallel enhancement PRs don't conflict)

```
### Added
- **Models::Auditable**: `ConcernsOnRails.setup { |c| c.audit_actor = -> {
  Current.user&.id } }` sets the `"by"` actor once for every audited model that
  passes no `actor:` (resolved per save, `instance_exec`'d on the record);
  `actor: false` opts a model out, and `actor: :method_name` stamps a record
  method's value. A non-callable `audit_actor` raises when set.
```

## Test plan

- [x] +9 Auditable examples: fallback used; fallback `instance_exec`'d on the record; model-level `actor:` wins; `actor: false` opts out (and is exposed via `auditable_actor`); Symbol actor with a value and with `nil` (no `"by"`); lazy per-save resolution; Hash coercion; `actor: "nope"` and `audit_actor = "nope"` rejected. +1 Configuration example (round trip, rejection, reset to nil).
- [x] Full suite: 1267 examples, 0 failures (98.35%).
- [x] RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
