### PR TITLE
Expirable: before/after_expire lifecycle hooks, expire_in!, clear_expiry!

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,12 +624,19 @@ ApiToken.expiring_within(1.day)  # future expiry within the next 1 day
 ```ruby
 token.expire!                       # expires_at = now
 token.expire!(2.hours.from_now)     # explicit time
+token.expire_in!(15.minutes)        # absolute lifetime from now, whatever the current expiry
 token.extend_expiry!(by: 1.day)     # pushes expiry forward
+token.clear_expiry!                 # never expires (nil)
 ```
 
 `extend_expiry!` is smart about the base:
 - If `expires_at` is `nil` or in the past → new value is `now + by`
 - If `expires_at` is still in the future → `by` is added to the existing value
+
+**Lifecycle hooks** — override `before_expire` / `after_expire` on the model; they fire around `expire!`
+(and therefore `expire_in!` and `expire_all`) inside one transaction, so a raising `after_expire` rolls the
+expiry back. Renewals (`extend_expiry!`) and `clear_expiry!` do not fire them. Overriding either hook moves
+`expire_all` from its single `UPDATE` to the per-record path so the hooks run for every row.
 
 **Bulk operations**
 

--- a/docs/concerns/expirable.md
+++ b/docs/concerns/expirable.md
@@ -87,7 +87,10 @@ ApiToken.expiring_within(1.hour)   # expires_at in (now, now + 1.hour]
 |---|---|
 | `expired?` | Returns `true` when the expiry column is set and its value is less than or equal to `Time.zone.now`. Returns `false` when the column is `nil`. |
 | `active?` | Inverse of `expired?`. Returns `true` when not expired (including records with no expiry set). |
-| `expire!(time = Time.zone.now)` | Persists an expiry timestamp via `update`. Defaults to the current time, making the record immediately expired. Accepts any `Time`-compatible value. |
+| `expire!(time = Time.zone.now)` | Persists an expiry timestamp via `update`. Defaults to the current time, making the record immediately expired. Accepts any `Time`-compatible value. Runs `before_expire`, the write, then `after_expire` (only when the write succeeded) inside one transaction; returns the `update` result. |
+| `expire_in!(duration)` | Sets an absolute lifetime from now — `expire!(Time.zone.now + duration)` — whatever the current expiry. Fires the hooks like `expire!`. |
+| `clear_expiry!` | Sets the expiry column to `nil` so the record never expires. No hooks (nothing expired). |
+| `before_expire` / `after_expire` | Lifecycle hooks, no-ops by default. Fired by `expire!` / `expire_in!` / `expire_all`; not by `extend_expiry!` or `clear_expiry!`. Overriding either moves `expire_all` to the per-record path. |
 | `extend_expiry!(by:)` | Pushes the expiry forward by a duration. The base for the calculation is smart: if the record is never-expiring or already expired, `now` is used as the base; if the record has a future expiry, the existing value is used as the base. |
 | `time_until_expiry` | Returns an `ActiveSupport::Duration` representing seconds until expiry, `nil` if there is no expiry set, or `0.seconds` if the record is already expired. |
 
@@ -155,6 +158,7 @@ old_invite.active?     # => true
 
 ## Notes & gotchas
 
+- **Hooks share the write's transaction.** A raising `after_expire` rolls the expiry back; a write that fails validation returns `false` and skips `after_expire`. `expire_all` detects an overridden hook (like an overridden `expire!`) and streams per record so the hooks run for every row — declare hooks knowing the bulk verb pays a query per record.
 - **Boundary is exclusive for the expiring record.** A record whose `expires_at` equals `Time.zone.now` exactly is considered expired (`expired?` returns `true`, `active?` returns `false`). The same boundary applies to the `.expired` scope (`<= now`) and `.active` scope (`> now`).
 - **`nil` means never-expires, not immediately-expired.** `expired?` returns `false` and `active?` returns `true` when the column is `nil`. The `.active` scope includes `NULL` rows; the `.expired` scope excludes them.
 - **`expirable_by` must be called before the model is used.** The macro writes the `expirable_field` class attribute and validates the column. If you skip the call, the three scopes are still defined (they were added by `included do`) but they will read from the default `expirable_field` value of `:expires_at`, which may not match your actual column.

--- a/lib/concerns_on_rails/models/expirable.rb
+++ b/lib/concerns_on_rails/models/expirable.rb
@@ -31,9 +31,10 @@ module ConcernsOnRails
         end
 
         # Expire every currently-active record in the relation. Returns the
