### PR TITLE
Normalizable: chained normalizers (with: [...]), six new presets and Model.normalize(field, value)

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,7 +658,7 @@ expirable_by :valid_until
 
 ## ✨ Normalizable
 
-Auto-normalize attribute values in `before_validation` — strip whitespace, downcase emails, dedupe spaces, run any custom transform.
+Auto-normalize attribute values in `before_validation` — strip whitespace, downcase emails, dedupe spaces, chain transforms, run any custom lambda.
 
 ```ruby
 class User < ApplicationRecord
@@ -667,27 +667,36 @@ class User < ApplicationRecord
   normalizable :email,                  with: :email                       # strip + downcase
   normalizable :phone,                  with: :phone                       # digits only
   normalizable :first_name, :last_name, with: :whitespace                  # strip — same rule, multiple fields
-  normalizable :slug,                   with: ->(v) { v.to_s.parameterize } # custom lambda
+  normalizable :display_name,           with: %i[squish titleize]          # a chain, applied left to right
+  normalizable :bio,                    with: %i[squish nullify_blank]     # "" / "   " → nil
+  normalizable :website,                with: :url                         # "Example.COM/x" → "https://example.com/x"
+  normalizable :slug,                   with: ->(v) { v.to_s.parameterize } # custom lambda (chains with presets too)
 end
 
 User.create(email: "  ALICE@Example.com  ").email   # => "alice@example.com"
 User.create(phone: "+1 (415) 555-1234").phone       # => "14155551234"
+
+# The same rule outside a record — lookups and params see what the DB sees:
+User.find_by(email: User.normalize(:email, params[:email]))
 ```
 
 **Built-in presets**
 
-| Preset       | Transform                                |
-|--------------|------------------------------------------|
-| `:email`     | `strip` + `downcase`                     |
-| `:phone`     | digits only (`gsub(/\D/, "")`)           |
-| `:whitespace`| `strip`                                  |
-| `:squish`    | `squish` (collapse inner whitespace)     |
-| `:downcase`  | `downcase`                               |
-| `:upcase`    | `upcase`                                 |
+| Preset          | Transform                                                            |
+|-----------------|----------------------------------------------------------------------|
+| `:email`        | `strip` + `downcase`                                                 |
+| `:phone`        | digits only (`gsub(/\D/, "")`)                                       |
+| `:whitespace` / `:strip` | `strip`                                                     |
+| `:squish`       | `squish` (collapse inner whitespace)                                 |
+| `:downcase` / `:upcase` / `:capitalize` / `:titleize` | the String method of the same name |
+| `:parameterize` | `parameterize` (URL slug)                                            |
+| `:nullify_blank`| `""` or whitespace-only → `nil` (content untouched)                  |
+| `:url`          | strip, default scheme to `https://` (`host:port` counts as schemeless), lowercase scheme + host, keep path/query; unparseable input comes back stripped for your format validator to reject |
 
 **Notes**
 - Runs in `before_validation`, so DB constraints and AR validations see the normalized value.
