### PR TITLE
SecureHeadable: HSTS, cross-origin (COOP/COEP/CORP) and Permissions-Policy presets + bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1704,6 +1704,9 @@ class ApplicationController < ActionController::Base
   # Preset headers, plus any custom "Header-Name" => "value" pairs:
   secure_headers :nosniff, :sameorigin_frame, :no_referrer_leak, :disable_legacy_xss
   secure_headers "Permissions-Policy" => "geolocation=()"
+  # ...or the break-nothing baseline in one line, then relax what you must (later wins):
+  secure_headers :recommended
+  secure_headers :sameorigin_frame
 
   # Delegates to Rails' native CSP DSL — roll out report-only FIRST:
   content_security_policy_for(report_only: true) do |policy|
@@ -1724,6 +1727,13 @@ end
 | `:no_referrer_leak`   | `Referrer-Policy: strict-origin-when-cross-origin`     |
 | `:no_cross_domain`    | `X-Permitted-Cross-Domain-Policies: none`              |
 | `:disable_legacy_xss` | `X-XSS-Protection: 0` (the only correct modern value)  |
+| `:hsts`               | `Strict-Transport-Security: max-age=31536000; includeSubDomains` (no `preload` — opt in via a custom pair) |
+| `:same_origin_opener` / `:same_origin_opener_allow_popups` | `Cross-Origin-Opener-Policy: same-origin` / `same-origin-allow-popups` |
+| `:require_corp_embedder` | `Cross-Origin-Embedder-Policy: require-corp`        |
+| `:same_origin_resource` | `Cross-Origin-Resource-Policy: same-origin`          |
+| `:no_sensitive_permissions` | `Permissions-Policy` denying camera, microphone, geolocation, payment, usb and motion sensors |
+
+**Bundles** (expand to presets in place, so a later preset or custom pair still wins): `:recommended` = nosniff, deny_frame, no_referrer_leak, no_cross_domain, disable_legacy_xss, same_origin_opener_allow_popups, no_sensitive_permissions — deliberately *without* COEP/CORP (they block cross-origin embeds of your resources and CDN assets lacking CORP headers) and HSTS (belongs with `force_ssl`), so it breaks nothing; `:cross_origin_isolation` = same_origin_opener + require_corp_embedder + same_origin_resource (what SharedArrayBuffer / high-resolution timers require).
 
 **Notes**
 - Headers are applied in an `after_action`, so they reinforce Rails' middleware defaults; later `secure_headers` declarations win on a colliding name.

--- a/docs/concerns/secure-headable.md
+++ b/docs/concerns/secure-headable.md
@@ -46,6 +46,19 @@ Registers one or more header preset symbols and/or arbitrary custom headers. Can
 | `:no_referrer_leak` | `Referrer-Policy` | `strict-origin-when-cross-origin` |
 | `:no_cross_domain` | `X-Permitted-Cross-Domain-Policies` | `none` |
 | `:disable_legacy_xss` | `X-XSS-Protection` | `0` |
+| `:hsts` | `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` — one year, no `preload` (the preload list is a months-long commitment; add it as a custom pair). For API-only apps behind a TLS-terminating proxy; with `force_ssl` / `config.ssl_options` Rails sets this itself. |
+| `:same_origin_opener` | `Cross-Origin-Opener-Policy` | `same-origin` — severs `window.opener`; breaks OAuth/payment popups that rely on it |
+| `:same_origin_opener_allow_popups` | `Cross-Origin-Opener-Policy` | `same-origin-allow-popups` — the popup-friendly variant used by `:recommended` |
+| `:require_corp_embedder` | `Cross-Origin-Embedder-Policy` | `require-corp` — every cross-origin subresource must opt in via CORS/CORP |
+| `:same_origin_resource` | `Cross-Origin-Resource-Policy` | `same-origin` — other origins cannot embed your responses via `<img>`/`<script>` (CORS fetches are unaffected) |
+| `:no_sensitive_permissions` | `Permissions-Policy` | `accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()` |
+
+**Bundles** — a bundle name expands to its presets *in declaration position*, so `secure_headers :recommended, :sameorigin_frame` (or a later `secure_headers` call) relaxes a bundled header.
+
+| Bundle | Presets | Why this set |
+|---|---|---|
+| `:recommended` | `nosniff`, `deny_frame`, `no_referrer_leak`, `no_cross_domain`, `disable_legacy_xss`, `same_origin_opener_allow_popups`, `no_sensitive_permissions` | The baseline that breaks nothing: no COEP/CORP (they block cross-origin embeds of your resources and CDN assets without CORP headers) and no HSTS (belongs with `force_ssl`). Relax `deny_frame` → `:sameorigin_frame` if the app frames itself. |
+| `:cross_origin_isolation` | `same_origin_opener`, `require_corp_embedder`, `same_origin_resource` | What `SharedArrayBuffer` and high-resolution timers require — expect to add CORS/CORP headers to every cross-origin asset first. |
 
 **Custom headers** (`**custom`): any `"Header-Name" => "value"` keyword pairs. Keys are coerced to strings via `to_s`.
 
