### PR TITLE
Taggable: tag_counts — relation-aware tag → record count for tag clouds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1048,6 +1048,7 @@ article.save!
 Article.tagged_with("ruby", "rails")          # records carrying BOTH tags
 Article.tagged_with("ruby", "go", any: true)  # records carrying ANY tag
 Article.all_tags                               # => sorted unique tags in use
+Article.published.tag_counts(limit: 20)        # => { "ruby" => 12, "rails" => 7, ... } — a tag cloud, relation-aware
 ```
 
 **Options**
@@ -1060,7 +1061,8 @@ Article.all_tags                               # => sorted unique tags in use
 **Notes**
 - Matching is **boundary-safe** — searching `rail` does not match `rails`. An explicit SQL `ESCAPE` clause makes tags containing `_` / `%` match literally on every adapter.
 - Tags are normalized in `before_validation`, so a direct `record.tags = "a, b"` assignment is cleaned too. An empty list stores `NULL`.
-- Reach for [`acts-as-taggable-on`](https://github.com/mbleigh/acts-as-taggable-on) when you need tag contexts, ownership, counts/clouds, or polymorphic tags shared across models.
+- `tag_counts` runs one `GROUP BY` on the raw column — identical tag strings ship once with their row count and are split in Ruby — so it scales with distinct tag strings, not rows; ordered by count desc then name, `limit:` keeps the top N.
+- Reach for [`acts-as-taggable-on`](https://github.com/mbleigh/acts-as-taggable-on) when you need tag contexts, ownership, or polymorphic tags shared across models.
 
 ---
 

--- a/docs/concerns/taggable.md
+++ b/docs/concerns/taggable.md
@@ -97,6 +97,18 @@ Splits a raw stored column value on the configured delimiter and returns a norma
 
 Normalizes a single tag: strips surrounding whitespace and optionally lowercases it. Used internally by all normalization paths.
 
+#### `.tag_counts(limit: nil) → Hash{String => Integer}`
+
+Tag → number of records carrying it, ordered by count descending then tag name — the shape a tag cloud needs. Relation-aware, so it composes with scopes and `tagged_with`:
+
+```ruby
+Article.tag_counts                     # => { "ruby" => 3, "go" => 2, "api" => 1, "rails" => 1 }
+Article.published.tag_counts(limit: 20)
+Article.tagged_with("go").tag_counts   # counts among records that carry "go"
+```
+
+One `GROUP BY` query on the raw column: identical tag strings come back once with their row count and are split in Ruby, so the cost scales with the number of *distinct tag strings*, not rows. A record counts once per tag even if the stored string repeats it. Returns `{}` when nothing is tagged.
+
 ### Instance methods
 
 #### `#tag_list → Array<String>`
@@ -201,6 +213,6 @@ Post.tagged_with("rails")        # => [p]
 - **`before_validation` normalization covers direct assignment.** If you assign the raw column directly (`record.tags = "a, b"`), the `before_validation` hook strips, splits, and de-duplicates the value before saving. You do not have to go through `tag_list=` for normalization to apply.
 - **Boundary-safe SQL matching.** The `tagged_with` scope builds four OR-ed clauses per tag against the delimiter-joined column: an exact match (`column = ?`) plus three `LIKE` patterns that pin the tag to a delimiter boundary — `tag<delim>%` (tag first), `%<delim>tag` (tag last), and `%<delim>tag<delim>%` (tag in the middle). Each `LIKE` carries an explicit `ESCAPE '\\'` clause, so tags containing `_` or `%` are escaped and will not behave as SQL wildcards, and a search for `"rail"` will not match `"rails"`.
 - **`tagged_with` with no arguments returns `all`.** An empty tag array short-circuits to `all`, so the result is safely chainable without a conditional guard.