-        # Integer count. Expirable defines no lifecycle hooks, so this is a
-        # single UPDATE unless the model overrode `expire!` or declares
-        # validations (see Support::BatchOps.fast_path?).
+        # Integer count. A single UPDATE unless the model overrode `expire!`
+        # or a lifecycle hook (before_expire / after_expire), or declares
+        # validations (see Support::BatchOps.fast_path?) — then it streams
+        # per record so the hooks run.
         def expire_all(time = Time.zone.now)
           active = all.public_send(expirable_scope_names.fetch(:active))
           if expirable_batch_fast_path?
@@ -52,11 +53,11 @@ module ConcernsOnRails
         private
 
         # Whether the single-UPDATE fast path is safe — the whole decision
-        # (bang method unoverridden AND the model declares no validations,
-        # plus why) lives in Support::BatchOps.fast_path?. Expirable defines
-        # no lifecycle hooks, so `expire!` is the only method to check.
+        # (bang method and hooks unoverridden AND the model declares no
+        # validations, plus why) lives in Support::BatchOps.fast_path?.
         def expirable_batch_fast_path?
-          ConcernsOnRails::Support::BatchOps.fast_path?(self, ConcernsOnRails::Models::Expirable, :expire!)
+          ConcernsOnRails::Support::BatchOps.fast_path?(self, ConcernsOnRails::Models::Expirable,
+                                                        :expire!, :before_expire, :after_expire)
         end
 
         # Scopes live here (not in `included do`) so their names can be affixed —
@@ -96,8 +97,36 @@ module ConcernsOnRails
         value <= Time.zone.now
       end
 
+      # Lifecycle hooks — override in the model. Fired by `expire!` (and so by
+      # `expire_in!` and `expire_all`), not by `extend_expiry!` (a renewal) or
+      # `clear_expiry!`. Overriding either one moves `expire_all` to the
+      # per-record path.
+      def before_expire; end
+      def after_expire; end
+
+      # Write the expiry (default: now, i.e. expire immediately). The hooks and
+      # the write share one transaction, so a raising after_expire rolls the
+      # expiry back (SoftDeletable's pattern); a failed write (validation)
+      # returns false and skips after_expire.
       def expire!(time = Time.zone.now)
-        update(self.class.expirable_field => time)
+        result = false
+        transaction do
+          before_expire
+          result = update(self.class.expirable_field => time)
+          after_expire if result
+        end
+        result
+      end
+
+      # Set an absolute lifetime from now — `token.expire_in!(15.minutes)` —
+      # whatever the current expiry. Sugar for `expire!(now + duration)`.
+      def expire_in!(duration)
+        expire!(Time.zone.now + duration)
+      end
+
+      # Make the record never expire (nil expiry). No hooks: nothing expired.
+      def clear_expiry!
+        update(self.class.expirable_field => nil)
       end
 
       # Push expiry forward by `by:`. If the record has no expiry yet, or has

--- a/spec/concerns/models/expirable_spec.rb
+++ b/spec/concerns/models/expirable_spec.rb
@@ -325,4 +325,103 @@ describe ConcernsOnRails::Expirable do
       expect(invalid.reload.expires_at).to be_nil
     end
   end