@@ -124,6 +137,7 @@ end
 
 ## Notes & gotchas
 
+- **`:recommended` is conservative on purpose.** It picks `same-origin-allow-popups` over `same-origin` for COOP and leaves COEP/CORP out because those three are the headers that break real apps (popup logins, CDN images, embedded widgets). Opt into `:cross_origin_isolation` deliberately, after your cross-origin assets carry CORP/CORS headers.
 - **`after_action`, not `before_action`:** Headers are written after the response is rendered. This means they can reinforce or override headers that Rails middleware or the render process set earlier. It also means the `response` object is available and populated when `apply_secure_headers` runs.
 - **Later declarations win:** Each call to `secure_headers` merges into the accumulated class attribute hash. If `:sameorigin_frame` is declared first and `:deny_frame` is declared second (even in a separate call), `X-Frame-Options` resolves to `DENY`. This applies across inheritance: a subcontroller that calls `secure_headers :deny_frame` will override the parent's `:sameorigin_frame` for that header only, leaving all other inherited headers intact.
 - **`:disable_legacy_xss` emits `"0"`, never `"1; mode=block"`:** The legacy XSS auditor was itself exploitable (information disclosure, bypass) and has been removed from Chrome, Firefox, and Edge. `"0"` explicitly disables any remaining auditor. This concern will never emit a non-zero value for this header.

--- a/lib/concerns_on_rails/controllers/secure_headable.rb
+++ b/lib/concerns_on_rails/controllers/secure_headable.rb
@@ -13,6 +13,9 @@ module ConcernsOnRails
     #     # Apply preset headers, plus any custom "Header-Name" => "value" pairs:
     #     secure_headers :nosniff, :sameorigin_frame, :no_referrer_leak, :disable_legacy_xss
     #     secure_headers "Permissions-Policy" => "geolocation=()"
+    #     # ...or the break-nothing baseline in one line, then relax what you must:
+    #     secure_headers :recommended
+    #     secure_headers :sameorigin_frame          # later declarations win
     #
     #     # Delegates to Rails' native CSP DSL — roll out report-only FIRST:
     #     content_security_policy_for(report_only: true) do |policy|
@@ -36,6 +39,27 @@ module ConcernsOnRails
     #   :no_referrer_leak   — Referrer-Policy: strict-origin-when-cross-origin
     #   :no_cross_domain    — X-Permitted-Cross-Domain-Policies: none
     #   :disable_legacy_xss — X-XSS-Protection: 0 (the only correct modern value)
+    #   :hsts               — Strict-Transport-Security: max-age=31536000; includeSubDomains
+    #                         (for API-only apps behind a TLS-terminating proxy; when
+    #                         you use force_ssl / config.ssl_options Rails sets it)
+    #   :same_origin_opener              — Cross-Origin-Opener-Policy: same-origin
+    #   :same_origin_opener_allow_popups — Cross-Origin-Opener-Policy: same-origin-allow-popups
+    #                                      (keeps OAuth / payment popups working)
+    #   :require_corp_embedder           — Cross-Origin-Embedder-Policy: require-corp
+    #   :same_origin_resource            — Cross-Origin-Resource-Policy: same-origin
+    #   :no_sensitive_permissions        — Permissions-Policy denying camera, microphone,
+    #                                      geolocation, payment, usb and motion sensors
+    #
+    # Bundles (expand to presets, so a later preset or custom pair still wins):
+    #   :recommended            — nosniff, deny_frame, no_referrer_leak, no_cross_domain,
+    #                             disable_legacy_xss, same_origin_opener_allow_popups,
+    #                             no_sensitive_permissions. Deliberately WITHOUT COEP/CORP
+    #                             (they block cross-origin embeds of your resources and
+    #                             CDN assets without CORP headers) and HSTS (belongs
+    #                             with force_ssl) — the baseline that breaks nothing.
+    #   :cross_origin_isolation — same_origin_opener, require_corp_embedder,
+    #                             same_origin_resource (SharedArrayBuffer / high-res
+    #                             timers need all three).
     module SecureHeadable
       extend ActiveSupport::Concern
 
@@ -49,7 +73,25 @@ module ConcernsOnRails
         deny_frame: %w[X-Frame-Options DENY],
         no_referrer_leak: %w[Referrer-Policy strict-origin-when-cross-origin],
         no_cross_domain: %w[X-Permitted-Cross-Domain-Policies none],
