### PR TITLE
Localizable: Content-Language response header + Vary: Accept-Language

### DIFF
--- a/README.md
+++ b/README.md
@@ -1748,7 +1748,9 @@ end
 
 Resolution order: `params[param]` → first match in `Accept-Language` → `default` → `I18n.default_locale`. The chosen locale is always validated against `I18n.available_locales`, so a stray param or a mismatched `available:` list can never raise `I18n::InvalidLocale`.
 
-**Options**: `available:` (allow-list for matching; defaults to `I18n.available_locales`), `default:`, `param:` (default `:locale`), `header:` (default `true`).
+Every response carries **`Content-Language: <resolved locale>`** (BCP 47 form — `pt_BR` → `pt-BR`) and, when `Accept-Language` is a locale source, **`Vary: Accept-Language`** appended to any existing `Vary` (de-duplicated) so shared caches key on the header. Both are written *before* the action runs, so a `rescue_from`-rendered error still carries them; `response_headers: false` turns them off.
+
+**Options**: `available:` (allow-list for matching; defaults to `I18n.available_locales`), `default:`, `param:` (default `:locale`), `header:` (default `true`), `response_headers:` (default `true`).
 
 ---
 

--- a/docs/concerns/localizable.md
+++ b/docs/concerns/localizable.md
@@ -105,6 +105,7 @@ end
 ## Notes & gotchas
 
 - **`Content-Language` and `Vary` are on by default.** A localized JSON body is a different representation per locale; without `Vary: Accept-Language` a shared cache (CDN, `Rack::Cache`) would serve one client's French to another's English. The headers are written before the action, so they ride a rescued error too. If you localize only via a URL param, pass `header: false` and `Vary` is skipped (the URL already differs); `response_headers: false` disables both.
+
 **Resolution order.** The concern resolves locale in this priority sequence: `params[param]` → first matching language in `Accept-Language` → `default:` option → `I18n.default_locale`. Each step is attempted only if the previous one produced no match within the allow-list.
 
 **Final validation against `I18n.available_locales`.** Even if a locale passes the `available:` allow-list, `resolved_locale` performs a final check against `I18n.available_locales` before returning. If the two lists fall out of sync (e.g. the `available:` option is set to `[:en, :fr]` but I18n is later reconfigured to only `[:en]`), the resolved `:fr` candidate is discarded and `I18n.default_locale` is returned instead. This means locale resolution is always safe to hand to `I18n.with_locale` without risk of `I18n::InvalidLocale`.

--- a/docs/concerns/localizable.md
+++ b/docs/concerns/localizable.md
@@ -40,6 +40,7 @@ The `localizable` class macro accepts the following keyword options:
 | `default:` | `Symbol` / `nil` | `nil` | Locale to use when neither the param nor the header produces a match. Coerced to a symbol. When `nil` and no match is found, falls back to `I18n.default_locale`. |
 | `param:` | `Symbol` / `nil` | `:locale` | Name of the query/route parameter to inspect first. Coerced to a symbol. Pass `nil` to disable param-based resolution entirely. |
 | `header:` | `Boolean` | `true` | When `true`, parses the `Accept-Language` request header as a fallback after param resolution fails. Set to `false` to skip header inspection. |
+| `response_headers:` | `Boolean` | `true` | Emit `Content-Language: <resolved locale>` on every response (BCP 47 form, `pt_BR` → `pt-BR`) and, when `header:` is `true`, append `Accept-Language` to the `Vary` header (de-duplicated, never clobbering an existing `Vary`). Written before the action runs. Set `false` to emit neither. |
 
 Calling `localizable` with no arguments is valid; all options take their defaults.
 
@@ -49,14 +50,14 @@ Calling `localizable` with no arguments is valid; all options take their default
 
 | Signature | Visibility | Description |
 |---|---|---|
-| `switch_locale(&block)` | public | `around_action` callback. Calls `I18n.with_locale(resolved_locale, &block)`, running the action block under the chosen locale and restoring the previous locale afterwards. Subclasses may override this method. |
+| `switch_locale(&block)` | public | `around_action` callback. Writes the response headers (`Content-Language`, and `Vary: Accept-Language` when the header is a source), then calls `I18n.with_locale(resolved_locale, &block)`, running the action block under the chosen locale and restoring the previous locale afterwards. Subclasses may override this method. |
 | `resolved_locale` | public | Returns the `Symbol` locale chosen for the current request using the resolution order described below. Never returns a value absent from `I18n.available_locales`. |
 
 ### Class methods
 
 | Signature | Description |
 |---|---|
-| `localizable(available:, default:, param:, header:)` | Configuration macro. Stores options in the inheritable `localizable_options` class attribute. Safe to call in subcontrollers to narrow or change the options for that subtree. |
+| `localizable(available:, default:, param:, header:, response_headers:)` | Configuration macro. Stores options in the inheritable `localizable_options` class attribute. Safe to call in subcontrollers to narrow or change the options for that subtree. |
 
 ## Examples
 