+  describe "lifecycle hooks (before_expire / after_expire)" do
+    let(:hooked) do
+      Class.new(TestModel) do
+        self.table_name = "api_tokens"
+        include ConcernsOnRails::Expirable
+
+        expirable_by
+
+        attr_reader :log
+
+        def before_expire
+          (@log ||= []) << :before_expire
+        end
+
+        def after_expire
+          (@log ||= []) << :after_expire
+        end
+      end
+    end
+
+    it "fires around expire! (and expire_in!), not around extend_expiry! or clear_expiry!" do
+      token = hooked.create!
+      token.expire!
+      expect(token.log).to eq(%i[before_expire after_expire])
+
+      token.instance_variable_set(:@log, nil)
+      token.expire_in!(1.hour)
+      expect(token.log).to eq(%i[before_expire after_expire])
+
+      token.instance_variable_set(:@log, nil)
+      token.extend_expiry!(by: 1.day)
+      token.clear_expiry!
+      expect(token.log).to be_nil
+    end
+
+    it "shares one transaction — a raising after_expire rolls the expiry back" do
+      failing = Class.new(hooked) do
+        def after_expire
+          raise "boom"
+        end
+      end
+      token = failing.create!(expires_at: nil)
+      expect { token.expire! }.to raise_error("boom")
+      expect(token.reload.expires_at).to be_nil
+    end
+
+    it "skips after_expire and returns false when the write fails validation" do
+      invalid = Class.new(hooked) do
+        validates :value, presence: true
+      end
+      token = invalid.new(value: "ok").tap { |t| t.save!(validate: false) }
+      token.value = nil
+      expect(token.expire!).to be(false)
+      expect(token.log).to eq(%i[before_expire])
+      expect(token.reload.expires_at).to be_nil
+    end
+
+    it "expire_all takes the per-record path when a hook is overridden, firing it once per record" do
+      stub_const("HookedToken", hooked)
+      2.times { HookedToken.create!(expires_at: nil) }
+      seen = 0
+      counting = Class.new(HookedToken) do
+        define_method(:after_expire) { seen += 1 }
+      end
+      expect(counting.expire_all).to eq(2)
+      expect(seen).to eq(2)
+    end
+
+    it "expire_all still collapses to a single UPDATE when the hooks are not overridden" do
+      2.times { ApiToken.create!(expires_at: nil) }
+      sql = []
+      callback = ->(*, payload) { sql << payload[:sql] if payload[:sql] =~ /\AUPDATE/i }
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        expect(ApiToken.expire_all).to eq(2)
+      end
+      expect(sql.size).to eq(1)
+    end
+  end
+
+  describe "#expire_in! and #clear_expiry!" do
+    it "expire_in!(duration) sets an absolute lifetime from now, whatever the current expiry" do
+      token = ApiToken.create!(expires_at: 10.days.from_now)
+      travel_to(Time.utc(2026, 7, 1, 12)) { token.expire_in!(15.minutes) }
+      expect(token.reload.expires_at).to eq(Time.utc(2026, 7, 1, 12, 15))
+
+      expired = ApiToken.create!(expires_at: 1.day.ago)
+      travel_to(Time.utc(2026, 7, 1, 12)) { expired.expire_in!(1.hour) }
+      expect(expired.reload.expires_at).to eq(Time.utc(2026, 7, 1, 13))
+    end
+
+    it "clear_expiry! makes the record never expire" do
+      token = ApiToken.create!(expires_at: 1.day.ago)
+      expect(token.expired?).to be(true)
+      expect(token.clear_expiry!).to be(true)
+      expect(token.reload.expires_at).to be_nil
+      expect(token.active?).to be(true)
+      expect(token.time_until_expiry).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Expirable was the one lifecycle concern **without hooks**: when a trial or a share link expired (`expire!` / `expire_all`) there was no seam to downgrade the account or notify anyone. Following the SoftDeletable / Publishable pattern:

```ruby
class Trial < ApplicationRecord
  include ConcernsOnRails::Expirable
  expirable_by

  def after_expire = account.downgrade!     # fires for expire!, expire_in!, expire_all
end

trial.expire_in!(14.days)    # absolute lifetime from now, whatever the current expiry
trial.clear_expiry!          # never expires
```

- **`before_expire` / `after_expire`** — fired by `expire!` (and so by `expire_in!` and `expire_all`) inside one transaction with the write, so a raising `after_expire` rolls the expiry back; a write that fails validation returns `false` and skips `after_expire`. Not fired by `extend_expiry!` (a renewal) or `clear_expiry!`.
- **Batch fast path stays honest**: the `expire_all` gate now checks the hooks too — overridden, it streams per record so the hooks run for every row; unoverridden, it stays a single `UPDATE` (spec asserts one statement).
- **`expire_in!(duration)`** — `expire!(now + duration)`: an absolute lifetime, where `extend_expiry!(by:)` adds to a future expiry.
- **`clear_expiry!`** — nil expiry, no hooks.

No behaviour change for models that override nothing.

## Docs

- `README.md` — mutators block (`expire_in!`, `clear_expiry!`) and a "Lifecycle hooks" paragraph.
- `docs/concerns/expirable.md` — `expire!` row updated, three new method rows, a Notes bullet.

## Changelog entry (for `CHANGELOG.md` at release — kept out of this diff so parallel enhancement PRs don't conflict)

```
### Added
- **Models::Expirable**: `before_expire` / `after_expire` lifecycle hooks (fired
  by `expire!`, `expire_in!` and `expire_all`, in one transaction with the
  write; overriding them moves `expire_all` to the per-record path), plus
  `expire_in!(duration)` for an absolute lifetime from now and `clear_expiry!`.
```

## Test plan

- [x] +7 examples: hooks fire around `expire!` and `expire_in!` but not `extend_expiry!`/`clear_expiry!`; a raising `after_expire` rolls back; a failed validation returns `false` and skips `after_expire`; `expire_all` per record with an overridden hook (once per row) and a single `UPDATE` without; `expire_in!` from a future and a past expiry; `clear_expiry!`.
- [x] Full suite: 1264 examples, 0 failures (98.33%).
- [x] RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
