### PR TITLE
Tokenizable: expires_in: (expiring tokens) and consume_<field> (race-safe single use)

### DIFF
--- a/README.md
+++ b/README.md
@@ -786,19 +786,22 @@ class User < ApplicationRecord
   include ConcernsOnRails::Tokenizable
 
   tokenizable_by :api_token                                  # 32-char URL-safe
-  tokenizable_by :reset_password_token, length: 24
+  tokenizable_by :reset_password_token, length: 24, expires_in: 2.hours   # needs reset_password_token_expires_at
   tokenizable_by :invite_code, type: :alphanumeric, length: 8
 end
 
-user = User.create!                       # all three tokens auto-generated
+user = User.create!                       # all three tokens auto-generated (+ the reset token's expiry stamped)
 user.api_token                            # => "k3Jf...g2" (32 URL-safe chars)
 user.api_token?                           # => true
+user.reset_password_token_expired?        # => false, until reset_password_token_expires_at passes
 
-user.regenerate_api_token!                # rotates and persists
-user.revoke_api_token!                    # nils the column
+user.regenerate_api_token!                # rotates and persists (an expiring field gets a fresh expiry too)
+user.revoke_api_token!                    # nils the column (and the expiry)
 
 User.find_by_api_token(token)             # Rails default
-User.authenticate_by_api_token(token)     # timing-safe; returns user or nil
+User.authenticate_by_api_token(token)     # timing-safe; returns user or nil — nil for an EXPIRED token
+User.consume_reset_password_token(token)  # single use: authenticate AND revoke atomically; nil the second time
+User.reset_password_token_expired         # scope: rows whose expiry has passed (cleanup jobs)
 ```
 
 **Options**
@@ -807,12 +810,15 @@ User.authenticate_by_api_token(token)     # timing-safe; returns user or nil
 | -------- | ----------- | ------------------------------------------------------------- |
 | `type:`  | `:urlsafe`  | One of `:urlsafe`, `:hex`, `:alphanumeric`, `:numeric`        |
 | `length:`| `32`        | Character length of the generated token                       |
+| `expires_in:` | `nil`  | A `Duration`/seconds. Stamps `<field>_expires_at` (a `datetime` column you add) on every generation; `authenticate_by_`/`consume_` refuse a stale token; adds `<field>_expired?` and the `<field>_expired` scope |
 
 **Notes**
 - URL-safe by default (`A–Z`, `a–z`, `0–9`, `-`, `_`) — drop straight into URLs and headers.
 - Caller-supplied values are respected: `User.create!(api_token: "preset")` won't be overwritten.
 - Generation does a best-effort uniqueness check before insert and retries up to 10 times. Pair with a `unique` DB index for real safety, especially for short alphanumeric/numeric codes.
-- `.authenticate_by_<field>` uses `ActiveSupport::SecurityUtils.secure_compare` to avoid leaking partial matches via response timing.
+- `.authenticate_by_<field>` uses `ActiveSupport::SecurityUtils.secure_compare` to avoid leaking partial matches via response timing, and returns `nil` once an `expires_in:` token has expired.
+- `.consume_<field>(value)` (every field) is the single-use verb — password resets, invite codes, magic links: it authenticates, then revokes with a **conditional `UPDATE`** keyed on the token still being present, so two concurrent consumers cannot both succeed; the loser gets `nil`. An expired token is refused and left in place.
+- A caller-supplied token on an `expires_in:` field gets the configured lifetime unless the caller also sets `<field>_expires_at`; a row whose expiry is `nil` never expires.
 - Distinct from `Hashable`: Hashable handles a single random field; Tokenizable focuses on security tokens (multi-field, URL-safe default, timing-safe lookup, revocation).
 
 ---

--- a/docs/concerns/tokenizable.md
+++ b/docs/concerns/tokenizable.md
@@ -29,6 +29,7 @@ Each field passed to `tokenizable_by` must already exist as a string column. Add
 | Column | Type | Required |
 |---|---|---|
 | _(field name, e.g. `api_token`)_ | `string` | Yes |
+| `<field>_expires_at` (e.g. `reset_password_token_expires_at`) | `datetime` | With `expires_in:` | Stamped on every generation, cleared on revoke; checked at class load with a typed migration hint. |
 
 ```ruby
 class AddTokensToUsers < ActiveRecord::Migration[7.1]