-        disable_legacy_xss: %w[X-XSS-Protection 0]
+        disable_legacy_xss: %w[X-XSS-Protection 0],
+        # One year, subdomains included, no `preload` — the preload list is a
+        # months-long commitment that must be an explicit, custom-pair decision.
+        hsts: ["Strict-Transport-Security", "max-age=31536000; includeSubDomains"],
+        same_origin_opener: %w[Cross-Origin-Opener-Policy same-origin],
+        same_origin_opener_allow_popups: %w[Cross-Origin-Opener-Policy same-origin-allow-popups],
+        require_corp_embedder: %w[Cross-Origin-Embedder-Policy require-corp],
+        same_origin_resource: %w[Cross-Origin-Resource-Policy same-origin],
+        no_sensitive_permissions: ["Permissions-Policy",
+                                   "accelerometer=(), camera=(), geolocation=(), gyroscope=(), " \
+                                   "magnetometer=(), microphone=(), payment=(), usb=()"]
+      }.freeze
+
+      # Named sets of presets. Expanded in declaration position, so
+      # `secure_headers :recommended, :sameorigin_frame` relaxes the frame rule.
+      BUNDLES = {
+        cross_origin_isolation: %i[same_origin_opener require_corp_embedder same_origin_resource],
+        recommended: %i[nosniff deny_frame no_referrer_leak no_cross_domain disable_legacy_xss
+                        same_origin_opener_allow_popups no_sensitive_permissions]
       }.freeze
 
       included do
@@ -67,14 +109,16 @@ module ConcernsOnRails
       end
 
       class_methods do
-        # Register preset headers (by symbol) plus optional custom
-        # "Header-Name" => "value" pairs. Later declarations win on collision.
+        # Register preset headers (by symbol, bundles expanded in place) plus
+        # optional custom "Header-Name" => "value" pairs. Later declarations —
+        # and later positions within one call — win on collision.
         def secure_headers(*presets, **custom)
-          resolved = presets.to_h do |key|
+          expanded = presets.flat_map { |key| BUNDLES.fetch(key, [key]) }
+          resolved = expanded.to_h do |key|
             PRESETS.fetch(key) do
               raise ArgumentError,
                     "ConcernsOnRails::Controllers::SecureHeadable: unknown preset '#{key}'. " \
-                    "Valid presets: #{PRESETS.keys.join(', ')}"
+                    "Valid presets: #{PRESETS.keys.join(', ')}. Bundles: #{BUNDLES.keys.join(', ')}"
             end
           end
 

--- a/spec/concerns/controllers/secure_headable_spec.rb
+++ b/spec/concerns/controllers/secure_headable_spec.rb
@@ -140,4 +140,75 @@ describe ConcernsOnRails::Controllers::SecureHeadable do
       expect(forwarded).to eq(block)
     end
   end
+  describe "modern presets and bundles" do
+    def headers_for(*presets)
+      klass = controller_class(base_class) { secure_headers(*presets) }
+      controller = klass.new
+      controller.apply_secure_headers
+      controller.response.headers
+    end
+
+    it "adds HSTS, the cross-origin trio (COOP / COEP / CORP) and a conservative Permissions-Policy" do
+      headers = headers_for(:hsts, :same_origin_opener, :require_corp_embedder, :same_origin_resource, :no_sensitive_permissions)
+      expect(headers["Strict-Transport-Security"]).to eq("max-age=31536000; includeSubDomains")
+      expect(headers["Cross-Origin-Opener-Policy"]).to eq("same-origin")
+      expect(headers["Cross-Origin-Embedder-Policy"]).to eq("require-corp")
+      expect(headers["Cross-Origin-Resource-Policy"]).to eq("same-origin")
+      expect(headers["Permissions-Policy"])
+        .to eq("accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()")
+    end
+
+    it "offers the popup-friendly COOP variant" do
+      expect(headers_for(:same_origin_opener_allow_popups)["Cross-Origin-Opener-Policy"]).to eq("same-origin-allow-popups")
+    end
+
+    it ":recommended bundles the break-nothing baseline (no COEP/CORP/HSTS)" do
+      headers = headers_for(:recommended)
+      expect(headers).to include(
+        "X-Content-Type-Options" => "nosniff",
+        "X-Frame-Options" => "DENY",
+        "Referrer-Policy" => "strict-origin-when-cross-origin",
+        "X-Permitted-Cross-Domain-Policies" => "none",
+        "X-XSS-Protection" => "0",
+        "Cross-Origin-Opener-Policy" => "same-origin-allow-popups"
+      )
+      expect(headers).to have_key("Permissions-Policy")
+      expect(headers).not_to have_key("Cross-Origin-Embedder-Policy")
+      expect(headers).not_to have_key("Cross-Origin-Resource-Policy")
+      expect(headers).not_to have_key("Strict-Transport-Security")
+      expect(headers.size).to eq(7)
+    end
+
+    it ":cross_origin_isolation bundles COOP same-origin + COEP require-corp + CORP same-origin" do
+      headers = headers_for(:cross_origin_isolation)
+      expect(headers).to eq(
+        "Cross-Origin-Opener-Policy" => "same-origin",
+        "Cross-Origin-Embedder-Policy" => "require-corp",
+        "Cross-Origin-Resource-Policy" => "same-origin"
+      )
+    end
+
+    it "lets a later preset or custom value relax a bundled header (order wins)" do
+      relaxed = headers_for(:recommended, :sameorigin_frame)
+      expect(relaxed["X-Frame-Options"]).to eq("SAMEORIGIN")
+
+      klass = controller_class(base_class) do
+        secure_headers :recommended
+        secure_headers "Permissions-Policy" => "geolocation=(self)"
+      end
+      controller = klass.new
+      controller.apply_secure_headers
+      expect(controller.response.headers["Permissions-Policy"]).to eq("geolocation=(self)")
+    end
+
+    it "lists presets and bundles in the unknown-preset error" do
+      expect { controller_class(base_class) { secure_headers :nope } }
+        .to raise_error(ArgumentError, /unknown preset 'nope'.*Valid presets: nosniff.*hsts.*Bundles: cross_origin_isolation, recommended/)
+    end
+
+    it "exposes the bundle map" do
+      expect(described_class::BUNDLES.keys).to match_array(%i[cross_origin_isolation recommended])
+      described_class::BUNDLES.each_value { |members| expect(members - described_class::PRESETS.keys).to be_empty }
+    end
+  end
 end