-- **No external gem dependencies.** Unlike `acts-as-taggable-on`, this concern requires no additional gems. The trade-off is that it has no support for tag counts, contexts, ownership, or polymorphic tags shared across multiple model types. Reach for `acts-as-taggable-on` when those features are needed.
+- **No external gem dependencies.** Unlike `acts-as-taggable-on`, this concern requires no additional gems. The trade-off is that it has no support for tag contexts, ownership, or polymorphic tags shared across multiple model types (`tag_counts` covers clouds). Reach for `acts-as-taggable-on` when those features are needed.
 - **Delimiter must not appear inside a tag value.** Tags containing the configured delimiter character produce incorrect split behavior. Choose a delimiter that cannot appear in your tag vocabulary, or sanitize tag input before assigning.
-- **`all_tags` is a full-table scan.** It `pluck`s every row's tag column and aggregates in Ruby. Add a database-level index on the column only if needed for `tagged_with` queries; `all_tags` cannot use it efficiently at scale.
+- **`all_tags` and `tag_counts` read every distinct tag string.** `all_tags` plucks the distinct column values, `tag_counts` groups them with a row count; both then split in Ruby. Cheap while the set of distinct tag strings is small, a candidate for caching on very large tables. Add a database-level index on the column only if needed for `tagged_with` queries; neither aggregate can use it.

--- a/lib/concerns_on_rails/models/taggable.rb
+++ b/lib/concerns_on_rails/models/taggable.rb
@@ -24,6 +24,7 @@ module ConcernsOnRails
     #   Article.tagged_with("ruby", "rails")          # records carrying BOTH tags
     #   Article.tagged_with("ruby", "go", any: true)  # records carrying ANY tag
     #   Article.all_tags                               # sorted unique tags in use
+    #   Article.published.tag_counts(limit: 20)        # { "ruby" => 12, "rails" => 7, ... } for a tag cloud
     #
     # Notes:
     #   * Matching is boundary-safe ("rail" does not match "rails").
@@ -32,7 +33,7 @@ module ConcernsOnRails
     #     "a" and "b"), everywhere, so what you read back always matches what
     #     a save would have produced.
     #   * Reach for acts-as-taggable-on when you need tag contexts, ownership,
-    #     tag counts/clouds, or polymorphic tags shared across models.
+    #     or polymorphic tags shared across models.
     module Taggable
       extend ActiveSupport::Concern
 
@@ -81,6 +82,22 @@ module ConcernsOnRails
                .pluck(taggable_field)
                .flat_map { |raw| taggable_split(raw) }
                .uniq.sort
+        end
+
+        # Tag => number of records carrying it, ordered by count desc then tag
+        # asc (a Hash keeps insertion order, so `.first(n)` / `.keys` are the
+        # cloud). Relation-aware: `Article.published.tag_counts`. One GROUP BY
+        # query on the raw column — identical tag strings ship once with their
+        # row count and are split in Ruby, so the cost scales with DISTINCT tag
+        # strings, not rows. `limit:` keeps the top N.
+        def tag_counts(limit: nil)
+          counts = Hash.new(0)
+          all.where.not(taggable_field => nil).unscope(:order).group(taggable_field).count.each do |raw, rows|
+            taggable_split(raw).each { |tag| counts[tag] += rows }
+          end
+          ordered = counts.sort_by { |tag, count| [-count, tag] }
+          ordered = ordered.first(limit.to_i) if limit
+          ordered.to_h
         end
 
         # Split a raw stored column value into a normalized tag array.

--- a/spec/concerns/models/taggable_spec.rb
+++ b/spec/concerns/models/taggable_spec.rb
@@ -247,4 +247,62 @@ describe ConcernsOnRails::Taggable do
       expect(TagDoc.tagged_with("ruby")).to contain_exactly(hit)
     end
   end