@@ -58,6 +59,7 @@ tokenizable_by(field, type: :urlsafe, length: 32)
 | `field` | `Symbol` / `String` | — (required) | The model column that stores the token. Converted to a symbol internally. Must exist in the database schema at class-load time or `ArgumentError` is raised. |
 | `type:` | `Symbol` | `:urlsafe` | Token character set. Valid values: `:urlsafe`, `:hex`, `:alphanumeric`, `:numeric`. Any other value raises `ArgumentError`. |
 | `length:` | `Integer` | `32` | Exact character length of the generated token. Must be a positive integer; `0` or negative raises `ArgumentError`. Converted via `to_i`, so string digits are accepted. |
+| `expires_in:` | `ActiveSupport::Duration` or `Integer` (seconds) | `nil` | Gives the field a lifetime. `<field>_expires_at` is stamped with `Time.current + expires_in` on create, on `regenerate_<field>!`, and for a caller-supplied token that arrives without its own expiry; `revoke_<field>!` clears it. `authenticate_by_<field>` and `consume_<field>` refuse an expired token; `<field>_expired?` and the `<field>_expired` scope report it. Must be positive. |
 
 **Type reference**
 
@@ -70,7 +72,7 @@ tokenizable_by(field, type: :urlsafe, length: 32)
 
 ## Scopes
 
-`Tokenizable` does not add any ActiveRecord scopes. Use Rails' built-in `find_by_<field>` or the concern's `authenticate_by_<field>` class method for lookups.
+One scope per field declared with `expires_in:` — `<field>_expired` (e.g. `User.reset_password_token_expired`): rows whose `<field>_expires_at` is set and has passed, for cleanup jobs (`User.reset_password_token_expired.update_all(reset_password_token: nil, reset_password_token_expires_at: nil)`). Fields without `expires_in:` add no scopes; use Rails' `find_by_<field>` or the concern's `authenticate_by_<field>` for lookups.
 
 ## Methods
 
@@ -83,14 +85,17 @@ For each field declared with `tokenizable_by`, the following instance methods ar
 | `regenerate_api_token!` | Generates a new token value and immediately persists it with `update!`. Overwrites the existing value unconditionally. |
 | `revoke_api_token!` | Sets the column to `nil` and immediately persists the change with `update!`. |
 | `api_token?` | Returns `true` if the column value is present (non-nil, non-blank), `false` otherwise. |
+| `api_token_expired?` | `true` once `api_token_expires_at` has been reached. Always `false` for a field without `expires_in:`, or when the expiry is `nil`. |
 
 ### Class methods
 
 | Method | Description |
 |---|---|
-| `tokenizable_by(field, type:, length:)` | Configuration macro. Registers the field, validates options, installs a `before_create` callback, and defines all helper methods for that field. |
+| `tokenizable_by(field, type:, length:, expires_in:)` | Configuration macro. Registers the field, validates options, installs a `before_create` callback, and defines all helper methods for that field. |
 | `generate_tokenizable_value(field)` | Generates and returns a new random value for the given field using its registered type and length. Raises `ArgumentError` if `field` is not a registered tokenizable field. |
-| `authenticate_by_api_token(value)` | _(one per field)_ Looks up a record by the token column and performs a constant-time comparison using `ActiveSupport::SecurityUtils.secure_compare`. Returns the matching record or `nil`. Returns `nil` immediately for blank input. |
+| `authenticate_by_api_token(value)` | _(one per field)_ Looks up a record by the token column and performs a constant-time comparison using `ActiveSupport::SecurityUtils.secure_compare`. Returns the matching record or `nil`. Returns `nil` immediately for blank input, and for an expired token on an `expires_in:` field. |
+| `consume_api_token(value)` | _(one per field)_ Single use: `authenticate_by_api_token`, then revoke the token (and its expiry) with a conditional `UPDATE … WHERE id = ? AND api_token = ?`. Returns the reloaded record when exactly one row was revoked, otherwise `nil` — so two concurrent consumers cannot both win, and an expired or wrong token is refused and left untouched. |
+| `tokenizable_expiry_column(field)` | `:<field>_expires_at`. |
 
 ## Examples
 
@@ -158,6 +163,8 @@ device2.pin  # => "847203" (random 6-digit string)
 
 ## Notes & gotchas
 
