### PR TITLE
Schedulable: overlapping(from, to) scope and overlaps? predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,9 @@ Promotion.current                    # WHERE starts_at <= NOW AND (ends_at IS NU
 Promotion.upcoming                   # WHERE starts_at > NOW
 Promotion.expired                    # WHERE ends_at <= NOW
 Promotion.active_at(time)            # active at an arbitrary time
+Promotion.overlapping(from, to)      # windows intersecting [from, to) — clashing bookings, a calendar page
+Promotion.overlapping(from..to)      # Range form; `..` makes the end inclusive; nil on either side = unbounded
+promo.overlaps?(from, to)            # the instance-side predicate
 ```
 
 **Configuration**

--- a/docs/concerns/schedulable.md
+++ b/docs/concerns/schedulable.md
@@ -78,6 +78,7 @@ All scopes are added in the `included` block, so they are available without call
 | `.current` | Delegates to `.active_at(Time.zone.now)`. |
 | `.upcoming` | Records whose start column is strictly after `Time.zone.now`. Returns `none` if `starts_at` is configured as `nil`. |
 | `.expired` | Records whose end column is on or before `Time.zone.now`. Returns `none` if `ends_at` is configured as `nil`. |
+| `.overlapping(from, to = nil)` | Records whose window intersects the query window `[from, to)` — the clash check for bookings, the query for a calendar page. Same boundary rules as `.active_at` (inclusive start, exclusive end): a record whose window merely touches the query window (`ends_at == from` or `starts_at == to`) does not overlap. Either side may be `nil` (unbounded). Accepts a `Range` instead of two arguments; `from..to` makes the end inclusive, `from...to` keeps it exclusive. Unstarted records (`nil` start) never overlap, matching `.active_at`. An inverted window raises `ArgumentError`. Affixable like the other scopes. |
 
 ```ruby
 # Active right now
@@ -101,6 +102,7 @@ Promotion.expired
 |---|---|
 | `active_at?(time) → Boolean` | Returns `true` when the record's start time is on or before `time` AND the end time is either `nil` or strictly after `time`. Boundary semantics: inclusive start, exclusive end. |
 | `current? → Boolean` | Calls `active_at?(Time.zone.now)`. |
+| `overlaps?(from, to = nil) → Boolean` | Instance-side mirror of `.overlapping`: does this record's window intersect `[from, to)`? Same boundary, `nil`-side and `Range` rules. |
 | `upcoming? → Boolean` | Returns `true` when the start column value is strictly after `Time.zone.now`. Returns `false` if the start field is not configured or the value is `nil`. |
 | `expired? → Boolean` | Returns `true` when the end column value is on or before `Time.zone.now`. Returns `false` if the end field is not configured or the value is `nil`. |
 | `start!(time = Time.zone.now)` | Writes `time` to the configured start column and persists with `update`. Raises a plain `RuntimeError` if no start field is configured. |
@@ -179,6 +181,7 @@ Coupon.upcoming # => []
 
 ## Notes & gotchas
 
+- **`overlapping` uses the standard interval test** — `starts_at < to AND (ends_at IS NULL OR ends_at > from)` — with the exclusive end matching `active_at`, so back-to-back bookings (`09:00–10:00`, `10:00–11:00`) do not clash. Pass `from..to` when you want an inclusive end.
 - **Boundary semantics are inclusive-start, exclusive-end.** A record is active at exactly `starts_at` but is not active at exactly `ends_at`. This matches the behavior of SQL half-open intervals and is verified by the spec's `freeze_time` boundary tests.
 - **`nil` column values have defined semantics.** A `nil` start value means "not yet started" — the record is not `current?` or `upcoming?`. A `nil` end value means "never expires" — the record remains `current?` indefinitely once started. A record with both `nil` is not current, not upcoming, and not expired.
 - **No `default_scope`.** Unlike `SoftDeletable`, `Schedulable` does not hide records automatically. All records are returned by plain `Model.all`; time-filtering must be applied explicitly via `.current`, `.upcoming`, `.expired`, or `.active_at`.