+  describe ".tag_counts" do
+    before do
+      TagArticle.create!(title: "a", tag_list: "ruby, rails")
+      TagArticle.create!(title: "b", tag_list: "ruby, go")
+      TagArticle.create!(title: "c", tag_list: "ruby")
+      TagArticle.create!(title: "d", tag_list: "go, api")
+      TagArticle.create!(title: "e")
+    end
+
+    it "returns tag => record count, ordered by count desc then tag asc" do
+      expect(TagArticle.tag_counts).to eq("ruby" => 3, "go" => 2, "api" => 1, "rails" => 1)
+      expect(TagArticle.tag_counts.keys).to eq(%w[ruby go api rails])
+    end
+
+    it "counts a record once per tag even when the stored string repeats it" do
+      TagArticle.create!(title: "f").update_column(:tags, "ruby,ruby, Ruby ")
+      expect(TagArticle.tag_counts["ruby"]).to eq(4)
+      expect(TagArticle.tag_counts["Ruby"]).to eq(1) # case-sensitive without downcase:
+    end
+
+    it "is relation-aware" do
+      expect(TagArticle.where(title: %w[a b]).tag_counts).to eq("ruby" => 2, "go" => 1, "rails" => 1)
+      expect(TagArticle.tagged_with("go").tag_counts).to eq("go" => 2, "api" => 1, "ruby" => 1)
+      expect(TagArticle.order(:title).tag_counts.keys.first).to eq("ruby") # an ORDER BY on the relation is harmless
+    end
+
+    it "supports limit: for tag clouds" do
+      expect(TagArticle.tag_counts(limit: 2)).to eq("ruby" => 3, "go" => 2)
+      expect(TagArticle.tag_counts(limit: 0)).to eq({})
+    end
+
+    it "returns {} when nothing is tagged" do
+      TagArticle.delete_all
+      expect(TagArticle.tag_counts).to eq({})
+    end
+
+    it "groups identical tag strings in SQL rather than plucking every row" do
+      sql = []
+      callback = ->(*, payload) { sql << payload[:sql] if payload[:sql] =~ /\ASELECT/i }
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        TagArticle.tag_counts
+      end
+      expect(sql.size).to eq(1)
+      expect(sql.first).to match(/GROUP BY/i)
+      expect(sql.first).to match(/COUNT\(/i)
+    end
+
+    it "case-folds with downcase: true so Ruby and ruby are one tag" do
+      folded = Class.new(TestModel) do
+        self.table_name = "tag_articles"
+        include ConcernsOnRails::Taggable
+
+        taggable_by :tags, downcase: true
+      end
+      folded.create!(title: "g", tag_list: "Ruby, RAILS")
+      expect(folded.tag_counts).to include("ruby" => 4, "rails" => 2)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

The docs told people to reach for `acts-as-taggable-on` for tag counts/clouds — but a single-column tag store can answer "how many records carry each tag" cheaply:

```ruby
Article.tag_counts                        # => { "ruby" => 3, "go" => 2, "api" => 1, "rails" => 1 }
Article.published.tag_counts(limit: 20)   # relation-aware; top 20 for a tag cloud
Article.tagged_with("go").tag_counts      # counts among records carrying "go"
```

- **One `GROUP BY` query** on the raw column: identical tag strings come back once with their row count and are split in Ruby, so the cost scales with the number of *distinct tag strings*, not rows (the spec asserts a single `SELECT … COUNT … GROUP BY`).
- Ordered by count descending, then tag name — a Hash keeps insertion order, so `.keys` is the cloud. `limit:` keeps the top N.
- Relation-aware (scopes, `tagged_with`, `where`); an `ORDER BY` on the relation is dropped for the aggregate. A record counts once per tag even if its stored string repeats it; `downcase: true` folds `Ruby`/`ruby` into one tag. `{}` when nothing is tagged.

## Docs

- `README.md` — example line, a performance note, the `acts-as-taggable-on` handoff no longer lists counts/clouds.
- `docs/concerns/taggable.md` — `.tag_counts` section, two Notes bullets updated.

## Changelog entry (for `CHANGELOG.md` at release — kept out of this diff so parallel enhancement PRs don't conflict)

```
### Added
- **Models::Taggable**: `tag_counts(limit: nil)` — relation-aware tag → record
  count ordered by count then name, from a single `GROUP BY` on the tag column
  (cost scales with distinct tag strings, not rows). The tag-cloud query.
```

## Test plan

- [x] +7 examples: ordering; once-per-record with a repeated stored tag; relation-aware (`where`, `tagged_with`, and an ordered relation); `limit:` including `0`; empty table; exactly one `GROUP BY … COUNT` query; `downcase: true` folding.
- [x] Full suite: 1264 examples, 0 failures (98.32%).
- [x] RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