-- `nil` values are skipped — no `nil → ""` coercion.
+- `with:` takes a preset, a Proc, or an Array of them (applied in order); every entry is validated at class load.
+- `nil` values are skipped — no `nil → ""` coercion (use `:nullify_blank` for the opposite direction).
 - Preset normalizers pass non-string values through unchanged.
 - Works on Rails 5+ (no dependency on Rails 7.1's built-in `normalizes`).
 

--- a/docs/concerns/normalizable.md
+++ b/docs/concerns/normalizable.md
@@ -1,4 +1,4 @@
-`Normalizable` automatically cleans and transforms model attribute values in a `before_validation` callback, so downstream validations, uniqueness checks, and database writes always operate on canonical data. It ships six built-in presets for the most common string transformations (whitespace stripping, email lowercasing, phone digit extraction, and case conversion) and accepts any custom `Proc` or lambda for domain-specific rules, eliminating the repetitive `before_validation` boilerplate that accumulates across large Rails codebases.
+`Normalizable` automatically cleans and transforms model attribute values in a `before_validation` callback, so downstream validations, uniqueness checks, and database writes always operate on canonical data. It ships a dozen built-in presets for the most common string transformations (whitespace, email, phone digits, case conversion, slugs, blank-to-nil, URL canonicalisation), lets you chain them (`with: %i[squish titleize]`), accepts any custom `Proc` or lambda for domain-specific rules, and exposes the same rule outside a record via `Model.normalize(field, value)` — eliminating the repetitive `before_validation` boilerplate that accumulates across large Rails codebases.
 
 ## When to use it
 
@@ -7,6 +7,8 @@
 - Stripping accidental leading/trailing whitespace from free-text fields (names, slugs, codes) so uniqueness validations and display are consistent.
 - Collapsing internal whitespace in bio or description fields where users may paste text with irregular spacing.
 - Applying a URL slug or identifier transformation (e.g., `parameterize`, `tr`, `gsub`) through a custom lambda without subclassing the model.
+- Turning optional free-text fields that arrive as `""` from forms into `NULL` (`:nullify_blank`) so `presence`/uniqueness semantics and `WHERE bio IS NULL` behave.
+- Looking a record up by a normalized value (`User.find_by(email: User.normalize(:email, params[:email]))`) so a mixed-case login form finds the lowercase row.
 
 ## Installation
 
@@ -18,6 +20,9 @@ class User < ApplicationRecord
   normalizable :phone,                   with: :phone
   normalizable :first_name, :last_name,  with: :whitespace
   normalizable :code,                    with: :upcase
+  normalizable :display_name,            with: %i[squish titleize]
+  normalizable :bio,                     with: %i[squish nullify_blank]
+  normalizable :website,                 with: :url
   normalizable :slug,                    with: ->(v) { v.to_s.parameterize }
 end
 ```
@@ -37,7 +42,7 @@ Declares one or more fields to normalize and the transformation to apply. Call t
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `*fields` | One or more `Symbol` (positional) | — | The model attribute(s) to normalize. At least one is required; passing none raises `ArgumentError`. Each field is verified to exist as a database column at class-load time. |
-| `with:` | `Symbol` or `Proc`/lambda | — | **Required.** Either a built-in preset symbol (see table below) or any callable that accepts the raw value and returns the transformed value. Passing any other type (e.g., a `String`) raises `ArgumentError`. |
+| `with:` | `Symbol`, `Proc`/lambda, or an `Array` of them | — | **Required.** A built-in preset symbol (see table below), any callable that accepts the raw value and returns the transformed value, or an Array of those applied left to right (`%i[squish titleize]`, `[:strip, ->(v) { v.reverse }]`). Every entry is validated at class load; an empty Array or any other type (e.g., a `String`) raises `ArgumentError`. |
 
 **Built-in presets for `with:`**
 
@@ -45,10 +50,15 @@ Declares one or more fields to normalize and the transformation to apply. Call t
 |--------|-----------|
 | `:email` | `strip` + `downcase` |
 | `:phone` | Remove all non-digit characters (`gsub(/\D/, "")`) |
-| `:whitespace` | `strip` (leading/trailing whitespace only) |
+| `:whitespace` / `:strip` | `strip` (leading/trailing whitespace only) |
 | `:squish` | `squish` (strip and collapse internal whitespace to single spaces) |
 | `:downcase` | `downcase` |
 | `:upcase` | `upcase` |
+| `:capitalize` | `capitalize` (first character up, the rest down) |
+| `:titleize` | `titleize` (each word capitalised) |
+| `:parameterize` | `parameterize` (URL-safe slug: `"Hello World!"` → `"hello-world"`) |
+| `:nullify_blank` | `""` or whitespace-only → `nil`; anything with content passes through untouched. Chain it last: `%i[squish nullify_blank]` |
+| `:url` | `strip`, prepend `https://` when no scheme is present (`localhost:3000` is host:port, not a scheme; `mailto:` is left alone), lowercase the scheme and host, keep path/query/fragment as typed (`"  Example.COM/Some/Path "` → `"https://example.com/Some/Path"`). Input that does not parse as a URI is returned stripped but otherwise unchanged so a format validator can reject it |
 
 All built-in presets are string-safe: they apply their transform only when the value is a `String`; non-string values pass through unchanged.
 
@@ -75,10 +85,20 @@ Iterates over all rules declared with `normalizable` and applies each normalizer
 ```ruby
 normalizable :email, with: :email
 normalizable :first_name, :last_name, with: :whitespace
+normalizable :display_name, with: %i[squish titleize]
 normalizable :code, with: ->(v) { v.to_s.parameterize }
 ```
 
-Registers normalization rules on the class. Rules accumulate across multiple calls; later calls for the same field overwrite the previous rule for that field only. Raises `ArgumentError` on configuration errors (missing fields, unknown preset, invalid `with:` type, or non-existent database column).
+Registers normalization rules on the class. Rules accumulate across multiple calls; later calls for the same field overwrite the previous rule for that field only. Raises `ArgumentError` on configuration errors (missing fields, unknown preset, invalid `with:` type or Array entry, or non-existent database column).
+
+#### `normalize(field, value)`
+
+```ruby
+User.normalize(:email, "  ALICE@Example.com ")   # => "alice@example.com"
+User.find_by(email: User.normalize(:email, params[:email]))
+```
+
+Applies the declared rule for `field` to a bare value — the exact transform a record would apply in `before_validation` — so lookups, params and background jobs canonicalise input the same way the database does. `nil` returns `nil` (records skip `nil` too). Raises `ArgumentError` naming the declared fields when `field` has no rule.
 
 ## Examples
 
@@ -146,7 +166,10 @@ account.email   # => "alice@example.com"
 - **Non-string values pass through preset normalizers unchanged.** Every built-in preset guards with `v.is_a?(String)`, so applying `:downcase` to an integer column returns the integer unmodified rather than raising a `NoMethodError`.
 - **Column existence is validated at class-load time.** If a field passed to `normalizable` does not exist in the database table, an `ArgumentError` is raised immediately when the class is evaluated (not at runtime), with the message `"does not exist in the database (table: <table_name>)"` followed by a ready-to-paste `bin/rails generate migration` command. This is enforced by `ConcernsOnRails::Support::ColumnGuard`.
 - **Multiple calls accumulate.** Each `normalizable` call merges its fields into the class-level `normalizable_rules` hash. Rules for distinct fields stack; if the same field appears in two separate calls, the later call's normalizer wins for that field.
-- **`with:` accepts only `Symbol` or `Proc`.** Passing a `String` (e.g., `with: "downcase"`) raises `ArgumentError: :with must be a preset symbol or a Proc/lambda`. This catches the common mistake of quoting a preset name.
+- **`normalize` is a class method on your model.** If your model already defines its own `normalize` class method, the concern's definition (added via `ClassMethods` on include) will be shadowed by yours when declared after the include.
+- **`with:` accepts a `Symbol`, a `Proc`, or an `Array` of them.** Passing a `String` (e.g., `with: "downcase"`) — at the top level or inside an Array — raises `ArgumentError: :with must be a preset symbol or a Proc/lambda`. This catches the common mistake of quoting a preset name. `with: []` raises too.
+- **Chains run left to right and short-circuit on type.** Each step receives the previous step's output; because presets pass non-Strings through, a `:nullify_blank` in the middle of a chain simply hands `nil` to the remaining steps. Put it last.
+- **`:url` is deliberately conservative.** It only touches the case-insensitive parts (scheme, host) and adds a missing `https://`; it never strips `www.`, trailing slashes or query strings, and never raises — pair it with `validates :website, format:` (or `URI::DEFAULT_PARSER.make_regexp`) to reject garbage.
 - **Unknown preset symbols raise immediately.** Passing an unrecognized symbol such as `with: :flarbgnarb` raises `ArgumentError: unknown preset '...'` and lists the valid preset names.
 - **`normalizable_rules` is a `class_attribute`.** It is inherited by subclasses. Rules defined on a parent class apply to all subclasses via normal Ruby inheritance; subclasses can add their own rules without affecting the parent.
 - **Works on Rails 5+.** The concern intentionally does not depend on Rails 7.1's built-in `normalizes` API, making it usable in projects that cannot upgrade to a recent Rails version.

--- a/lib/concerns_on_rails/models/normalizable.rb
+++ b/lib/concerns_on_rails/models/normalizable.rb
@@ -1,4 +1,9 @@
 require "active_support/concern"
+# The presets call String#squish / #titleize / #parameterize, which are
+# core_ext, not part of active_support/concern. Each concern file requires
+# what it uses so a direct require of this file still works.
+require "active_support/core_ext/string/filters"
+require "active_support/core_ext/string/inflections"
 require "uri"
 require "concerns_on_rails/support/column_guard"
 

--- a/lib/concerns_on_rails/models/normalizable.rb
+++ b/lib/concerns_on_rails/models/normalizable.rb
@@ -1,14 +1,44 @@
 require "active_support/concern"
+require "uri"
 require "concerns_on_rails/support/column_guard"
 
 module ConcernsOnRails
   module Models
     # Declarative attribute normalization that runs in before_validation.
     #
+    #   normalizable :email,   with: :email                     # one preset
+    #   normalizable :name,    with: %i[squish titleize]        # a chain, applied left to right
+    #   normalizable :bio,     with: %i[squish nullify_blank]   # "" / "   " -> nil
+    #   normalizable :website, with: :url                       # "Example.COM/x" -> "https://example.com/x"
+    #   normalizable :slug,    with: ->(v) { v.to_s.parameterize }
+    #
+    #   User.normalize(:email, params[:email])   # the same rule, outside a record — for lookups
+    #
     # On Rails 7.1+ you may prefer the framework-native `normalizes` macro for
     # new code; this concern provides the same ergonomics on Rails 5.0–7.0.
     module Normalizable
       extend ActiveSupport::Concern
+
+      LABEL = "ConcernsOnRails::Models::Normalizable".freeze
+      # "scheme:" — but a colon followed by a digit is a port ("localhost:3000"),
+      # not a scheme, so those still get https:// prepended.
+      URL_SCHEME = /\A[a-z][a-z0-9+.-]*:(?!\d)/i
+
+      # `:url` — strip, default the scheme to https://, lowercase the scheme and
+      # host (the case-insensitive parts) and leave path/query alone. Input that
+      # doesn't parse as a URI comes back stripped but otherwise untouched, so a
+      # format validator can still reject it.
+      def self.normalize_url(value)
+        stripped = value.strip
+        return stripped if stripped.empty?
+
+        uri = URI.parse(stripped.match?(URL_SCHEME) ? stripped : "https://#{stripped}")
+        uri.scheme = uri.scheme.downcase
+        uri.host = uri.host.downcase if uri.host
+        uri.to_s
+      rescue URI::InvalidURIError, URI::InvalidComponentError
+        stripped
+      end
 
       # Built-in normalization presets. Each is string-safe — non-string values
       # pass through unchanged so callers don't have to guard themselves.
@@ -16,9 +46,15 @@ module ConcernsOnRails
         email: ->(v) { v.is_a?(String) ? v.strip.downcase : v },
         phone: ->(v) { v.is_a?(String) ? v.gsub(/\D/, "") : v },
         whitespace: ->(v) { v.is_a?(String) ? v.strip : v },
+        strip: ->(v) { v.is_a?(String) ? v.strip : v },
         squish: ->(v) { v.is_a?(String) ? v.squish : v },
         downcase: ->(v) { v.is_a?(String) ? v.downcase : v },
-        upcase: ->(v) { v.is_a?(String) ? v.upcase : v }
+        upcase: ->(v) { v.is_a?(String) ? v.upcase : v },
+        capitalize: ->(v) { v.is_a?(String) ? v.capitalize : v },
+        titleize: ->(v) { v.is_a?(String) ? v.titleize : v },
+        parameterize: ->(v) { v.is_a?(String) ? v.parameterize : v },
+        nullify_blank: ->(v) { v.is_a?(String) && v.strip.empty? ? nil : v },
+        url: ->(v) { v.is_a?(String) ? Normalizable.normalize_url(v) : v }
       }.freeze
 
       included do