--- a/lib/concerns_on_rails/models/schedulable.rb
+++ b/lib/concerns_on_rails/models/schedulable.rb
@@ -9,7 +9,7 @@ module ConcernsOnRails
 
       DEFAULT_STARTS_AT_FIELD = :starts_at
       DEFAULT_ENDS_AT_FIELD = :ends_at
-      SCOPE_BASES = %i[active_at current upcoming expired].freeze
+      SCOPE_BASES = %i[active_at current upcoming expired overlapping].freeze
 
       included do
         class_attribute :schedulable_starts_at_field, instance_accessor: false, default: DEFAULT_STARTS_AT_FIELD
@@ -49,7 +49,49 @@ module ConcernsOnRails
                                                   label: "ConcernsOnRails::Models::Schedulable")
         end
 
+        # The relation behind the `overlapping` scope. Public (like
+        # schedulable_window) because scope lambdas resolve methods through the
+        # relation, which cannot reach private class methods.
+        def schedulable_overlapping(from, to = nil)
+          from, to, inclusive_end = schedulable_window(from, to)
+          relation = all
+          relation = schedulable_started_before(relation, to, inclusive_end) if schedulable_starts_at_field
+          relation = schedulable_ending_after(relation, from) if schedulable_ends_at_field && from
+          relation
+        end
+
+        # Normalizes an overlapping/overlaps? window into [from, to,
+        # inclusive_end]: two Times, or one Range (`..` → inclusive end).
+        def schedulable_window(from, to)
+          inclusive_end = false
+          if from.is_a?(Range)
+            raise ArgumentError, "ConcernsOnRails::Models::Schedulable: pass a Range or from/to, not both" unless to.nil?
+
+            inclusive_end = !from.exclude_end?
+            to = from.end
+            from = from.begin
+          end
+          raise ArgumentError, "ConcernsOnRails::Models::Schedulable: from must not be after to" if from && to && from > to
+
+          [from, to, inclusive_end]
+        end
+
         private
+
+        # Started (NULL never overlaps, matching active_at) and, with a `to`,
+        # started before it — or on it for an inclusive Range end.
+        def schedulable_started_before(relation, to, inclusive_end)
+          column = arel_table[schedulable_starts_at_field]
+          return relation.where.not(schedulable_starts_at_field => nil) if to.nil?
+
+          relation.where(inclusive_end ? column.lteq(to) : column.lt(to))
+        end
+
+        # Open-ended, or ending strictly after `from`.
+        def schedulable_ending_after(relation, from)
+          column = arel_table[schedulable_ends_at_field]
+          relation.where(column.eq(nil).or(column.gt(from)))
+        end
 
         # Built here rather than inline in `included do` so the names can be
         # affixed. `current` resolves `active_at` through the names map — a
@@ -88,6 +130,14 @@ module ConcernsOnRails
 
             where(arel_table[field].lteq(Time.zone.now))
           }
+
+          # Records whose window intersects [from, to) — bookings that clash,
+          # events on a calendar page. Same boundary rules as active_at
+          # (inclusive start, exclusive end): a window that merely touches the
+          # query window does not overlap. Either side may be nil (unbounded);
+          # a Range works too, and `from..to` makes the end inclusive.
+          # Unstarted records (nil starts_at) never overlap, matching active_at.
+          scope schedulable_scope_names[:overlapping], ->(from, to = nil) { schedulable_overlapping(from, to) }
         end
       end # rubocop:enable Metrics/BlockLength
 
@@ -98,6 +148,13 @@ module ConcernsOnRails
 
       def current?
         active_at?(Time.zone.now)
+      end
+
+      # Does this record's window intersect [from, to)? Mirrors the
+      # `overlapping` scope — boundaries, nil sides and Ranges included.
+      def overlaps?(from, to = nil)
+        from, to, inclusive_end = self.class.schedulable_window(from, to)
+        schedulable_starts_before?(to, inclusive_end) && schedulable_ends_after?(from)
       end
 
       def upcoming?
@@ -169,6 +226,30 @@ module ConcernsOnRails
         value.nil? || value > time
       end
       private :schedulable_not_ended_at?