+- **Expiry is checked in Ruby, revocation in SQL.** `authenticate_by_<field>` compares `<field>_expires_at` against `Time.current` on the fetched row (so time travel in tests works); `consume_<field>` then revokes with a single conditional `UPDATE`, which is what makes it safe under concurrency — the second consumer's `UPDATE` matches 0 rows and returns `nil`. Wrap nothing in a transaction yourself.
+- **A `nil` expiry never expires.** Only rows whose `<field>_expires_at` is set are ever considered expired; a token you created before adding `expires_in:` keeps working until regenerated (which stamps it) or revoked.
 - **Column must exist at class load time.** `tokenizable_by` calls `ensure_columns!` immediately when the macro is evaluated. If the migration has not been run, Rails will raise `ArgumentError: '...' does not exist in the database (table: ...)` as soon as the class is loaded, not at runtime.
 - **Caller-supplied values are preserved.** The `before_create` callback calls `assign_tokenizable_value` only when the column is blank. `User.create!(api_token: "preset")` will store `"preset"` unchanged.
 - **Tokens are generated on `create` only.** There is no `before_save` or `before_update` callback. Tokens do not rotate automatically on update; call `regenerate_<field>!` explicitly when rotation is needed.

--- a/docs/concerns/tokenizable.md
+++ b/docs/concerns/tokenizable.md
@@ -51,7 +51,7 @@ end
 Call `tokenizable_by` once per token field. Multiple calls on the same model are additive and do not interfere with one another.
 
 ```ruby
-tokenizable_by(field, type: :urlsafe, length: 32)
+tokenizable_by(field, type: :urlsafe, length: 32, expires_in: nil)
 ```
 
 | Option | Type | Default | Description |

--- a/lib/concerns_on_rails/models/duplicable.rb
+++ b/lib/concerns_on_rails/models/duplicable.rb
@@ -161,10 +161,22 @@ module ConcernsOnRails
       def duplicable_generator_columns
         columns = []
         columns << self.class.friendly_id_config.slug_column if duplicable_concern?(Sluggable)
-        columns.concat(self.class.tokenizable_fields.keys) if duplicable_concern?(Tokenizable)
+        columns.concat(duplicable_token_columns) if duplicable_concern?(Tokenizable)
         columns << self.class.hashable_field if duplicable_concern?(Hashable) && self.class.hashable_field
         columns.concat(duplicable_sequence_columns) if duplicable_concern?(Sequenceable)
         columns
+      end
+
+      # A token and its `expires_in:` stamp must be cleared together. Blanking
+      # only the token leaves the copy with a fresh secret carrying the
+      # original's expiry — often already in the past, so the copy's token is
+      # born dead.
+      def duplicable_token_columns
+        self.class.tokenizable_fields.flat_map do |field, config|
+          next field unless config[:expires_in]
+
+          [field, self.class.tokenizable_expiry_column(field)]
+        end
       end
 
       def duplicable_sequence_columns

--- a/lib/concerns_on_rails/models/tokenizable.rb
+++ b/lib/concerns_on_rails/models/tokenizable.rb
@@ -13,7 +13,7 @@ module ConcernsOnRails
     #     include ConcernsOnRails::Tokenizable
     #
     #     tokenizable_by :api_token                              # 32-char URL-safe
-    #     tokenizable_by :reset_password_token, length: 24
+    #     tokenizable_by :reset_password_token, length: 24, expires_in: 2.hours
     #     tokenizable_by :invite_code, type: :alphanumeric, length: 8
     #   end
     #
@@ -24,6 +24,16 @@ module ConcernsOnRails
     #
     #   User.find_by_api_token(token)             # Rails default
     #   User.authenticate_by_api_token(token)     # constant-time compare; returns record or nil
+    #   User.consume_invite_code(code)            # authenticate AND revoke in one step (single use)
+    #
+    # `expires_in:` gives a field a lifetime: `<field>_expires_at` (a datetime
+    # column you add) is stamped whenever the token is generated — on create,
+    # on regenerate_<field>!, and for a caller-supplied token that arrives
+    # without its own expiry — and cleared by revoke_<field>!.
+    # `authenticate_by_<field>` / `consume_<field>` refuse an expired token,
+    # `<field>_expired?` reports it, and the `<field>_expired` scope finds rows
+    # for cleanup. `consume_<field>` (every field) revokes with a conditional
+    # UPDATE, so two concurrent consumers cannot both win.
     #
     # Unlike Hashable, one model can declare multiple token fields, generation is
     # URL-safe by default, and `assign_tokenizable_value` retries on uniqueness
