### PR TITLE
Maskable: masked_attributes and as_json(masked:) — carry the masks into serialized output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1134,6 +1134,18 @@ end
 
 `mask:` sets the mask character (default `*`). Nil and non-string values pass through untouched. To strip dangerous HTML instead, see [Sanitizable](#-sanitizable).
 
+**Serialization** — mask in the response, not just in the view
+
+```ruby
+user.masked_attributes            # => { "email" => "j****@example.com", "card" => "**** **** **** 4242" }
+user.as_json(masked: true)        # every declared field swapped for its masked form, the rest raw
+user.as_json(masked: [:email])    # just these fields (undeclared ones raise)
+user.to_json(masked: true, only: %i[id email])   # composes with only:/except:/methods:/include:
+render json: users.map { |u| u.as_json(masked: true) }
+```
+
+Plain `as_json` / `to_json` are untouched, so nothing changes until you ask.
+
 ---
 
 ## 💰 Monetizable

--- a/docs/concerns/maskable.md
+++ b/docs/concerns/maskable.md
@@ -1,4 +1,4 @@
-Non-destructive display masking for sensitive model attributes. `Maskable` adds a `masked_<field>` reader for each declared field and **never writes to the database column** — the raw value is preserved exactly as stored, making masking a pure presentation concern. It ships five built-in masking presets (email, phone, credit card, last-four, and full mask) and accepts a custom `Proc` for arbitrary strategies. There are no runtime gem dependencies beyond `ActiveSupport`.
+Non-destructive display masking for sensitive model attributes. `Maskable` adds a `masked_<field>` reader for each declared field and **never writes to the database column** — the raw value is preserved exactly as stored, making masking a pure presentation concern. It ships five built-in masking presets (email, phone, credit card, last-four, and full mask) and accepts a custom `Proc` for arbitrary strategies. `masked_attributes` and `as_json(masked: true)` carry the masks into serialized output. There are no runtime gem dependencies beyond `ActiveSupport`.
 
 ## When to use it
 
@@ -7,6 +7,7 @@ Non-destructive display masking for sensitive model attributes. `Maskable` adds 
 - Logging or serializing phone numbers with PII regulations (GDPR, CCPA) that prohibit full exposure.
 - Showing SSNs or national ID numbers in read-only views where a partial hint is sufficient for identity confirmation.
 - Building API responses that include a "safe" representation of a secret token or API key without exposing the full value.
+- Rendering the same record to two audiences — full values for the owner, `record.as_json(masked: true)` for support staff or a public profile — without maintaining a serializer per audience.
 
 ## Installation
 
@@ -63,6 +64,8 @@ For each field declared with `maskable`, the concern defines one reader on the m
 | Signature | Description |
 |-----------|-------------|
 | `masked_<field>` | Returns the masked representation of the attribute. Returns `nil` when the column value is `nil`. Returns non-`String` values unchanged (for preset strategies). |
+| `masked_attributes` | Every declared field masked, as a `Hash` with `String` keys (like `attributes`): `{ "email" => "j***@x.com", "card" => "**** **** **** 4242" }`. Undeclared columns are not included. |
+| `serializable_hash(masked: true \| [:field, ...])` | The standard Rails serialization entry point (so `as_json` and `to_json` accept the same option). `masked: true` swaps every declared field for its masked form; an Array/Symbol limits it to those fields. Fields removed by `only:`/`except:` stay removed; a field in `masked:` that was never declared `maskable` raises `ArgumentError`. Without `masked:` the output is unchanged. |
 
 ### Class methods
 
@@ -119,6 +122,35 @@ key.masked_token  # => "sk_l…[REDACTED]"
 key.token         # => "sk_live_abc123xyz"
 ```
 
+### Masked serialization
+
+```ruby
+class User < ApplicationRecord
+  include ConcernsOnRails::Maskable
+
+  maskable :email, with: :email
+  maskable :card,  with: :credit_card
+end
+
+user = User.create!(email: "john.doe@example.com", card: "4242424242424242", name: "John")
+
+user.masked_attributes
+# => { "email" => "j*******@example.com", "card" => "**** **** **** 4242" }
+
+user.as_json(masked: true)
+# => { "id" => 1, "email" => "j*******@example.com", "card" => "**** **** **** 4242", "name" => "John", ... }
+
+user.as_json(masked: [:email], only: %i[id email card])
+# => { "id" => 1, "email" => "j*******@example.com", "card" => "4242424242424242" }
+
+user.to_json(masked: true, methods: :masked_email)   # composes with the usual options
+user.as_json                                          # unchanged — masking is opt-in per call
+
+# In a controller:
+render json: current_user.as_json                     # the owner sees everything
+render json: other_user.as_json(masked: true)         # everyone else sees the masked view
+```
+
 ## Notes & gotchas
 
 - **Read-only by design.** `masked_<field>` is a reader-only method. There is no corresponding writer, and the concern never calls `write_attribute` or `update_column`. The raw value in the database is never modified.
@@ -132,5 +164,6 @@ key.token         # => "sk_live_abc123xyz"
 - **Phone preset edge case.** If the column value contains no digit characters, the `:phone` preset returns the value unchanged.
 - **Credit card with four or fewer digits.** When a card value has four or fewer digit characters, `:credit_card` falls back to `:all` and masks every character rather than using the grouped format.
 - **`maskable_rules` is a `class_attribute`.** Because `maskable_rules` is defined with `class_attribute`, subclasses inherit a reference to the parent's hash. Calling `maskable` in a subclass merges into a new hash (`self.maskable_rules = maskable_rules.merge(...)`) rather than mutating the parent, so subclass declarations do not bleed up.
+- **`masked:` rides `serializable_hash`.** The concern overrides `serializable_hash(options)` and calls `super` first, so `only:`/`except:`/`methods:`/`include:` behave exactly as in Rails; only the values of declared fields still present in the hash are replaced. Nested `include:` records are serialized with their own options — pass `masked:` inside the include hash (`include: { profile: { masked: true } }`) if the association is Maskable too.
 - **No ActiveRecord callbacks or hooks.** The concern does not register `before_save`, `after_initialize`, or any other callback. There is no performance impact at persistence time.
 - **No runtime gem dependencies.** `Maskable` requires only `active_support/concern`, the bundled `ConcernsOnRails::Support::Masker` helper, and the shared `ConcernsOnRails::Support::ColumnGuard` (used for the column-existence check). It does not depend on `friendly_id`, `acts_as_list`, or any other third-party gem.

--- a/lib/concerns_on_rails/models/maskable.rb
+++ b/lib/concerns_on_rails/models/maskable.rb
@@ -29,9 +29,17 @@ module ConcernsOnRails
     #   Proc         — used as-is (the caller owns the non-String guard)
     #
     # `mask:` sets the mask character (default "*") for the preset forms.
+    #
+    # Serialization: `masked_attributes` returns every declared field masked
+    # (String keys, like `attributes`), and `as_json(masked: true)` /
+    # `to_json(masked: true)` / `serializable_hash(masked: true)` swap the
+    # declared fields for their masked forms in the usual Rails serialization
+    # path — `masked: [:email]` limits it to a subset — so an API can render
+    # `user.as_json(masked: true)` without a serializer per audience.
     module Maskable
       extend ActiveSupport::Concern
 
+      LABEL = "ConcernsOnRails::Models::Maskable".freeze
       PRESETS = %i[email phone credit_card last4 all].freeze
 
       included do
@@ -55,7 +63,7 @@ module ConcernsOnRails
         end
       end
 
-      class_methods do
+      module ClassMethods
         private
 
         def resolve_masker(with, mask)
@@ -75,6 +83,41 @@ module ConcernsOnRails
           end
         end
       end
+
+      # Every declared field, masked, keyed like `attributes` (String keys):
+      #   user.masked_attributes  # => { "email" => "j***@x.com", "card" => "**** **** **** 4242" }
+      def masked_attributes
+        self.class.maskable_rules.to_h { |field, masker| [field.to_s, masker.call(self[field])] }
+      end
+
+      # `masked: true` (all declared fields) or `masked: [:email, ...]` swaps
+      # the masked form into the serialized hash — the entry point for
+      # `as_json` / `to_json` too. Fields dropped by `only:`/`except:` stay
+      # dropped; undeclared fields in `masked:` raise.
+      def serializable_hash(options = nil)
+        hash = super
+        masked = options && options[:masked]
+        return hash unless masked
+
+        maskable_fields_for(masked).each do |field|
+          next unless hash.key?(field.to_s)
+
+          hash[field.to_s] = self.class.maskable_rules.fetch(field).call(self[field])
+        end
+        hash
+      end
+
+      def maskable_fields_for(masked)
+        declared = self.class.maskable_rules.keys
+        return declared if masked == true
+
+        Array(masked).map(&:to_sym).each do |field|
+          next if declared.include?(field)
+
+          raise ArgumentError, "#{LABEL}: #{field} is not a maskable field (declared: #{declared.join(', ')})"
+        end
+      end
+      private :maskable_fields_for
     end
   end
 end

--- a/spec/concerns/models/maskable_spec.rb
+++ b/spec/concerns/models/maskable_spec.rb
@@ -163,4 +163,67 @@ describe ConcernsOnRails::Models::Maskable do
       end.to raise_error(ArgumentError, /does not exist in the database/)
     end
   end
+
+  describe "masked serialization (masked_attributes / as_json(masked:))" do
+    let(:user) do
+      class MaskableUser < TestModel
+        self.table_name = "maskable_users"
+        include ConcernsOnRails::Models::Maskable
+
+        maskable :email, with: :email
+        maskable :card,  with: :credit_card
+        maskable :phone, with: :phone
+      end
+      MaskableUser.create!(email: "john.doe@example.com", card: "4242424242424242", phone: "+1 (415) 555-2671",
+                           ssn: "123456789", age: 30)
+    end
+
+    it "masked_attributes returns every declared field masked, keyed like `attributes`" do
+      expect(user.masked_attributes).to eq(
+        "email" => "j*******@example.com", "card" => "**** **** **** 4242", "phone" => "***-2671"
+      )
+      expect(user.email).to eq("john.doe@example.com")
+    end
+
+    it "as_json(masked: true) swaps the declared fields for their masked form and leaves everything else raw" do
+      json = user.as_json(masked: true)
+      expect(json.slice("email", "card", "phone")).to eq(
+        "email" => "j*******@example.com", "card" => "**** **** **** 4242", "phone" => "***-2671"
+      )
+      expect(json["ssn"]).to eq("123456789") # not declared maskable → untouched
+      expect(json["age"]).to eq(30)
+      expect(json["id"]).to eq(user.id)
+    end
+
+    it "leaves as_json / to_json untouched without the option" do
+      expect(user.as_json["email"]).to eq("john.doe@example.com")
+      expect(JSON.parse(user.to_json)["card"]).to eq("4242424242424242")
+    end
+
+    it "masked: accepts a subset of the declared fields" do
+      json = user.as_json(masked: [:email])
+      expect(json["email"]).to eq("j*******@example.com")
+      expect(json["card"]).to eq("4242424242424242")
+      expect(user.as_json(masked: "card")["card"]).to eq("**** **** **** 4242")
+    end
+
+    it "composes with only:/except:/methods: and to_json" do
+      json = user.as_json(only: %i[email age], masked: true)
+      expect(json).to eq("email" => "j*******@example.com", "age" => 30)
+      expect(user.as_json(except: [:email], masked: true)).not_to have_key("email")
+      parsed = JSON.parse(user.to_json(masked: true, methods: :masked_email))
+      expect(parsed.values_at("email", "masked_email")).to eq(["j*******@example.com", "j*******@example.com"])
+    end
+
+    it "raises for an undeclared field in masked:" do
+      expect { user.as_json(masked: [:ssn]) }
+        .to raise_error(ArgumentError, /ssn is not a maskable field \(declared: email, card, phone\)/)
+    end
+
+    it "masks nil values as nil" do
+      user.update!(card: nil)
+      expect(user.masked_attributes["card"]).to be_nil
+      expect(user.as_json(masked: true)["card"]).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`Maskable` gives you `masked_email`, `masked_card`, … one reader at a time, but the place masking actually matters in an API is the JSON body — and today that means hand-assembling a hash or writing a serializer per audience. This wires the masks into the standard Rails serialization path.

- **`masked_attributes`** — every declared field masked, `String` keys like `attributes`: `{ "email" => "j***@x.com", "card" => "**** **** **** 4242" }`.
- **`as_json(masked: true)` / `to_json(masked: true)`** — implemented as a `serializable_hash(options)` override that calls `super` first, then swaps the declared fields' values for their masked forms. `only:`/`except:`/`methods:`/`include:` behave exactly as in Rails; a field those options drop stays dropped.
- **`masked: [:email]`** (or a single Symbol) — limit to a subset; an undeclared field raises `ArgumentError` naming the declared ones, so a typo can't silently leak a raw value.
- **Opt-in per call** — plain `as_json` / `to_json` are byte-for-byte unchanged. `render json: other_user.as_json(masked: true)` is the whole integration.
- `nil` masks to `nil` as before. Header comment, README and docs page updated (methods table, example, `include:` note).

## Changelog entry

```
### Added
- **Maskable**: `masked_attributes` (every declared field masked, keyed like `attributes`) and a
  `masked:` serialization option — `as_json(masked: true)` / `to_json(masked: true)` /
  `serializable_hash(masked: true)` swap the declared fields for their masked forms
  (`masked: [:email]` for a subset; undeclared fields raise). Composes with
  `only:`/`except:`/`methods:`/`include:`; plain serialization is unchanged.
```

## Test plan

- [x] `spec/concerns/models/maskable_spec.rb` — 7 new examples: `masked_attributes` shape + raw column untouched, `as_json(masked: true)` swaps declared fields only (undeclared `ssn`, `age`, `id` raw), no option → unchanged (`as_json` and `to_json`), subset via Array and Symbol, composition with `only:`/`except:`/`methods:` and `to_json`, undeclared-field error message, nil stays nil.
- [x] Full suite: 1264 examples, 0 failures. RuboCop clean.
- [x] README "Maskable" section gained a **Serialization** block; `docs/concerns/maskable.md` gained method rows, a worked example and a `serializable_hash`/`include:` gotcha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