@@ -103,6 +104,7 @@ end
 
 ## Notes & gotchas
 
+- **`Content-Language` and `Vary` are on by default.** A localized JSON body is a different representation per locale; without `Vary: Accept-Language` a shared cache (CDN, `Rack::Cache`) would serve one client's French to another's English. The headers are written before the action, so they ride a rescued error too. If you localize only via a URL param, pass `header: false` and `Vary` is skipped (the URL already differs); `response_headers: false` disables both.
 **Resolution order.** The concern resolves locale in this priority sequence: `params[param]` → first matching language in `Accept-Language` → `default:` option → `I18n.default_locale`. Each step is attempted only if the previous one produced no match within the allow-list.
 
 **Final validation against `I18n.available_locales`.** Even if a locale passes the `available:` allow-list, `resolved_locale` performs a final check against `I18n.available_locales` before returning. If the two lists fall out of sync (e.g. the `available:` option is set to `[:en, :fr]` but I18n is later reconfigured to only `[:en]`), the resolved `:fr` candidate is discarded and `I18n.default_locale` is returned instead. This means locale resolution is always safe to hand to `I18n.with_locale` without risk of `I18n::InvalidLocale`.

--- a/lib/concerns_on_rails/controllers/localizable.rb
+++ b/lib/concerns_on_rails/controllers/localizable.rb
@@ -18,9 +18,15 @@ module ConcernsOnRails
     # against `I18n.available_locales` before use, so a stray param or a
     # mismatched `available:` list can never raise `I18n::InvalidLocale`.
     #
+    # Every response carries `Content-Language: <resolved locale>` (BCP 47
+    # form, `pt_BR` → `pt-BR`) and, when the header is a locale source,
+    # `Vary: Accept-Language` appended to any existing Vary — written before
+    # the action runs, so a rescued error still carries them. Both are behind
+    # `response_headers:` (default `true`).
+    #
     # Options: `available:` (allow-list for param/header matching; defaults to
     # `I18n.available_locales`), `default:`, `param:` (default `:locale`),
-    # `header:` (default `true`).
+    # `header:` (default `true`), `response_headers:` (default `true`).
     module Localizable
       extend ActiveSupport::Concern
 
@@ -30,19 +36,23 @@ module ConcernsOnRails
       end
 
       class_methods do
-        def localizable(available: nil, default: nil, param: :locale, header: true)
+        def localizable(available: nil, default: nil, param: :locale, header: true, response_headers: true)
           self.localizable_options = {
             available: available&.map(&:to_sym),
             default: default&.to_sym,
             param: param&.to_sym,
-            header: header
+            header: header,
+            response_headers: response_headers ? true : false
           }
         end
       end
 
-      # Public so subclasses can override; runs the action under the resolved locale.
+      # Public so subclasses can override; writes the response headers, then
+      # runs the action under the resolved locale.
       def switch_locale(&)
-        I18n.with_locale(resolved_locale, &)
+        locale = resolved_locale
+        apply_locale_response_headers(locale)
+        I18n.with_locale(locale, &)
       end
 
       # The locale chosen for this request — always one I18n can switch to.
@@ -59,6 +69,29 @@ module ConcernsOnRails
       end
 
       private
+
+      # Content-Language always; Vary: Accept-Language only when the header can
+      # influence the choice (a param-only setup already differs by URL).
+      # Vary is appended and de-duplicated, never clobbered (Cacheable, the
+      # paginators' Link header — same rule).
+      def apply_locale_response_headers(locale)
+        return unless locale_response_headers?
+
+        response.set_header("Content-Language", locale.to_s.tr("_", "-"))
+        append_vary_accept_language if self.class.localizable_options.fetch(:header, true)
+      end
+
+      def locale_response_headers?
+        opts = self.class.localizable_options
+        return false if opts.key?(:response_headers) && !opts[:response_headers]
+
+        respond_to?(:response) && response.respond_to?(:set_header)
+      end
+
+      def append_vary_accept_language
+        existing = response.headers["Vary"].to_s.split(",").map(&:strip).reject(&:empty?)
+        response.set_header("Vary", (existing + ["Accept-Language"]).uniq.join(", "))
+      end
 
       def locale_from_param(opts, allowed)
         return nil unless opts[:param] && respond_to?(:params) && params

--- a/spec/concerns/controllers/localizable_spec.rb
+++ b/spec/concerns/controllers/localizable_spec.rb
@@ -91,4 +91,71 @@ describe ConcernsOnRails::Controllers::Localizable do
       expect(I18n.locale).to eq(:en) # restored
     end
   end