@@ -34,6 +44,7 @@ module ConcernsOnRails
     module Tokenizable
       extend ActiveSupport::Concern
 
+      LABEL = "ConcernsOnRails::Models::Tokenizable".freeze
       VALID_TYPES = %i[urlsafe hex alphanumeric numeric].freeze
       ALPHANUMERIC_ALPHABET = (("A".."Z").to_a + ("a".."z").to_a + ("0".."9").to_a).freeze
       NUMERIC_ALPHABET = ("0".."9").to_a.freeze
@@ -43,34 +54,38 @@ module ConcernsOnRails
         class_attribute :tokenizable_fields, instance_accessor: false, default: {}
       end
 
-      class_methods do
+      module ClassMethods
         include ConcernsOnRails::Support::ColumnGuard
 
         # Configure a tokenizable field.
         #
         # Options:
-        #   type:   one of :urlsafe (default), :hex, :alphanumeric, :numeric
-        #   length: character length of the generated token (default 32)
-        def tokenizable_by(field, type: :urlsafe, length: 32)
+        #   type:       one of :urlsafe (default), :hex, :alphanumeric, :numeric
+        #   length:     character length of the generated token (default 32)
+        #   expires_in: a Duration / seconds — stamps `<field>_expires_at` on
+        #               generation and makes authenticate/consume refuse stale tokens
+        def tokenizable_by(field, type: :urlsafe, length: 32, expires_in: nil)
           field = field.to_sym
           type = type.to_sym
           length = length.to_i
+          expires_in = validate_tokenizable_options!(type, length, expires_in)
 
-          ensure_columns!("ConcernsOnRails::Models::Tokenizable", field, types: "string:uniq")
-          validate_tokenizable_options!(type, length)
+          ensure_columns!(LABEL, field, types: "string:uniq")
+          ensure_columns!(LABEL, tokenizable_expiry_column(field), types: :datetime) if expires_in
 
           # Build a fresh hash so subclasses don't mutate the parent's config.
-          self.tokenizable_fields = tokenizable_fields.merge(field => { type: type, length: length })
+          self.tokenizable_fields = tokenizable_fields.merge(field => { type: type, length: length, expires_in: expires_in })
 
           before_create -> { assign_tokenizable_value(field) }
 
           define_tokenizable_methods(field)
+          define_tokenizable_expiry_methods(field) if expires_in
         end
 
         # Generate a new random value for the given field using its configured type/length.
         def generate_tokenizable_value(field)
           config = tokenizable_fields.fetch(field) do
-            raise ArgumentError, "ConcernsOnRails::Models::Tokenizable: '#{field}' is not a tokenizable field"
+            raise ArgumentError, "#{LABEL}: '#{field}' is not a tokenizable field"
           end
 
           length = config[:length]
@@ -82,9 +97,12 @@ module ConcernsOnRails
           when :numeric      then ConcernsOnRails::Support::RandomValue.from_alphabet(NUMERIC_ALPHABET, length)
           end
         end
-      end
 
-      class_methods do
+        # `<field>_expires_at` — the column an `expires_in:` field stamps.
+        def tokenizable_expiry_column(field)
+          :"#{field}_expires_at"
+        end
+
         private
 
         def define_tokenizable_methods(field)
@@ -93,18 +111,26 @@ module ConcernsOnRails
           # straight into RecordNotUnique with no retry).
           define_method("regenerate_#{field}!") do
             ConcernsOnRails::Support::UniqueRetry.with_retries(limit: MAX_GENERATION_ATTEMPTS) do
-              update!(field => tokenizable_unique_value(field))
+              update!(tokenizable_generated_attributes(field))
             end
           end
-          define_method("revoke_#{field}!")     { update!(field => nil) }
+          define_method("revoke_#{field}!")     { update!(tokenizable_revoked_attributes(field)) }
           define_method("#{field}?")            { self[field].present? }
+          define_method("#{field}_expired?")    { tokenizable_expired?(field) }
           define_singleton_method("authenticate_by_#{field}") { |value| timing_safe_find(field, value) }