+
+      # Started (nil = never, matching active_at) and, when `to` is given,
+      # started before it (or on it, for an inclusive Range end).
+      def schedulable_starts_before?(to, inclusive_end)
+        field = self.class.schedulable_starts_at_field
+        return true unless field
+
+        value = self[field]
+        return false if value.nil?
+        return true if to.nil?
+
+        inclusive_end ? value <= to : value < to
+      end
+      private :schedulable_starts_before?
+
+      # Still running at `from` (open-ended or ending strictly after it).
+      def schedulable_ends_after?(from)
+        field = self.class.schedulable_ends_at_field
+        return true unless field && from
+
+        value = self[field]
+        value.nil? || value > from
+      end
+      private :schedulable_ends_after?
     end
   end
 end

--- a/spec/concerns/models/schedulable_spec.rb
+++ b/spec/concerns/models/schedulable_spec.rb
@@ -274,4 +274,90 @@ describe ConcernsOnRails::Schedulable do
       expect(klass.expired_window.pluck(:id)).to eq([over.id])
     end
   end
+  describe ".overlapping / #overlaps? (window intersection)" do
+    let(:t0) { Time.utc(2026, 6, 1, 10) }
+    let!(:before) { Promotion.create!(name: "before", starts_at: t0 - 3.hours, ends_at: t0 - 1.hour) }
+    let!(:touching_start) { Promotion.create!(name: "touching-start", starts_at: t0 - 2.hours, ends_at: t0) }
+    let!(:inside) { Promotion.create!(name: "inside", starts_at: t0 + 30.minutes, ends_at: t0 + 1.hour) }
+    let!(:spanning) { Promotion.create!(name: "spanning", starts_at: t0 - 1.day, ends_at: t0 + 1.day) }
+    let!(:open_ended) { Promotion.create!(name: "open-ended", starts_at: t0 - 1.hour) }
+    let!(:touching_end) { Promotion.create!(name: "touching-end", starts_at: t0 + 2.hours, ends_at: t0 + 3.hours) }
+    let!(:after) { Promotion.create!(name: "after", starts_at: t0 + 5.hours) }
+    let!(:unstarted) { Promotion.create!(name: "unstarted") }
+
+    def names(relation)
+      relation.order(:id).map(&:name)
+    end
+
+    it "returns records whose window intersects [from, to) — inclusive start, exclusive end" do
+      expect(names(Promotion.overlapping(t0, t0 + 2.hours))).to eq(%w[inside spanning open-ended])
+    end
+
+    it "excludes windows that only touch the boundaries" do
+      result = names(Promotion.overlapping(t0, t0 + 2.hours))
+      expect(result).not_to include("touching-start", "touching-end")
+    end
+
+    it "accepts a Range, honouring an inclusive end (..) vs an exclusive one (...)" do
+      expect(names(Promotion.overlapping(t0...(t0 + 2.hours)))).to eq(%w[inside spanning open-ended])
+      expect(names(Promotion.overlapping(t0..(t0 + 2.hours)))).to eq(%w[inside spanning open-ended touching-end])
+    end
+
+    it "treats a nil side as unbounded" do
+      expect(names(Promotion.overlapping(t0 + 4.hours, nil))).to eq(%w[spanning open-ended after])
+      expect(names(Promotion.overlapping(nil, t0 - 90.minutes))).to eq(%w[before touching-start spanning])
+      expect(Promotion.overlapping(nil, nil).count).to eq(Promotion.where.not(starts_at: nil).count) # unstarted never overlap
+    end
+
+    it "never returns unstarted records (nil starts_at), matching active_at" do
+      expect(names(Promotion.overlapping(t0 - 10.years, t0 + 10.years))).not_to include("unstarted")
+    end
+
+    it "is chainable and rejects an inverted window" do
+      expect(names(Promotion.where(name: "inside").overlapping(t0, t0 + 2.hours))).to eq(%w[inside])
+      expect { Promotion.overlapping(t0 + 1.hour, t0) }.to raise_error(ArgumentError, /from must not be after to/)
+    end
+
+    it "#overlaps? mirrors the scope, including boundaries and nil sides" do
+      expect(inside.overlaps?(t0, t0 + 2.hours)).to be(true)
+      expect(spanning.overlaps?(t0, t0 + 2.hours)).to be(true)
+      expect(open_ended.overlaps?(t0, t0 + 2.hours)).to be(true)
+      expect(touching_start.overlaps?(t0, t0 + 2.hours)).to be(false)
+      expect(touching_end.overlaps?(t0, t0 + 2.hours)).to be(false)
+      expect(touching_end.overlaps?(t0..(t0 + 2.hours))).to be(true)
+      expect(unstarted.overlaps?(t0 - 10.years, t0 + 10.years)).to be(false)
+      expect(after.overlaps?(t0 + 4.hours, nil)).to be(true)
+      expect(before.overlaps?(nil, t0 - 90.minutes)).to be(true)
+    end
+
+    it "is affixable like the other scopes" do
+      klass = Class.new(TestModel) do
+        self.table_name = "promotions"
+        include ConcernsOnRails::Schedulable
+
+        schedulable_by prefix: :promo
+      end
+      expect(klass).to respond_to(:promo_overlapping)
+      expect(klass).not_to respond_to(:overlapping)
+      expect(klass.promo_overlapping(t0, t0 + 2.hours).count).to eq(3)
+    end
+
+    it "works with an ends_at-only configuration (open-ended start)" do
+      ActiveRecord::Schema.define do
+        create_table :ending_promos, force: true do |t|
+          t.datetime :expires_at
+        end
+      end
+      klass = Class.new(TestModel) do
+        self.table_name = "ending_promos"
+        include ConcernsOnRails::Schedulable
+
+        schedulable_by starts_at: nil, ends_at: :expires_at
+      end
+      live = klass.create!(expires_at: t0 + 1.hour)
+      klass.create!(expires_at: t0 - 1.hour)
+      expect(klass.overlapping(t0, t0 + 2.hours).to_a).to eq([live])
+      expect(live.overlaps?(t0, t0 + 2.hours)).to be(true)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