@@ -29,35 +65,57 @@ module ConcernsOnRails
       class_methods do
         include ConcernsOnRails::Support::ColumnGuard
 
-        # Declare which fields should be normalized and how.
+        # Declare which fields should be normalized and how. `with:` is a preset
+        # Symbol, a Proc, or an Array of those applied in order.
         # Example:
         #   normalizable :email, with: :email
         #   normalizable :first_name, :last_name, with: :whitespace
+        #   normalizable :name, with: %i[squish titleize]
         #   normalizable :slug, with: ->(v) { v.to_s.parameterize }
         def normalizable(*fields, with:)
-          raise ArgumentError, "ConcernsOnRails::Models::Normalizable: at least one field is required" if fields.empty?
+          raise ArgumentError, "#{LABEL}: at least one field is required" if fields.empty?
 
           normalizer = resolve_normalizer(with)
-          ensure_columns!("ConcernsOnRails::Models::Normalizable", fields)
+          ensure_columns!(LABEL, fields)
           self.normalizable_rules = normalizable_rules.merge(fields.to_h { |f| [f.to_sym, normalizer] })
+        end
+
+        # Run a field's rule on a bare value — the same transform the record
+        # applies, for lookups and params:
+        #   User.find_by(email: User.normalize(:email, params[:email]))
+        # nil stays nil (records skip nil too); an undeclared field raises.
+        def normalize(field, value)
+          normalizer = normalizable_rules[field.to_sym]
+          unless normalizer
+            raise ArgumentError,
+                  "#{LABEL}: no normalization rule for #{field.to_sym.inspect} (declared: #{normalizable_rules.keys.join(', ')})"
+          end
+
+          value.nil? ? nil : normalizer.call(value)
         end
       end
 