+          define_singleton_method("consume_#{field}") { |value| consume_tokenizable_value(field, value) }
+        end
+
+        def define_tokenizable_expiry_methods(field)
+          column = tokenizable_expiry_column(field)
+          scope :"#{field}_expired", -> { where.not(column => nil).where(arel_table[column].lteq(Time.current)) }
         end
 
         # NOTE: the find_by below is an indexed SQL equality, which is not itself
         # timing-safe; secure_compare only hardens the in-Ruby comparison of the
         # already-fetched candidate. For a truly constant-time lookup, store and
-        # query a digest instead of the raw token.
+        # query a digest instead of the raw token. An expired token never
+        # authenticates.
         def timing_safe_find(field, value)
           return nil if value.blank?
 
@@ -114,31 +140,41 @@ module ConcernsOnRails
           stored = candidate[field].to_s
           given = value.to_s
           return nil unless stored.bytesize == given.bytesize
+          return nil unless ActiveSupport::SecurityUtils.secure_compare(stored, given)
 
-          ActiveSupport::SecurityUtils.secure_compare(stored, given) ? candidate : nil
+          candidate.public_send("#{field}_expired?") ? nil : candidate
+        end
+
+        # Single use: authenticate, then revoke with a conditional UPDATE keyed
+        # on the token still being there — if a concurrent consumer got in
+        # first, the UPDATE touches 0 rows and this call returns nil.
+        def consume_tokenizable_value(field, value)
+          record = public_send("authenticate_by_#{field}", value)
+          return nil unless record
+
+          revoked = unscoped.where(primary_key => record.id, field => value)
+                            .update_all(record.send(:tokenizable_revoked_attributes, field))
+          revoked == 1 ? record.reload : nil
+        end
+
+        def validate_tokenizable_options!(type, length, expires_in)
+          raise ArgumentError, "#{LABEL}: unknown type '#{type}'. Valid types: #{VALID_TYPES.join(', ')}" unless VALID_TYPES.include?(type)
+          raise ArgumentError, "#{LABEL}: length must be a positive integer" unless length.positive?
+          return nil if expires_in.nil?
+          return expires_in.to_i if expires_in.respond_to?(:to_i) && expires_in.to_i.positive?
+
+          raise ArgumentError, "#{LABEL}: expires_in must be a positive Duration or number of seconds"
         end
       end
 
-      class_methods do
-        def validate_tokenizable_options!(type, length)
-          unless VALID_TYPES.include?(type)
-            raise ArgumentError,
-                  "ConcernsOnRails::Models::Tokenizable: unknown type '#{type}'. Valid types: #{VALID_TYPES.join(', ')}"
-          end
-
-          return if length.positive?
-
-          raise ArgumentError, "ConcernsOnRails::Models::Tokenizable: length must be a positive integer"
-        end
-
-        private :validate_tokenizable_options!
-      end
-
-      # Assigns the generated value only when blank, so callers can pass an explicit one.
+      # Assigns the generated value only when blank, so callers can pass an
+      # explicit one; an `expires_in:` field also gets its expiry stamped when
+      # the caller didn't set one.
       def assign_tokenizable_value(field)
-        return if self[field].present?
+        self[field] = tokenizable_unique_value(field) if self[field].blank?
 
-        self[field] = tokenizable_unique_value(field)
+        column = tokenizable_expiry_column_for(field)
+        self[column] = tokenizable_expiry_from_now(field) if column && self[field].present? && self[column].blank?
       end
 
       # Generate → in-Ruby exists? precheck → retry, up to MAX_GENERATION_ATTEMPTS
@@ -150,8 +186,45 @@ module ConcernsOnRails
           return candidate unless self.class.unscoped.exists?(field => candidate)
         end
 
-        raise "ConcernsOnRails::Models::Tokenizable: could not generate a unique value for '#{field}' " \
+        raise "#{LABEL}: could not generate a unique value for '#{field}' " \
               "after #{MAX_GENERATION_ATTEMPTS} attempts — consider a longer length or a larger alphabet"