+  describe "response headers (Content-Language / Vary)" do
+    it "sets Content-Language to the resolved locale while switching" do
+      c = controller(params: { locale: "fr" }) { localizable available: %i[en fr de], default: :en }
+      c.switch_locale { nil }
+      expect(c.response.headers["Content-Language"]).to eq("fr")
+    end
+
+    it "appends Vary: Accept-Language when the header is a locale source, merging with an existing Vary" do
+      c = controller(accept_language: "de") { localizable available: %i[en fr de], default: :en }
+      c.response.set_header("Vary", "Accept")
+      c.switch_locale { nil }
+      expect(c.response.headers["Vary"]).to eq("Accept, Accept-Language")
+      expect(c.response.headers["Content-Language"]).to eq("de")
+
+      again = controller(accept_language: "de") { localizable available: %i[en fr de], default: :en }
+      again.response.set_header("Vary", "Accept-Language")
+      again.switch_locale { nil }
+      expect(again.response.headers["Vary"]).to eq("Accept-Language") # de-duplicated
+    end
+
+    it "does not add Vary when header: false (the locale cannot depend on Accept-Language)" do
+      c = controller(params: { locale: "fr" }) { localizable available: %i[en fr de], default: :en, header: false }
+      c.switch_locale { nil }
+      expect(c.response.headers["Content-Language"]).to eq("fr")
+      expect(c.response.headers).not_to have_key("Vary")
+    end
+
+    it "can be switched off with response_headers: false" do
+      c = controller(accept_language: "fr") { localizable available: %i[en fr de], default: :en, response_headers: false }
+      c.switch_locale { nil }
+      expect(c.response.headers).not_to have_key("Content-Language")
+      expect(c.response.headers).not_to have_key("Vary")
+    end
+
+    it "emits a BCP 47 tag (underscore locales become dashed)" do
+      saved = I18n.available_locales
+      I18n.available_locales = %i[en pt_BR]
+      c = controller(params: { locale: "pt_BR" }) { localizable available: %i[en pt_BR], default: :en }
+      c.switch_locale { nil }
+      expect(c.response.headers["Content-Language"]).to eq("pt-BR")
+    ensure
+      I18n.available_locales = saved
+    end
+
+    it "writes the headers before the action, so a raising action (rescue_from path) still carries them" do
+      c = controller(accept_language: "de") { localizable available: %i[en fr de], default: :en }
+      expect { c.switch_locale { raise "boom" } }.to raise_error("boom")
+      expect(c.response.headers["Content-Language"]).to eq("de")
+      expect(c.response.headers["Vary"]).to eq("Accept-Language")
+    end
+
+    it "is a no-op on a controller without a response object" do
+      klass = Class.new do
+        def self.around_action(*); end
+        # no ActiveSupport here — stub what the included block needs
+        def self.class_attribute(*, **); end
+
+        def self.localizable_options
+          {}
+        end
+        include ConcernsOnRails::Controllers::Localizable
+      end
+      bare = klass.new
+      allow(bare).to receive(:resolved_locale).and_return(:en)
+      expect(bare.switch_locale { I18n.locale }).to eq(:en)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

A localized JSON body is a different representation per locale, yet the response said nothing about it — no `Content-Language` for clients, and no `Vary` for shared caches, so a CDN or `Rack::Cache` in front of the API could serve one client's French to the next client's English.

`switch_locale` now writes, **before** running the action (so a `rescue_from`-rendered error carries them too):

```
Content-Language: fr            # the resolved locale, BCP 47 form (pt_BR → pt-BR)
Vary: Accept, Accept-Language   # Accept-Language appended when the header is a locale source
```

- `Vary` is appended to any existing value and de-duplicated, never clobbered (the same rule as Cacheable and the paginators' `Link` header). It is skipped with `header: false`, when the locale can only come from the URL param and the URL already differs.
- `localizable … response_headers: false` disables both headers.
- Guarded on a real response object; no behaviour change to locale resolution itself.

## Docs

- `README.md` — a paragraph on the two headers + the `response_headers:` option.
- `docs/concerns/localizable.md` — config row, `switch_locale` row, macro signature, a Notes bullet on why the headers matter for shared caches.

## Changelog entry (for `CHANGELOG.md` at release — kept out of this diff so parallel enhancement PRs don't conflict)

```
### Added
- **Controllers::Localizable**: every response now carries
  `Content-Language: <resolved locale>` and, when `Accept-Language` is a locale
  source, `Vary: Accept-Language` (appended to an existing `Vary`), written
  before the action so rescued errors carry them too. Opt out with
  `localizable … response_headers: false`.
```

## Test plan

- [x] +7 examples: `Content-Language` set; `Vary` merged with an existing `Accept` and de-duplicated; `header: false` → no `Vary`; `response_headers: false` → neither; `pt_BR` → `pt-BR`; headers survive a raising action; no-op on an object without a response.
- [x] Full suite: 1264 examples, 0 failures (98.33%).
- [x] RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