-      class_methods do
+      module ClassMethods
         private
+
+        # An Array composes: each step receives the previous step's output.
+        def resolve_normalizer_chain(with)
+          raise ArgumentError, "#{LABEL}: with: [] needs at least one normalizer" if with.empty?
+
+          steps = with.map { |step| resolve_normalizer(step) }
+          ->(v) { steps.reduce(v) { |memo, step| step.call(memo) } }
+        end
 
         def resolve_normalizer(with)
           case with
+          when Array then resolve_normalizer_chain(with)
           when Symbol
             PRESETS.fetch(with) do
-              raise ArgumentError,
-                    "ConcernsOnRails::Models::Normalizable: unknown preset '#{with}'. " \
-                    "Valid presets: #{PRESETS.keys.join(', ')}"
+              raise ArgumentError, "#{LABEL}: unknown preset '#{with}'. Valid presets: #{PRESETS.keys.join(', ')}"
             end
           when Proc then with
           else
-            raise ArgumentError,
-                  "ConcernsOnRails::Models::Normalizable: :with must be a preset symbol or a Proc/lambda, got #{with.class}"
+            raise ArgumentError, "#{LABEL}: :with must be a preset symbol or a Proc/lambda (or an Array of them), got #{with.class}"
           end
         end
       end

--- a/spec/concerns/models/normalizable_spec.rb
+++ b/spec/concerns/models/normalizable_spec.rb
@@ -251,4 +251,84 @@ describe ConcernsOnRails::Models::Normalizable do
       expect(user.last_name).to eq("Smith")
     end
   end
