### PR TITLE
Searchable: ranked: relevance ordering (exact → prefix → substring) and search_rank

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,13 +721,22 @@ Article.search("ruby framework")  # title OR body must contain "ruby" AND "frame
 # match: :prefix           — term%  (starts with)
 # match: :exact            — term   (full match)
 searchable_by :sku, match: :prefix
+
+# ranked: true — best matches first: exact, then prefix, then substring hits;
+# within a tier the earlier-declared column wins. Portable CASE expression, no index needed.
+searchable_by :title, :body, ranked: true
+Article.search("ruby")                        # "ruby" (title) → "Ruby" (body) → "Rubyists…" → "…about ruby"
+Article.search("ruby", ranked: false)         # per-call override (and `ranked: true` opts in per call)
+Article.recent.search("ruby")                 # relevance leads; the existing ORDER BY breaks ties
+Article.search(q).pluck(:id, Article.search_rank(q))  # the score itself (0 = exact hit on the first column)
 ```
 
 **Notes**
 - Uses Arel's `matches`, which emits `ILIKE` on Postgres (case-insensitive) and `LIKE` elsewhere.
 - The query is escaped before interpolation — `%`, `_`, and `\` from user input are treated as literals, not wildcards.
 - Blank or nil queries return the relation unchanged, so it's safe to drop into a controller pipeline.
-- Reach for `pg_search` / Elasticsearch when you need ranking, stemming, or full-text indexes.
+- `ranked:` uses `reorder`, so relevance is always the primary sort; under `mode: :all` the per-term scores are summed.
+- Reach for `pg_search` / Elasticsearch when you need stemming, weighting by frequency, or full-text indexes.
 
 ---
 

--- a/docs/concerns/searchable.md
+++ b/docs/concerns/searchable.md
@@ -1,4 +1,4 @@
-A lightweight LIKE-based full-text search concern for ActiveRecord models. `Searchable` adds a `.search` scope that queries one or more string columns using SQL `LIKE` / `ILIKE` patterns, handling input escaping automatically. It requires no external search engine, no background indexing, and no additional gems — making it a practical first choice for applications where ranked or stemmed full-text search is not yet needed.
+A lightweight LIKE-based full-text search concern for ActiveRecord models. `Searchable` adds a `.search` scope that queries one or more string columns using SQL `LIKE` / `ILIKE` patterns, handling input escaping automatically. It requires no external search engine, no background indexing, and no additional gems — making it a practical first choice for applications where stemmed, indexed full-text search is not yet needed. An opt-in `ranked:` mode orders results by relevance (exact → prefix → substring) with a portable `CASE` expression.
 
 ## When to use it
 
@@ -6,6 +6,7 @@ A lightweight LIKE-based full-text search concern for ActiveRecord models. `Sear
 - An admin interface that needs a quick "search by title or body" filter across a `posts` or `articles` table.
 - A customer support tool that must search open tickets by subject line using a simple starts-with or contains pattern.
 - Any model where search inputs come from untrusted user input and you need SQL wildcard characters (`%`, `_`, `\`) to be treated as literals automatically.
+- A search-as-you-type box or admin lookup where the exact or prefix hit should be the first row, not buried among substring matches (`ranked: true`).
 - Prototyping or early-stage apps where `pg_search` or Elasticsearch would be premature — you can swap the concern out later without changing call sites.
 
 ## Installation
@@ -25,6 +26,9 @@ class Article < ApplicationRecord
 
   # OR: require an exact, case-sensitive match
   # searchable_by :code, match: :exact, case_sensitive: true
+
+  # OR: order results by relevance (exact → prefix → substring)
+  # searchable_by :title, :body, ranked: true
 end
 ```
 
@@ -54,7 +58,7 @@ end
 The single macro `searchable_by` configures the concern. It must be called at least once; calling it a second time on the same class replaces all previous settings.
 
 ```
-searchable_by(*fields, mode:, match:, case_sensitive:)
+searchable_by(*fields, mode:, match:, case_sensitive:, ranked:)
 ```
 
 | Option | Type | Default | Description |
@@ -63,8 +67,11 @@ searchable_by(*fields, mode:, match:, case_sensitive:)
 | `mode:` | `:any` \| `:all` | `:any` | `:any` treats the entire query string as a single term. `:all` splits the query on whitespace and requires every term to match at least one of the configured columns (each term adds an `AND` `WHERE` clause; columns for that term are combined with `OR`). |
 | `match:` | `:contains` \| `:prefix` \| `:exact` | `:contains` | Controls the LIKE pattern shape. `:contains` wraps the term as `%term%`. `:prefix` appends a trailing wildcard: `term%`. `:exact` emits the term verbatim with no wildcards. |
 | `case_sensitive:` | `Boolean` | `false` | When `false`, Arel emits `ILIKE` on PostgreSQL (case-insensitive). When `true`, plain `LIKE` is emitted on all adapters. SQLite's `LIKE` is case-insensitive for ASCII by default regardless of this setting. |
+| `ranked:` | `Boolean` | `false` | When `true`, `.search` orders results by relevance: exact matches first, then prefix matches, then substring matches; within a tier the earlier-declared column wins. Built as a `CASE` expression over the same `LIKE`/`ILIKE` predicates (so it follows `case_sensitive:`), applied with `reorder` — the relation's existing `ORDER BY` becomes the tiebreaker. Under `mode: :all` the per-term scores are summed. Anything other than `true`/`false` raises `ArgumentError`. |
 
 Valid values for `mode:` are `:any` and `:all`. Valid values for `match:` are `:contains`, `:prefix`, and `:exact`. Passing any other value raises `ArgumentError` at class-load time.
+
+The tiers `ranked:` can distinguish depend on `match:` — `:contains` ranks exact → prefix → substring, `:prefix` ranks exact → prefix, and `:exact` (where every hit is exact) ranks by column position alone.
 
 ## Scopes
 
@@ -72,7 +79,7 @@ Valid values for `mode:` are `:any` and `:all`. Valid values for `match:` are `:
 
 | Scope | Description |
 |---|---|
-| `.search(query)` | Returns records where at least one configured column matches `query`. When `query` is `nil` or blank (including whitespace-only strings), returns the unfiltered relation unchanged. Fully chainable with other scopes and `where` clauses. |
+| `.search(query, ranked: nil)` | Returns records where at least one configured column matches `query`. When `query` is `nil` or blank (including whitespace-only strings), returns the unfiltered relation unchanged (and unordered). Fully chainable with other scopes and `where` clauses. `ranked: true` / `false` overrides the macro's `ranked:` for this call. |
 
 ```ruby
 # Basic usage
@@ -94,7 +101,8 @@ Article.search("rails").where(published: true).order(:created_at)
 | Method | Signature | Description |
 |---|---|---|
 | `searchable_by` | `searchable_by(*fields, mode: :any, match: :contains, case_sensitive: false)` | Configuration macro. Sets the columns, match mode, pattern style, and case sensitivity for the `.search` scope. Raises `ArgumentError` for empty field lists, missing columns, or unrecognised option values. |
-| `search_relation` | `search_relation(query) → ActiveRecord::Relation` | Public class method backing the `.search` scope. Accepts a query string and returns a relation. Called by the scope lambda; can also be called directly when composing queries programmatically. |
+| `search_relation` | `search_relation(query, ranked: nil) → ActiveRecord::Relation` | Public class method backing the `.search` scope. Accepts a query string and returns a relation. Called by the scope lambda; can also be called directly when composing queries programmatically. |
+| `search_rank` | `search_rank(query) → Arel node` | The relevance expression `ranked:` orders by — lower is better, `0` is an exact hit on the first declared column, `tier × columns + column position` in general. Pass it to `pluck`/`select` to expose scores. Raises `ArgumentError` for a blank query. |
 
 ### Instance methods
 
@@ -158,6 +166,32 @@ Book.search("ruby language").pluck(:title)
 # => ["Ruby"]
 ```
 
+**Relevance ranking**
+
+```ruby
+class Article < ApplicationRecord
+  include ConcernsOnRails::Searchable
+
+  searchable_by :title, :body, ranked: true
+end
+
+Article.create!(title: "Introduction to Ruby", body: "ruby basics")
+Article.create!(title: "ruby",                 body: "the language")
+Article.create!(title: "Rubyists unite",       body: "")
+Article.create!(title: "Gems",                 body: "Ruby")
+Article.create!(title: "Other",                body: "loves ruby")
+
+Article.search("ruby").pluck(:title)
+# => ["ruby", "Gems", "Rubyists unite", "Introduction to Ruby", "Other"]
+#     exact title, exact body, prefix title, prefix body, substring body
+
+Article.search("ruby").pluck(:title, Article.search_rank("ruby"))
+# => [["ruby", 0], ["Gems", 1], ["Rubyists unite", 2], ["Introduction to Ruby", 3], ["Other", 5]]
+
+Article.order(created_at: :desc).search("ruby")   # relevance first, newest first within a tier
+Article.search("ruby", ranked: false)             # plain filter, no ORDER BY
+```
+
 ## Notes & gotchas
 
 - **At least one field is required.** Calling `searchable_by` with no arguments raises `ArgumentError` immediately at class-load time (message includes "at least one field").
@@ -168,4 +202,7 @@ Book.search("ruby language").pluck(:title)
 - **Case sensitivity is adapter-dependent.** With `case_sensitive: false` (the default), Arel emits `ILIKE` on PostgreSQL, which is genuinely case-insensitive. On SQLite, `LIKE` is used and is case-insensitive for ASCII characters by default, but case-sensitive for non-ASCII. On MySQL, case sensitivity depends on the column collation, not the `ILIKE`/`LIKE` distinction.
 - **`mode: :all` splits on whitespace only.** The split is `String#split` with no argument, which splits on any whitespace run. There is no phrase-quoting or stop-word handling. A query of `"ruby on rails"` produces three terms: `"ruby"`, `"on"`, `"rails"`.
 - **`searchable_by` is not additive.** Calling it a second time on the same class replaces `searchable_fields`, `searchable_mode`, `searchable_match`, and `searchable_case_sensitive` entirely — it does not merge with a previous call.
+- **`ranked:` replaces the ORDER BY head.** It calls `reorder(rank, *existing_orders)`, so relevance is always the primary key and whatever the relation was already ordered by breaks ties. Add your own `.reorder` after `.search` if you need something else on top.
+- **`ranked:` and `DISTINCT`/`GROUP BY`.** PostgreSQL requires ORDER BY expressions to appear in the select list under `SELECT DISTINCT`; select `search_rank(q)` explicitly or drop `distinct` when ranking.
+- **Ranking is by match shape, not frequency.** A row that mentions the term ten times scores the same as one that mentions it once; prefer `pg_search`'s `ts_rank` when term frequency matters.
 - **No full-text indexes are created.** For large tables, performance depends entirely on a sequential scan against the LIKE pattern. Consider `pg_search` (PostgreSQL) or a dedicated search service when the table grows beyond a few hundred thousand rows or when ranking and stemming are needed.

--- a/lib/concerns_on_rails/models/searchable.rb
+++ b/lib/concerns_on_rails/models/searchable.rb
@@ -12,11 +12,13 @@ module ConcernsOnRails
     #     searchable_by :title, :body, mode: :all                      # every term must match
     #     searchable_by :sku,         match: :prefix                   # "abc" -> "abc%"
     #     searchable_by :code,        match: :exact, case_sensitive: true
+    #     searchable_by :title, :body, ranked: true                    # best matches first
     #   end
     #
     #   Article.search("hello")            # WHERE title ILIKE '%hello%' OR body ILIKE '%hello%'
     #   Article.search("")                 # no-op — returns the full relation
     #   Article.search("foo").where(...)   # chainable like any scope
+    #   Article.search("foo", ranked: true) # per-call ranking override
     #
     # Options (all optional; the defaults reproduce a single-term, case-insensitive
     # "contains" search across the given columns):
@@ -27,6 +29,13 @@ module ConcernsOnRails
     #                   NOTE: this only affects Postgres. On MySQL/SQLite, LIKE
     #                   case sensitivity is governed by the column collation, so
     #                   the flag is effectively a no-op there.
+    #   ranked:         false (default). true orders results by relevance: exact
+    #                   matches, then prefix matches, then substring matches, and
+    #                   within a tier the earlier-declared column wins. Implemented
+    #                   as a portable CASE expression (no full-text index needed);
+    #                   the relation's existing ORDER BY becomes the tiebreaker.
+    #                   `search(q, ranked: true/false)` overrides per call and
+    #                   `search_rank(q)` exposes the expression for select/pluck.
     #
     # Uses Arel's `matches`. The query is escaped before interpolation, so
     # `%` / `_` / `\` from user input are treated as literals.
@@ -37,41 +46,66 @@ module ConcernsOnRails
       LIKE_SPECIAL = /[\\%_]/
       VALID_MODES = %i[any all].freeze
       VALID_MATCHES = %i[contains prefix exact].freeze
+      # Which match tiers can be told apart under each match mode (best first).
+      # Under :exact every hit is exact, so only the column position ranks.
+      RANK_TIERS = { contains: %i[exact prefix contains], prefix: %i[exact prefix], exact: %i[exact] }.freeze
 
       included do
         class_attribute :searchable_fields, instance_accessor: false, default: []
         class_attribute :searchable_mode, instance_accessor: false, default: :any
         class_attribute :searchable_match, instance_accessor: false, default: :contains
         class_attribute :searchable_case_sensitive, instance_accessor: false, default: false
+        class_attribute :searchable_ranked, instance_accessor: false, default: false
       end
 
       class_methods do
         include ConcernsOnRails::Support::ColumnGuard
 
-        def searchable_by(*fields, mode: :any, match: :contains, case_sensitive: false)
+        def searchable_by(*fields, mode: :any, match: :contains, case_sensitive: false, ranked: false)
           raise ArgumentError, "ConcernsOnRails::Models::Searchable: at least one field is required" if fields.empty?
 
           ensure_columns!("ConcernsOnRails::Models::Searchable", fields)
-          validate_search_options!(mode, match)
+          validate_search_options!(mode, match, ranked: ranked)
 
           self.searchable_fields = fields.map(&:to_sym)
           self.searchable_mode = mode.to_sym
           self.searchable_match = match.to_sym
           self.searchable_case_sensitive = case_sensitive
+          self.searchable_ranked = ranked
 
-          scope :search, ->(query) { search_relation(query) }
+          scope :search, ->(query, ranked: nil) { search_relation(query, ranked: ranked) }
         end
 
-        def search_relation(query)
-          return all if query.nil? || query.to_s.strip.empty?
+        # `ranked:` nil defers to the macro's setting; true/false override it.
+        def search_relation(query, ranked: nil)
+          terms = search_terms(query)
+          return all if terms.empty?
 
-          terms = searchable_mode == :all ? query.to_s.split : [query.to_s]
-          terms.reduce(all) { |relation, term| relation.where(search_term_predicate(term)) }
+          relation = terms.reduce(all) { |memo, term| memo.where(search_term_predicate(term)) }
+          ranked = searchable_ranked if ranked.nil?
+          ranked ? search_apply_rank(relation, terms) : relation
+        end
+
+        # The relevance expression `ranked:` orders by — lower is better, 0 is an
+        # exact match on the first column. Pluck or select it to show scores:
+        #   Article.search(q).pluck(:id, Article.search_rank(q))
+        # Under mode: :all it is the sum of the per-term scores.
+        def search_rank(query)
+          terms = search_terms(query)
+          raise ArgumentError, "ConcernsOnRails::Models::Searchable: search_rank needs a non-blank query" if terms.empty?
+
+          terms.map { |term| search_term_rank(term) }.reduce(:+)
         end
       end
 
-      class_methods do
+      module ClassMethods
         private
+
+        def search_terms(query)
+          return [] if query.nil? || query.to_s.strip.empty?
+
+          searchable_mode == :all ? query.to_s.split : [query.to_s]
+        end
 
         # OR the per-field LIKE predicate for a single term.
         def search_term_predicate(term)
@@ -82,22 +116,49 @@ module ConcernsOnRails
           predicates.reduce { |memo, predicate| memo.or(predicate) }
         end
 
-        def search_like_pattern(term)
+        def search_like_pattern(term, match = searchable_match)
           escaped = term.to_s.gsub(LIKE_SPECIAL) { |char| "#{LIKE_ESCAPE}#{char}" }
-          case searchable_match
+          case match
           when :prefix then "#{escaped}%"
           when :exact  then escaped
           else "%#{escaped}%"
           end
         end
 
-        def validate_search_options!(mode, match)
+        # reorder (not order) so relevance leads and whatever ORDER BY the
+        # relation already carried breaks ties.
+        def search_apply_rank(relation, terms)
+          rank = terms.map { |term| search_term_rank(term) }.reduce(:+)
+          relation.reorder(rank.asc, *relation.order_values)
+        end
+
+        # CASE WHEN <col1 exact> THEN 0 WHEN <col2 exact> THEN 1 WHEN <col1 prefix>
+        # THEN 2 ... ELSE <worst> END — one WHEN per (tier, column), so the
+        # score is tier * columns + column position.
+        def search_term_rank(term)
+          fields = searchable_fields
+          tiers = RANK_TIERS.fetch(searchable_match)
+          node = Arel::Nodes::Case.new
+          tiers.each_with_index do |tier, tier_index|
+            pattern = search_like_pattern(term, tier)
+            fields.each_with_index do |field, field_index|
+              matched = arel_table[field].matches(pattern, LIKE_ESCAPE, searchable_case_sensitive)
+              node = node.when(matched).then((tier_index * fields.size) + field_index)
+            end
+          end
+          node.else(tiers.size * fields.size)
+        end
+
+        def validate_search_options!(mode, match, ranked: false)
           unless VALID_MODES.include?(mode.to_sym)
             raise ArgumentError, "ConcernsOnRails::Models::Searchable: unknown mode '#{mode}'. Valid modes: #{VALID_MODES.join(', ')}"
           end
-          return if VALID_MATCHES.include?(match.to_sym)
+          unless VALID_MATCHES.include?(match.to_sym)
+            raise ArgumentError, "ConcernsOnRails::Models::Searchable: unknown match '#{match}'. Valid matches: #{VALID_MATCHES.join(', ')}"
+          end
+          return if [true, false].include?(ranked)
 
-          raise ArgumentError, "ConcernsOnRails::Models::Searchable: unknown match '#{match}'. Valid matches: #{VALID_MATCHES.join(', ')}"
+          raise ArgumentError, "ConcernsOnRails::Models::Searchable: ranked: must be true or false (got #{ranked.inspect})"
         end
       end
     end

--- a/spec/concerns/models/searchable_spec.rb
+++ b/spec/concerns/models/searchable_spec.rb
@@ -218,4 +218,101 @@ describe ConcernsOnRails::Searchable do
       end.to raise_error(ArgumentError, /unknown match/)
     end
   end
+  describe "relevance ranking (ranked:)" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :ranked_posts, force: true do |t|
+          t.string :title
+          t.text :body
+        end
+      end
+      stub_const("RankedPost", Class.new(TestModel) do
+        self.table_name = "ranked_posts"
+        include ConcernsOnRails::Searchable
+
+        searchable_by :title, :body, ranked: true
+      end)
+      stub_const("UnrankedPost", Class.new(TestModel) do
+        self.table_name = "ranked_posts"
+        include ConcernsOnRails::Searchable
+
+        searchable_by :title, :body
+      end)
+      RankedPost.create!(title: "Introduction to Ruby", body: "ruby basics") # title contains, body prefix
+      RankedPost.create!(title: "ruby", body: "the language")                # title exact
+      RankedPost.create!(title: "Rubyists unite", body: "")                  # title prefix
+      RankedPost.create!(title: "Gems", body: "Ruby")                        # body exact
+      RankedPost.create!(title: "Other", body: "loves ruby")                 # body contains
+    end
+
+    it "orders exact before prefix before substring matches, earlier columns first within a tier" do
+      expect(RankedPost.search("ruby").pluck(:title))
+        .to eq(["ruby", "Gems", "Rubyists unite", "Introduction to Ruby", "Other"])
+    end
+
+    it "keeps the relation's existing ORDER BY as the tiebreaker" do
+      RankedPost.create!(title: "ruby", body: "another exact")
+      expect(RankedPost.order(body: :desc).search("ruby").pluck(:body).first(2)).to eq(["the language", "another exact"])
+      expect(RankedPost.order(body: :asc).search("ruby").pluck(:body).first(2)).to eq(["another exact", "the language"])
+    end
+
+    it "can be switched on or off per call" do
+      expect(UnrankedPost.search("ruby").order_values).to be_empty
+      expect(UnrankedPost.search("ruby", ranked: true).pluck(:title).first).to eq("ruby")
+      expect(RankedPost.search("ruby", ranked: false).order_values).to be_empty
+    end
+
+    it "leaves blank queries unordered and unfiltered" do
+      expect(RankedPost.search("").order_values).to be_empty
+      expect(RankedPost.search(nil).count).to eq(5)
+    end
+
+    it "sums the per-term scores under mode: :all" do
+      RankedPost.delete_all
+      stub_const("AllRankedPost", Class.new(TestModel) do
+        self.table_name = "ranked_posts"
+        include ConcernsOnRails::Searchable
+
+        searchable_by :title, :body, mode: :all, ranked: true
+      end)
+      AllRankedPost.create!(title: "Introduction to Ruby", body: "gems galore") # 4 + 3
+      AllRankedPost.create!(title: "Ruby", body: "gems")                        # 0 + 1
+      AllRankedPost.create!(title: "rubygems", body: "")                        # 2 + 4
+      AllRankedPost.create!(title: "python", body: "gems")                      # excluded: no "ruby"
+
+      expect(AllRankedPost.search("ruby gems").pluck(:title)).to eq(["Ruby", "rubygems", "Introduction to Ruby"])
+    end
+
+    it "ranks by column position alone under match: :exact" do
+      RankedPost.delete_all
+      stub_const("ExactRankedPost", Class.new(TestModel) do
+        self.table_name = "ranked_posts"
+        include ConcernsOnRails::Searchable
+
+        searchable_by :title, :body, match: :exact, ranked: true
+      end)
+      ExactRankedPost.create!(title: "x", body: "ruby")
+      ExactRankedPost.create!(title: "ruby", body: "x")
+      ExactRankedPost.create!(title: "rubyist", body: "rubyist")
+
+      expect(ExactRankedPost.search("ruby").pluck(:title)).to eq(%w[ruby x])
+    end
+
+    it "exposes the rank expression through search_rank for select/pluck" do
+      ranks = RankedPost.search("ruby").pluck(RankedPost.search_rank("ruby"))
+      expect(ranks).to eq([0, 1, 2, 3, 5])
+      expect { RankedPost.search_rank("  ") }.to raise_error(ArgumentError, /search_rank needs a non-blank query/)
+    end
+
+    it "validates ranked: at class load" do
+      expect do
+        Class.new(TestModel) do
+          self.table_name = "ranked_posts"
+          include ConcernsOnRails::Searchable
+
+          searchable_by :title, ranked: :maybe
+        end
+      end.to raise_error(ArgumentError, /ranked: must be true or false/)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`Searchable` filters well but returns hits in table order, so a search-as-you-type box shows "Introduction to Ruby" above the article literally titled "ruby". This adds opt-in relevance ordering without a search engine or index.

- **`searchable_by :title, :body, ranked: true`** — `search(q)` orders exact matches first, then prefix matches, then substring matches; within a tier the earlier-declared column wins. Score = `tier × columns + column position` (0 = exact hit on the first column).
- **Portable** — one `CASE WHEN col ILIKE … THEN n …` expression built from the same escaped `matches` predicates the `WHERE` uses, so it honours `case_sensitive:` and works on SQLite/PostgreSQL/MySQL alike. No new columns, no index.
- **Composable** — applied with `reorder(rank, *existing_orders)`, so relevance leads and whatever the relation was already ordered by (`Article.recent.search(q)`) breaks ties. Blank queries stay unfiltered *and* unordered.
- **Per-call override** — `search(q, ranked: true | false)`; the macro value is the default.
- **`search_rank(q)`** — the Arel expression itself, for `pluck`/`select` (`Article.search(q).pluck(:id, Article.search_rank(q))`). Under `mode: :all` it is the sum of the per-term scores; under `match: :prefix` / `:exact` only the distinguishable tiers are emitted (`:exact` ranks by column position alone).
- `ranked:` is validated at class load (`true`/`false` only).

## Changelog entry

```
### Added
- **Searchable**: `searchable_by ..., ranked: true` orders `search` results by relevance — exact
  matches, then prefix matches, then substring matches, earlier-declared columns first within a
  tier — via a portable CASE expression (no index); the relation's existing ORDER BY becomes the
  tiebreaker. `search(q, ranked: true|false)` overrides per call; `search_rank(q)` exposes the
  score expression for `pluck`/`select`. Per-term scores are summed under `mode: :all`.
```

## Test plan

- [x] `spec/concerns/models/searchable_spec.rb` — 8 new examples: tier/column ordering, existing ORDER BY kept as tiebreaker (both directions), per-call override both ways, blank query unordered, `mode: :all` summed scores, `match: :exact` column-position ranking, `search_rank` pluck values `[0, 1, 2, 3, 5]` + blank-query error, `ranked:` validation.
- [x] Full suite: 1265 examples, 0 failures. RuboCop clean.
- [x] README "Searchable" section + `docs/concerns/searchable.md` (option row, scope signature, `search_rank` method row, ranking example, DISTINCT/frequency gotchas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