+      end
+
+      private
+
+      # A fresh token plus, for an expiring field, a fresh expiry.
+      def tokenizable_generated_attributes(field)
+        attributes = { field => tokenizable_unique_value(field) }
+        column = tokenizable_expiry_column_for(field)
+        attributes[column] = tokenizable_expiry_from_now(field) if column
+        attributes
+      end
+
+      def tokenizable_revoked_attributes(field)
+        attributes = { field => nil }
+        column = tokenizable_expiry_column_for(field)
+        attributes[column] = nil if column
+        attributes
+      end
+
+      # nil for a field declared without expires_in:.
+      def tokenizable_expiry_column_for(field)
+        config = self.class.tokenizable_fields.fetch(field)
+        config[:expires_in] ? self.class.tokenizable_expiry_column(field) : nil
+      end
+
+      def tokenizable_expiry_from_now(field)
+        Time.current + self.class.tokenizable_fields.fetch(field)[:expires_in]
+      end
+
+      # True only for an expiring field whose expiry has been reached; a field
+      # without expires_in:, or a row with no expiry set, never expires.
+      def tokenizable_expired?(field)
+        column = tokenizable_expiry_column_for(field)
+        return false unless column
+
+        expires_at = self[column]
+        expires_at.present? && expires_at <= Time.current
       end
     end
   end

--- a/spec/concerns/models/duplicable_spec.rb
+++ b/spec/concerns/models/duplicable_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe ConcernsOnRails::Models::Duplicable do
         t.integer :sequence
         t.string :number
         t.string :token
+        t.datetime :token_expires_at
         t.datetime :issued_at
         t.datetime :deleted_at
         t.text :audit_log
@@ -236,7 +237,7 @@ RSpec.describe ConcernsOnRails::Models::Duplicable do
         include ConcernsOnRails::Models::SoftDeletable
         include ConcernsOnRails::Models::Lockable
 
-        tokenizable_by :token, type: :hex, length: 12
+        tokenizable_by :token, type: :hex, length: 12, expires_in: 1.hour
         sequenceable_by :sequence, into: :number, prefix: "INV-"
         auditable_by :title, into: :audit_log
         soft_deletable_by :deleted_at, default_scope: false
@@ -252,6 +253,19 @@ RSpec.describe ConcernsOnRails::Models::Duplicable do
       expect(copy.token).not_to eq(original.token)
       expect(copy.sequence).to eq(original.sequence + 1)
       expect(copy.number).to eq("INV-#{copy.sequence}")
+    end
+
+    it "gives the copy's token a fresh expiry instead of inheriting the original's" do
+      original = travel_to(Time.utc(2026, 1, 1, 10)) { klass.create!(title: "Q1") }
+      expect(original.token_expires_at).to eq(Time.utc(2026, 1, 1, 11))
+
+      # Without clearing the stamp alongside the token, the copy would carry a
+      # brand-new secret that expired five months ago.
+      travel_to(Time.utc(2026, 6, 1, 10)) do
+        copy = original.duplicate!
+        expect(copy.token_expires_at).to eq(Time.utc(2026, 6, 1, 11))
+        expect(copy.token_expired?).to be(false)
+      end
     end
 
     it "does not inherit the original's audit history (only the copy's own creation entry)" do

--- a/spec/concerns/models/tokenizable_spec.rb
+++ b/spec/concerns/models/tokenizable_spec.rb
@@ -228,4 +228,141 @@ describe ConcernsOnRails::Tokenizable do
       end.to raise_error(ArgumentError, /length must be a positive integer/)
     end
   end