+
+  describe "chained normalizers, extra presets and Model.normalize" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :normalizable_extras, force: true do |t|
+          t.string :name
+          t.text :bio
+          t.string :slug
+          t.string :website
+          t.string :title
+          t.string :note
+        end
+      end
+      stub_const("NormalizableExtra", Class.new(TestModel) do
+        self.table_name = "normalizable_extras"
+        include ConcernsOnRails::Models::Normalizable
+
+        normalizable :name,    with: %i[squish titleize]
+        normalizable :bio,     with: %i[squish nullify_blank]
+        normalizable :slug,    with: :parameterize
+        normalizable :website, with: :url
+        normalizable :title,   with: :capitalize
+        normalizable :note,    with: [:strip, ->(v) { "#{v}!" }]
+      end)
+    end
+
+    def normalized(attrs)
+      record = NormalizableExtra.new(attrs)
+      record.valid?
+      record
+    end
+
+    it "applies an Array of presets and callables left to right" do
+      expect(normalized(name: "  alice   SMITH ").name).to eq("Alice Smith")
+      expect(normalized(note: "  abc ").note).to eq("abc!")
+    end
+
+    it ":nullify_blank turns blank strings into nil and leaves content alone" do
+      expect(normalized(bio: "   ").bio).to be_nil
+      expect(normalized(bio: "").bio).to be_nil
+      expect(normalized(bio: "  hi   there ").bio).to eq("hi there")
+    end
+
+    it ":parameterize, :capitalize and :titleize" do
+      expect(normalized(slug: "Hello World!").slug).to eq("hello-world")
+      expect(normalized(title: "hELLO").title).to eq("Hello")
+      expect(NormalizableExtra.normalize(:name, "jane doe")).to eq("Jane Doe")
+    end
+
+    it ":url defaults the scheme to https, lowercases scheme + host, keeps the path and rejects nothing" do
+      expect(normalized(website: "  Example.COM/Some/Path ").website).to eq("https://example.com/Some/Path")
+      expect(normalized(website: "HTTP://Foo.Bar:8080/X?q=Y").website).to eq("http://foo.bar:8080/X?q=Y")
+      expect(normalized(website: "mailto:Someone@Example.com").website).to eq("mailto:Someone@Example.com")
+      expect(normalized(website: "localhost:3000/admin").website).to eq("https://localhost:3000/admin")
+      expect(normalized(website: "not a url ").website).to eq("not a url") # left for a format validator to reject
+      expect(normalized(website: "   ").website).to eq("")
+    end
+
+    it "Model.normalize(field, value) applies a field's rule outside a record (lookups, params)" do
+      expect(NormalizableExtra.normalize(:name, " bob   jones ")).to eq("Bob Jones")
+      expect(NormalizableExtra.normalize("website", "Example.com")).to eq("https://example.com")
+      expect(NormalizableExtra.normalize(:bio, nil)).to be_nil
+      expect { NormalizableExtra.normalize(:zzz, "x") }
+        .to raise_error(ArgumentError, /no normalization rule for :zzz \(declared: name, bio, slug, website, title, note\)/)
+    end
+
+    it "validates every entry of an Array at class load" do
+      build = lambda do |with|
+        Class.new(TestModel) do
+          self.table_name = "normalizable_extras"
+          include ConcernsOnRails::Models::Normalizable
+
+          normalizable :name, with: with
+        end
+      end
+      expect { build.call(%i[squish bogus]) }.to raise_error(ArgumentError, /unknown preset 'bogus'/)
+      expect { build.call([]) }.to raise_error(ArgumentError, /with: \[\] needs at least one normalizer/)
+      expect { build.call([:squish, "downcase"]) }.to raise_error(ArgumentError, /must be a preset symbol or a Proc/)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Three things every real app ends up hand-rolling around `Normalizable`:

- **Chains** — `normalizable :name, with: %i[squish titleize]` / `[:strip, ->(v) { … }]`. Steps run left to right, each receiving the previous output; every entry is validated at class load (`with: []`, an unknown preset or a quoted preset name inside the Array all raise).
- **Six new presets** — `:strip` (alias of `:whitespace`), `:capitalize`, `:titleize`, `:parameterize`, `:nullify_blank` (`""`/whitespace-only → `nil`, content untouched — the missing counterpart to "nil is never coerced") and `:url` (strip, default the scheme to `https://`, lowercase scheme + host, keep path/query as typed). `:url` is deliberately conservative: `localhost:3000/admin` is host:port and gets `https://`, `mailto:` is left alone, and anything that doesn't parse as a URI comes back stripped but unchanged so `validates :website, format:` can reject it.
- **`Model.normalize(field, value)`** — the same rule outside a record, so lookups and params canonicalise the way the DB does: `User.find_by(email: User.normalize(:email, params[:email]))`. `nil` returns `nil`; an undeclared field raises naming the declared ones. (Named `normalize` rather than Rails 7.1's `normalize_value_for` to avoid shadowing the built-in on 7.1+.)

No behaviour change for existing declarations; the header comment, README table and docs page are updated.

## Changelog entry

```
### Added
- **Normalizable**: `with:` accepts an Array of presets/callables applied left to right
  (`%i[squish titleize]`), validated at class load. New presets `:strip`, `:capitalize`,
  `:titleize`, `:parameterize`, `:nullify_blank` (blank → nil) and `:url` (strip, default
  `https://`, lowercase scheme + host, path/query untouched; unparseable input passes through
  stripped). `Model.normalize(field, value)` applies a field's rule to a bare value for lookups
  and params (nil → nil; undeclared field raises).
```

## Test plan

- [x] `spec/concerns/models/normalizable_spec.rb` — 6 new examples: Array chain (presets + lambda), `:nullify_blank` on `""`/`"   "`/content, `:parameterize`/`:capitalize`/`:titleize`, `:url` (schemeless host+path, uppercase scheme/host with port and query, `mailto:`, `localhost:3000`, garbage, blank), `Model.normalize` (Symbol/String field, nil, undeclared error), class-load validation of Array entries.
- [x] Full suite: 1263 examples, 0 failures. RuboCop clean.
- [x] README "Normalizable" section (chain + `:url` + lookup example, presets table) and `docs/concerns/normalizable.md` (option row, presets table, `normalize` method, gotchas for chains/`:url`/name shadowing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