### PR DESCRIPTION
## Summary

The six presets stopped at the 2015 set (nosniff, frame options, referrer policy, cross-domain policies, legacy XSS). Everything OWASP has recommended since had to be typed as a custom `"Header-Name" => "value"` pair.

**New presets**

| Preset | Header |
|---|---|
| `:hsts` | `Strict-Transport-Security: max-age=31536000; includeSubDomains` (no `preload` — a months-long commitment; add it as a custom pair) |
| `:same_origin_opener` | `Cross-Origin-Opener-Policy: same-origin` |
| `:same_origin_opener_allow_popups` | `Cross-Origin-Opener-Policy: same-origin-allow-popups` (keeps OAuth / payment popups working) |
| `:require_corp_embedder` | `Cross-Origin-Embedder-Policy: require-corp` |
| `:same_origin_resource` | `Cross-Origin-Resource-Policy: same-origin` |
| `:no_sensitive_permissions` | `Permissions-Policy` denying camera, microphone, geolocation, payment, usb and motion sensors |

**Bundles** — expanded in declaration position, so a later preset or custom pair still wins:

```ruby
secure_headers :recommended          # the break-nothing baseline
secure_headers :sameorigin_frame     # ...then relax what you must
secure_headers :cross_origin_isolation   # opt in deliberately (SharedArrayBuffer, high-res timers)
```

- `:recommended` = nosniff, deny_frame, no_referrer_leak, no_cross_domain, disable_legacy_xss, same_origin_opener_allow_popups, no_sensitive_permissions. Deliberately **without** COEP/CORP (they block cross-origin embeds of your resources and CDN assets lacking CORP headers) and HSTS (belongs with `force_ssl` / `config.ssl_options`), and with the popup-friendly COOP — the three things that break real apps are left as explicit opt-ins.
- `:cross_origin_isolation` = same_origin_opener + require_corp_embedder + same_origin_resource.
- The unknown-preset error lists bundles too; `BUNDLES` is a public constant like `PRESETS`.

No behaviour change for existing declarations.

## Docs

- `README.md` — example, six preset rows, a bundles paragraph.
- `docs/concerns/secure-headable.md` — preset rows with the "why/what breaks" notes, a bundles table, a Notes bullet.

## Changelog entry (for `CHANGELOG.md` at release — kept out of this diff so parallel enhancement PRs don't conflict)

```
### Added
- **Controllers::SecureHeadable**: presets `:hsts`, `:same_origin_opener`,
  `:same_origin_opener_allow_popups`, `:require_corp_embedder`,
  `:same_origin_resource`, `:no_sensitive_permissions`, plus bundles
  `:recommended` (the break-nothing baseline) and `:cross_origin_isolation`,
  expanded in place so later declarations still win.
```

## Test plan

- [x] +7 examples: every new header value; the popup COOP variant; `:recommended` contents (7 headers) and exclusions; `:cross_origin_isolation`; relaxing a bundled header by a later preset and by a custom pair; the error text lists bundles; every bundle member is a preset.
- [x] Full suite: 1264 examples, 0 failures (98.32%).
- [x] RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