"Which bookings clash with this one?" and "what's on the calendar between Monday and Friday?" are the two Schedulable queries every app writes by hand — and usually gets the boundaries wrong on.

```ruby
Room.overlapping(from, to)        # windows intersecting [from, to)
Room.overlapping(from..to)        # Range form; `..` makes the end inclusive, `...` keeps it exclusive
Room.overlapping(from, nil)       # nil on either side = unbounded
booking.overlaps?(from, to)       # instance-side mirror, same rules
```

- **The standard interval test** — `starts_at < to AND (ends_at IS NULL OR ends_at > from)` — with the same inclusive-start / exclusive-end rules as `active_at`, so back-to-back bookings (09–10, 10–11) do not clash and a window that merely touches the query window is excluded.
- Unstarted records (`nil` start) never overlap, matching `active_at`. Works with an `ends_at`-only configuration.
- Affixable like the other scopes (added to `SCOPE_BASES`), chainable, and an inverted window raises `ArgumentError`.
- The window normalization and the relation builder are public class methods (`schedulable_window`, `schedulable_overlapping`) because scope lambdas resolve methods through the relation, which cannot reach private class methods.

## Docs

- `README.md` — three lines in the Schedulable example.
- `docs/concerns/schedulable.md` — `.overlapping` scope row, `overlaps?` predicate row, a Notes bullet on the interval test.

## Changelog entry (for `CHANGELOG.md` at release — kept out of this diff so parallel enhancement PRs don't conflict)

```
### Added
- **Models::Schedulable**: `.overlapping(from, to)` (or a Range; `nil` sides
  unbounded) returns records whose window intersects `[from, to)` with the
  same inclusive-start / exclusive-end rules as `active_at`, and
  `#overlaps?(from, to)` mirrors it on a record. Affixable like the other
  scopes.
```

## Test plan

- [x] +9 examples: intersection set; touching boundaries excluded; Range with inclusive vs exclusive end; `nil` sides (both, and each); unstarted records excluded; chainable + inverted window raises; predicate mirror across all cases; affixing (`promo_overlapping`); `ends_at`-only model.
- [x] Full suite: 1266 examples, 0 failures (98.34%).
- [x] RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
