### PR TITLE
Paginatable: total: for collections that are already one page (external APIs, search services)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1470,6 +1470,15 @@ Anything answering `limit`/`offset` is treated as a relation; any other non-`Has
 (`Array`, `Set`, `Range`, `Enumerator` — consumed once) is materialized and sliced. A `Hash`,
 `nil` or a non-collection raises `ArgumentError` (call `.to_a` to paginate a Hash's pairs).
 
+**Already paginated upstream?** When an external API or search service hands you page N and the
+total it counted, pass `total:` — nothing is sliced, limited or counted; the collection comes back
+as-is and `total` drives `X-Total-Count`, `X-Total-Pages` and the `Link` header:
+
+```ruby
+result = Catalog.search(params[:q], page: params[:page], per_page: params[:per_page])
+render_success(data: paginated(result.hits, total: result.total_hits), meta: pagination_meta)
+```
+
 **URL params**
 
 | Param        | Default | Notes                              |

--- a/docs/concerns/paginatable.md
+++ b/docs/concerns/paginatable.md
@@ -47,7 +47,7 @@ end
 
 ### Instance methods
 
-**`paginated(collection) → ActiveRecord::Relation | Array`**
+**`paginated(collection, total: nil) → ActiveRecord::Relation | Array`**
 
 Applies pagination to the given collection and sets the four standard response headers. The argument is not mutated. Two kinds of input are accepted:
 
@@ -56,9 +56,11 @@ Applies pagination to the given collection and sets the four standard response h
 
 A `Hash` is rejected with an `ArgumentError` rather than silently paginated as `[key, value]` pairs (call `.to_a` if that is what you mean); `nil` and non-collections (a String, an Integer) raise the same error, naming the class received.
 
-**`pagination_meta(collection = nil) → Hash`**
+**`total:`** — the collection is already the current page (an external API or search service returned page N of a set it counted for you). Nothing is sliced, limited or counted: an Array comes back as the same Array, a relation is not given `LIMIT`/`OFFSET`, no `COUNT` runs, and `total` drives `X-Total-Count`, `X-Total-Pages` and the `Link` header. Must be a non-negative Integer (`ArgumentError` otherwise). Request the same `page`/`per_page` upstream that this controller reads.
 
-Returns `{ total:, page:, per_page:, total_pages: }` **without** applying `LIMIT`/`OFFSET` or slicing — handy for body-based pagination composed with `Respondable`'s `meta:`. Called with no argument after `paginated`, it reuses that call's memoized metadata (no second `COUNT`); pass a relation or collection to compute fresh. Accepts exactly the same inputs as `paginated`.
+**`pagination_meta(collection = nil, total: nil) → Hash`**
+
+Returns `{ total:, page:, per_page:, total_pages: }` **without** applying `LIMIT`/`OFFSET` or slicing — handy for body-based pagination composed with `Respondable`'s `meta:`. Called with no argument after `paginated`, it reuses that call's memoized metadata (no second `COUNT`); pass a relation or collection to compute fresh. Accepts exactly the same inputs as `paginated`; with `total:` the `COUNT` is skipped and the collection may be omitted entirely (`pagination_meta(total: result.total_hits)`).
 
 The four `X-*` headers set on `response`:
 

--- a/lib/concerns_on_rails/controllers/paginatable.rb
+++ b/lib/concerns_on_rails/controllers/paginatable.rb
@@ -61,18 +61,27 @@ module ConcernsOnRails
       # current page's Array slice (`[]` past the last page). The metadata is
       # memoized so a follow-up `pagination_meta` (no argument) reuses it.
       # Safe on empty collections.
-      def paginated(collection)
+      #
+      # `total:` says the collection IS the current page already — an external
+      # API or search service returned page N of a result set it counted for
+      # you. Nothing is sliced, limited or counted: the records come back
+      # untouched and `total` drives X-Total-Count, X-Total-Pages and the Link
+      # header. Ask the upstream for the same page/per_page you read here.
+      def paginated(collection, total: nil)
         @paginatable_meta = nil
         source = paginatable_source(collection)
+        pre_paginated = !total.nil?
         page = pagination_page
         per_page = pagination_per_page
         offset = (page - 1) * per_page
 
-        total = paginatable_total(source)
+        total = pre_paginated ? paginatable_validate_total!(total) : paginatable_total(source)
         total_pages = per_page.positive? ? (total.to_f / per_page).ceil : 0
 
         records =
-          if source.is_a?(Array)
+          if pre_paginated
+            source # the caller already fetched exactly this page: an Array stays an Array, a relation is not limited
+          elsif source.is_a?(Array)
             source[offset, per_page] || []
           else
             source.limit(per_page).offset(offset)
@@ -89,16 +98,11 @@ module ConcernsOnRails
       # with no argument after `paginated` to reuse its memoized meta — the
       # documented records+meta composition used to run the identical COUNT
       # twice per request. Pass a relation or collection to compute fresh.
-      def pagination_meta(collection = nil)
-        return @paginatable_meta if collection.nil? && @paginatable_meta
+      # With `total:` the COUNT is skipped (and the collection may be omitted).
+      def pagination_meta(collection = nil, total: nil)
+        return @paginatable_meta if collection.nil? && total.nil? && @paginatable_meta
 
-        if collection.nil?
-          raise ArgumentError,
-                "#{LABEL}: pagination_meta needs a relation or collection " \
-                "(no prior paginated call in this request to reuse)"
-        end
-
-        total = paginatable_total(paginatable_source(collection))
+        total = paginatable_meta_total(collection, total)
         per_page = pagination_per_page
         {
           total: total,
@@ -124,6 +128,23 @@ module ConcernsOnRails
         raise ArgumentError,
               "#{LABEL}: expected an ActiveRecord relation or an Enumerable (Array, Set, Range, ...), " \
               "got #{collection.class}#{hint}"
+      end
+
+      # `total:` wins (validated); otherwise COUNT the collection; neither
+      # given and nothing memoized is a caller error.
+      def paginatable_meta_total(collection, total)
+        return paginatable_validate_total!(total) unless total.nil?
+        return paginatable_total(paginatable_source(collection)) unless collection.nil?
+
+        raise ArgumentError,
+              "#{LABEL}: pagination_meta needs a relation or collection " \
+              "(no prior paginated call in this request to reuse)"
+      end
+
+      def paginatable_validate_total!(total)
+        return total if total.is_a?(Integer) && total >= 0
+
+        raise ArgumentError, "#{LABEL}: total: must be a non-negative Integer (got #{total.inspect})"
       end
 
       # Arrays already know their size. Relations COUNT with the clauses that

--- a/spec/concerns/controllers/paginatable_spec.rb
+++ b/spec/concerns/controllers/paginatable_spec.rb
@@ -308,4 +308,69 @@ describe ConcernsOnRails::Controllers::Paginatable do
       expect(controller.response.headers["X-Page"]).to eq("2")
     end
   end
+  describe "total: (a page that is already paginated — external APIs, search services)" do
+    let(:page_items) { (11..20).map { |i| "remote #{i}" } } # what the upstream returned for page 2 of 10
+
+    it "returns the collection unsliced and takes the totals from total:" do
+      controller = controller_class.new(params: { page: 2, per_page: 10 })
+      page = controller.paginated(page_items, total: 95)
+      expect(page).to eq(page_items)
+      expect(controller.response.headers).to include(
+        "X-Total-Count" => "95", "X-Page" => "2", "X-Per-Page" => "10", "X-Total-Pages" => "10"
+      )
+      expect(controller.pagination_meta).to eq(total: 95, page: 2, per_page: 10, total_pages: 10)
+    end
+
+    it "leaves a relation untouched too (no LIMIT/OFFSET, no COUNT)" do
+      controller = controller_class.new(params: { page: 3, per_page: 5 })
+      sql = []
+      callback = ->(*, payload) { sql << payload[:sql] if payload[:sql] =~ /\ASELECT/i }
+      records = ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        controller.paginated(Widget.where(name: "Widget 1"), total: 42).to_a
+      end
+      expect(records.map(&:name)).to eq(["Widget 1"])
+      expect(sql.size).to eq(1)
+      expect(sql.first).not_to match(/LIMIT|COUNT/i)
+      expect(controller.response.headers["X-Total-Count"]).to eq("42")
+      expect(controller.response.headers["X-Total-Pages"]).to eq("9")
+    end
+
+    it "builds the Link header from total:" do
+      klass = IntegrationHarness.build_controller do
+        include ConcernsOnRails::Controllers::Paginatable
+
+        define_method(:index) { render json: paginated(%w[a b], total: 45) }
+      end
+      result = IntegrationHarness.dispatch(klass, :index, query: "page=2&per_page=10")
+      expect(result.header("Link")).to include('<http://example.org/?page=5&per_page=10>; rel="last"')
+      expect(result.header("Link")).to include('<http://example.org/?page=3&per_page=10>; rel="next"')
+    end
+
+    it "pagination_meta accepts total: with or without a collection, skipping the COUNT" do
+      controller = controller_class.new(params: { page: 4, per_page: 20 })
+      expect(controller.pagination_meta(total: 61)).to eq(total: 61, page: 4, per_page: 20, total_pages: 4)
+      expect(controller.pagination_meta(Widget.all, total: 61)).to eq(total: 61, page: 4, per_page: 20, total_pages: 4)
+    end
+
+    it "handles total: 0 (empty page, no Link)" do
+      controller = controller_class.new
+      expect(controller.paginated([], total: 0)).to eq([])
+      expect(controller.response.headers["X-Total-Count"]).to eq("0")
+      expect(controller.response.headers["X-Total-Pages"]).to eq("0")
+      expect(controller.response.headers).not_to have_key("Link")
+    end
+
+    it "rejects a negative or non-Integer total:" do
+      controller = controller_class.new
+      expect { controller.paginated([], total: -1) }.to raise_error(ArgumentError, /total: must be a non-negative Integer/)
+      expect { controller.paginated([], total: "95") }.to raise_error(ArgumentError, /total: must be a non-negative Integer/)
+      expect { controller.pagination_meta(total: 1.5) }.to raise_error(ArgumentError, /total: must be a non-negative Integer/)
+    end
+
+    it "still slices and counts when total: is omitted" do
+      controller = controller_class.new(params: { page: 2, per_page: 3 })
+      expect(controller.paginated(page_items)).to eq(page_items[3, 3])
+      expect(controller.response.headers["X-Total-Count"]).to eq("10")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`paginated(hits)` sliced whatever it was given, so a controller proxying an external API or search service — which returns **page N and its own total** — had to fake a full collection or hand-write the `X-*` headers. The deferred item from #40, now that arrays exist:

```ruby
result = Catalog.search(params[:q], page: params[:page], per_page: params[:per_page])
render_success(data: paginated(result.hits, total: result.total_hits), meta: pagination_meta)
```

- With `total:` the collection **is** the current page: nothing is sliced, limited or counted — an Array comes back as the same Array, a relation gets no `LIMIT`/`OFFSET` and no `COUNT` runs — and `total` drives `X-Total-Count`, `X-Total-Pages` and the `Link` header.
- `pagination_meta(total:)` skips the `COUNT` and may omit the collection entirely.
- `total:` must be a non-negative Integer (`ArgumentError` otherwise). Without `total:` nothing changes.

**Stack**: based on `feature/pagination-link-headers` (#45), which sits on #40 — so this diff shows only the `total:` change. Merge order: #40 → #45 → this (and #59, also based on #45).

## Docs

- `README.md` — "Already paginated upstream?" paragraph with the example.
- `docs/concerns/paginatable.md` — `paginated` / `pagination_meta` signatures and the `total:` description.

## Changelog entry (for `CHANGELOG.md` at release — kept out of this diff so parallel enhancement PRs don't conflict)

```
### Added
- **Controllers::Paginatable**: `paginated(collection, total:)` /
  `pagination_meta(total:)` for collections that are already one page — an
  external API's or search service's page N plus its total: nothing is sliced
  or counted, and `total` drives the headers and the `Link` header.
```

## Test plan

- [x] +7 examples: unsliced Array with headers and memoized meta; relation untouched (one query, no `LIMIT`/`COUNT`); `Link` built from `total:`; `pagination_meta` with and without a collection; `total: 0`; negative / non-Integer rejected; default path unchanged.
- [x] Full suite on the stack: 1299 examples, 0 failures.
- [x] RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