+  describe "expires_in: (expiring tokens) and consume_<field> (single use)" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :reset_accounts, force: true do |t|
+          t.string :email
+          t.string :reset_token
+          t.datetime :reset_token_expires_at
+          t.string :invite_code
+        end
+      end
+    end
+
+    let(:klass) do
+      Class.new(TestModel) do
+        self.table_name = "reset_accounts"
+        include ConcernsOnRails::Tokenizable
+
+        tokenizable_by :reset_token, length: 24, expires_in: 2.hours
+        tokenizable_by :invite_code, type: :alphanumeric, length: 8
+      end
+    end
+
+    it "stamps <field>_expires_at on create and on regenerate" do
+      account = travel_to(Time.utc(2026, 5, 1, 10)) { klass.create!(email: "a@x.com") }
+      expect(account.reset_token_expires_at).to eq(Time.utc(2026, 5, 1, 12))
+
+      travel_to(Time.utc(2026, 5, 2, 10)) { account.regenerate_reset_token! }
+      expect(account.reload.reset_token_expires_at).to eq(Time.utc(2026, 5, 2, 12))
+    end
+
+    it "gives a caller-supplied token the configured lifetime unless the caller also set an expiry" do
+      supplied = travel_to(Time.utc(2026, 5, 1, 10)) { klass.create!(reset_token: "preset-token-value-12345") }
+      expect(supplied.reset_token).to eq("preset-token-value-12345")
+      expect(supplied.reset_token_expires_at).to eq(Time.utc(2026, 5, 1, 12))
+
+      explicit = klass.create!(reset_token: "another-preset-token-123", reset_token_expires_at: Time.utc(2030, 1, 1))
+      expect(explicit.reset_token_expires_at).to eq(Time.utc(2030, 1, 1))
+    end
+
+    it "revoke_<field>! clears the expiry too" do
+      account = klass.create!
+      account.revoke_reset_token!
+      account.reload
+      expect(account.reset_token).to be_nil
+      expect(account.reset_token_expires_at).to be_nil
+    end
+
+    it "<field>_expired? flips at the boundary; a token without an expiry never expires" do
+      account = travel_to(Time.utc(2026, 5, 1, 10)) { klass.create! }
+      travel_to(Time.utc(2026, 5, 1, 11, 59)) { expect(account.reset_token_expired?).to be(false) }
+      travel_to(Time.utc(2026, 5, 1, 12)) { expect(account.reset_token_expired?).to be(true) }
+
+      account.update_columns(reset_token_expires_at: nil)
+      travel_to(Time.utc(2030, 1, 1)) { expect(account.reset_token_expired?).to be(false) }
+      expect(klass.create!.invite_code_expired?).to be(false) # field without expires_in:
+    end
+
+    it "authenticate_by_<field> refuses an expired token" do
+      account = travel_to(Time.utc(2026, 5, 1, 10)) { klass.create! }
+      travel_to(Time.utc(2026, 5, 1, 11)) { expect(klass.authenticate_by_reset_token(account.reset_token)).to eq(account) }
+      travel_to(Time.utc(2026, 5, 1, 13)) { expect(klass.authenticate_by_reset_token(account.reset_token)).to be_nil }
+    end
+
+    it "consume_<field> authenticates once and revokes the token (single use)" do
+      account = klass.create!
+      token = account.reset_token
+      consumed = klass.consume_reset_token(token)
+      expect(consumed).to eq(account)
+      expect(consumed.reset_token).to be_nil
+      expect(consumed.reset_token_expires_at).to be_nil
+      expect(klass.consume_reset_token(token)).to be_nil
+      expect(klass.authenticate_by_reset_token(token)).to be_nil
+    end
+
+    it "consume_<field> is atomic — the row is revoked with a conditional UPDATE, so a second consumer loses" do
+      account = klass.create!
+      token = account.reset_token
+      # Simulate the race: someone else consumed it between our authenticate and our UPDATE.
+      allow(klass).to receive(:authenticate_by_reset_token).and_wrap_original do |original, value|
+        record = original.call(value)
+        klass.where(id: record.id).update_all(reset_token: nil, reset_token_expires_at: nil) if record
+        record
+      end
+      expect(klass.consume_reset_token(token)).to be_nil
+    end
+
+    it "consume_<field> returns nil for a wrong, blank or expired token" do
+      account = travel_to(Time.utc(2026, 5, 1, 10)) { klass.create! }
+      expect(klass.consume_reset_token("nope")).to be_nil
+      expect(klass.consume_reset_token(nil)).to be_nil
+      travel_to(Time.utc(2026, 5, 1, 13)) { expect(klass.consume_reset_token(account.reset_token)).to be_nil }
+      expect(account.reload.reset_token).to be_present # an expired token is not consumed
+    end
+
+    it "consume_<field> works for fields without expires_in: (invite codes)" do
+      account = klass.create!
+      expect(klass.consume_invite_code(account.invite_code)).to eq(account)
+      expect(account.reload.invite_code).to be_nil
+    end
+
+    it "defines an <field>_expired scope for cleanup" do
+      stale = travel_to(Time.utc(2026, 5, 1, 10)) { klass.create! }
+      fresh = klass.create!
+      travel_to(Time.utc(2026, 5, 1, 13)) do
+        expect(klass.reset_token_expired).to eq([stale])
+        expect(klass.reset_token_expired).not_to include(fresh)
+      end
+      expect(klass).not_to respond_to(:invite_code_expired)
+    end
+
+    it "records expires_in (seconds) in the field config" do
+      expect(klass.tokenizable_fields[:reset_token]).to include(expires_in: 7200)
+      expect(klass.tokenizable_fields[:invite_code]).to include(expires_in: nil)
+    end
+
+    it "requires the <field>_expires_at column with a typed migration hint" do
+      expect do
+        Class.new(TestModel) do
+          self.table_name = "reset_accounts"
+          include ConcernsOnRails::Tokenizable
+
+          tokenizable_by :invite_code, expires_in: 1.day
+        end
+      end.to raise_error(ArgumentError, /invite_code_expires_at.*does not exist.*invite_code_expires_at:datetime/)
+    end
+
+    it "rejects a non-positive expires_in:" do
+      expect do
+        Class.new(TestModel) do
+          self.table_name = "reset_accounts"
+          include ConcernsOnRails::Tokenizable
+
+          tokenizable_by :reset_token, expires_in: 0
+        end
+      end.to raise_error(ArgumentError, /expires_in must be a positive Duration or number of seconds/)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Password resets, magic links and invite codes are tokens that must **stop working after a while** and **work exactly once**. Both were left to the host app. Now:

```ruby
tokenizable_by :reset_password_token, length: 24, expires_in: 2.hours   # needs reset_password_token_expires_at (datetime)
tokenizable_by :invite_code, type: :alphanumeric, length: 8

User.authenticate_by_reset_password_token(token)   # nil once expired
User.consume_reset_password_token(token)           # authenticate AND revoke atomically; nil the second time
User.consume_invite_code(code)                     # single use works for any field
User.reset_password_token_expired                  # scope for cleanup jobs
user.reset_password_token_expired?
```

**`expires_in:`**
- Stamps `<field>_expires_at = Time.current + expires_in` on create, on `regenerate_<field>!`, and for a caller-supplied token that arrives without its own expiry (a caller-set expiry is respected); `revoke_<field>!` clears it. The column is checked at class load with a typed migration hint.
- `authenticate_by_<field>` returns `nil` for an expired token — the security half. `<field>_expired?` reports it; a `nil` expiry (rows from before the option existed) never expires; a field without `expires_in:` is never expired.
- `<field>_expired` scope: rows whose expiry has passed.

**`consume_<field>(value)`** — defined for every field:
- Authenticates (constant-time compare, expiry-aware), then revokes token + expiry with a **conditional `UPDATE … WHERE id = ? AND <field> = ?`**. Returns the reloaded record only when exactly one row was revoked, so two concurrent consumers cannot both win — the loser gets `nil`. An expired or wrong token is refused and left untouched.

Internals: the three `class_methods do` blocks became one `module ClassMethods` (Stateable precedent) and the label became a constant. No behaviour change for existing fields beyond gaining `consume_<field>` and `<field>_expired?` (always `false` without `expires_in:`).

## Docs

- `README.md` — example block, `expires_in:` option row, three Notes bullets.
- `docs/concerns/tokenizable.md` — columns row, `expires_in:` config row, Scopes section, `<field>_expired?` / `consume_<field>` / `tokenizable_expiry_column` rows, two Notes bullets.

## Changelog entry (for `CHANGELOG.md` at release — kept out of this diff so parallel enhancement PRs don't conflict)

```
### Added
- **Models::Tokenizable**: `tokenizable_by … expires_in:` gives a token a
  lifetime — `<field>_expires_at` is stamped on every generation,
  `authenticate_by_<field>` refuses an expired token, `<field>_expired?` and
  the `<field>_expired` scope report it. New `consume_<field>(value)` (every
  field) authenticates and revokes in one race-safe step for single-use
  tokens (password resets, magic links, invite codes).
```

## Test plan

- [x] +13 examples: stamping on create and regenerate; caller-supplied token gets the lifetime, caller-set expiry respected; revoke clears both; `expired?` at the boundary, with a `nil` expiry and on a non-expiring field; `authenticate_by_` refuses expired; consume happy path and second call `nil`; the race (a stubbed interleaving revokes between authenticate and UPDATE → `nil`); wrong/blank/expired refused and left in place; consume on a non-expiring field; the scope (and its absence on non-expiring fields); config introspection; column requirement with typed hint; non-positive `expires_in:` rejected.
- [x] Full suite: 1270 examples, 0 failures (98.34%).
- [x] RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
