### PR TITLE
Monetizable: scope-aware sum_/average_/minimum_/maximum_<name> aggregates and per-call formatting overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1158,9 +1158,17 @@ product.formatted_price # => "$19.99"
 |-------------------|-----------------------------------------------|
 | `price`           | the amount as a `BigDecimal` (cents ÷ 100)    |
 | `price=`          | assign in major units; rounded to whole cents |
-| `formatted_price` | a display string (`"$1,234.56"`)              |
+| `formatted_price` | a display string (`"$1,234.56"`); accepts per-call overrides: `formatted_price(unit: "€", delimiter: ".", separator: ",")` |
 
-**Options**: `as:` (explicit method name — required when the column does not end in `_cents`), `unit:` (`"$"`), `precision:` (`2`), `delimiter:` (`","`), `separator:` (`"."`), `subunit_to_unit:` (`100`). `nil` stays `nil` across all three methods.
+**Aggregates** — class methods that follow the current scope, exact and float-free:
+
+```ruby
+Product.sum_price                      # => BigDecimal   SUM(price_cents) / 100
+Product.in_stock.average_price         # average_ / minimum_ / maximum_ too — nil on an empty set (sum is 0)
+Order.paid.formatted_sum_total         # => "€3.500,50"  every aggregate has a formatted_ twin (overrides accepted)
+```
+
+**Options**: `as:` (explicit method name — required when the column does not end in `_cents`), `unit:` (`"$"`), `precision:` (`2`), `delimiter:` (`","`), `separator:` (`"."`), `subunit_to_unit:` (`100`). `nil` stays `nil` across all the accessors.
 
 ---
 

--- a/docs/concerns/monetizable.md
+++ b/docs/concerns/monetizable.md
@@ -1,4 +1,4 @@
-`Monetizable` adds float-free money accessors to any ActiveRecord model that stores monetary amounts as integer subunits (e.g. cents) in the database. Rather than reading and writing raw integers or tolerating binary-float rounding errors, the concern exposes a reader that returns a `BigDecimal`, a writer that accepts any numeric input and rounds it to whole subunits, and a display formatter — all derived automatically from the column name. No external money library is required.
+`Monetizable` adds float-free money accessors to any ActiveRecord model that stores monetary amounts as integer subunits (e.g. cents) in the database. Rather than reading and writing raw integers or tolerating binary-float rounding errors, the concern exposes a reader that returns a `BigDecimal`, a writer that accepts any numeric input and rounds it to whole subunits, a display formatter, and scope-aware class-level aggregates (`sum_price`, `average_price`, `formatted_sum_price`, …) — all derived automatically from the column name. No external money library is required.
 
 ## When to use it
 
@@ -7,6 +7,7 @@
 - An invoicing system must format amounts in different locales — e.g. `€1.999,99` for European display — using per-field delimiter and separator options.
 - A multi-currency ledger uses a non-standard subunit ratio (e.g. Japanese yen, where `subunit_to_unit: 1`) and needs the formatter to reflect that.
 - Any model where rounding money through floating-point arithmetic is unacceptable and explicit cent-level storage is preferred.
+- Reports and dashboards that need totals and averages per scope (`Order.paid.this_month.formatted_sum_total`) without repeating the cents-to-units division and formatting in every view.
 
 ## Installation
 
@@ -70,13 +71,15 @@ All method names below use `price` as the example base name, derived from a colu
 |-----------|---------|-------------|
 | `price` | `BigDecimal` or `nil` | Divides the raw integer column value by `subunit_to_unit` using `BigDecimal` arithmetic. Returns `nil` when the column is `nil`. |
 | `price=(amount)` | — | Multiplies `amount` by `subunit_to_unit`, rounds to the nearest whole subunit, and writes the result back to the integer column. Accepts any value coercible to `BigDecimal` (numeric, string). Assigns `nil` when `amount` is `nil`. |
-| `formatted_price` | `String` or `nil` | Returns a human-readable string using the `unit`, `precision`, `delimiter`, and `separator` options configured at class load time. Negative values are rendered with a leading minus before the unit symbol (e.g. `"-$5.00"`). Returns `nil` when the column is `nil`. |
+| `formatted_price(**overrides)` | `String` or `nil` | Returns a human-readable string using the `unit`, `precision`, `delimiter`, and `separator` options configured at class load time. Any of those (plus `subunit_to_unit`) can be overridden per call — `formatted_price(unit: "€", delimiter: ".", separator: ",")` — and an unknown key raises `ArgumentError`. Negative values are rendered with a leading minus before the unit symbol (e.g. `"-$5.00"`). Returns `nil` when the column is `nil`. |
 
 ### Class methods
 
 | Signature | Description |
 |-----------|-------------|
-| `monetizable(*fields, **options)` | Configuration macro. Validates that each field exists in the schema, then defines the three accessors for each field. Stores the field-to-name mapping in the class attribute `monetizable_rules`. |
+| `monetizable(*fields, **options)` | Configuration macro. Validates that each field exists in the schema, then defines the three instance accessors and the eight class-level aggregates for each field. Stores the field-to-name mapping in the class attribute `monetizable_rules`. |
+| `sum_price` / `average_price` / `minimum_price` / `maximum_price` | Scope-aware aggregates: `SUM`/`AVG`/`MIN`/`MAX` of the cents column divided by `subunit_to_unit`, as a `BigDecimal`. Because they are class methods, a relation delegates to them inside its scoping — `Product.in_stock.sum_price`, `Order.where(...).average_total`. `sum_` is `0` on an empty set; the other three return `nil`. |
+| `formatted_sum_price` / `formatted_average_price` / `formatted_minimum_price` / `formatted_maximum_price` (`**overrides`) | The same aggregates rendered through the field's formatting options (`"$1,234.56"`), with the same per-call overrides as `formatted_price`. `nil` when the aggregate is `nil`. |
 
 The class attribute `monetizable_rules` (a `Hash`) maps each raw cents column name (as a `Symbol`) to the derived method base name (as a `Symbol`). It is not part of the public API but is accessible for introspection.
 
@@ -127,6 +130,23 @@ invoice = Invoice.new(total_cents: 199_999)
 invoice.formatted_total # => "€1.999,99"
 ```
 
+**Scope-aware aggregates and report formatting**
+
+```ruby
+class Order < ApplicationRecord
+  include ConcernsOnRails::Monetizable
+
+  monetizable :total_cents, unit: "€", delimiter: ".", separator: ","
+  scope :paid, -> { where(state: "paid") }
+end
+
+Order.sum_total                     # => BigDecimal("3500.5")   SUM(total_cents) / 100
+Order.paid.average_total            # => BigDecimal("1750.25")  AVG over the paid scope only
+Order.paid.formatted_sum_total      # => "€3.500,50"
+Order.none.average_total            # => nil   (sum_total is 0)
+Order.paid.formatted_sum_total(unit: "EUR ")   # => "EUR 3.500,50"
+```
+
 ## Notes & gotchas
 
 - **Column must exist at class-load time.** `monetizable` calls `ensure_columns!` immediately when the macro is evaluated. If the migration has not been run, an `ArgumentError` is raised with the message `"'<field>' does not exist in the database (table: <table_name>)."` followed by a ready-to-paste `bin/rails generate migration ... <field>:integer` command. This means you cannot call `monetizable` in a model before running the corresponding migration.
@@ -147,6 +167,7 @@ invoice.formatted_total # => "€1.999,99"
 
 - **No ActiveRecord validations are added.** The concern defines no presence, numericality, or format validations. Add those to your model manually if required.
 
+- **Aggregates are class methods, not scopes.** `sum_price` and friends call `sum`/`average`/`minimum`/`maximum` on the current scope, so they work at the end of any relation chain but return a value, not a relation. `average` follows SQL semantics and skips `NULL` rows. On PostgreSQL the raw `AVG` is already a `BigDecimal`; on SQLite/MySQL it is cast through `BigDecimal(value.to_s)` before the division, so there is no float drift.
 - **No scope or callback hooks are defined.** This concern is purely about accessor and formatting methods; it does not touch `default_scope`, `before_save`, or any other ActiveRecord callback.
 
 ## Changed in 1.22.0

--- a/lib/concerns_on_rails/models/monetizable.rb
+++ b/lib/concerns_on_rails/models/monetizable.rb
@@ -28,8 +28,18 @@ module ConcernsOnRails
     # Options: `as:` (explicit method name — required when the column does not
     # end in `_cents`), `unit:` ("$"), `precision:` (2), `delimiter:` (","),
     # `separator:` ("."), `subunit_to_unit:` (100).
+    #
+    # Class-level aggregates come for free and follow the current scope:
+    #   Product.sum_price                        # => BigDecimal, SUM(price_cents) / 100
+    #   Product.in_stock.average_price           # average / minimum / maximum too; nil on empty sets
+    #   Product.formatted_sum_price              # => "$1,234.56" — every aggregate has a formatted_ twin
+    #   product.formatted_price(unit: "€", delimiter: ".", separator: ",")   # per-call display overrides
     module Monetizable
       extend ActiveSupport::Concern
+
+      LABEL = "ConcernsOnRails::Models::Monetizable".freeze
+      AGGREGATES = %i[sum average minimum maximum].freeze
+      FORMAT_OPTIONS = %i[unit precision delimiter separator subunit_to_unit].freeze
 
       included do
         class_attribute :monetizable_rules, instance_accessor: false, default: {}
@@ -54,15 +64,29 @@ module ConcernsOnRails
 
           ensure_columns!("ConcernsOnRails::Models::Monetizable", fields, types: :integer)
           config = { unit: unit, precision: precision, delimiter: delimiter, separator: separator, subunit_to_unit: subunit_to_unit }
-          fields.each { |cents_field| define_money_accessors(cents_field.to_sym, as, config) }
+          fields.each do |cents_field|
+            name = money_name(cents_field.to_sym, as)
+            define_money_accessors(cents_field.to_sym, name, config)
+            define_money_aggregates(cents_field.to_sym, name, config)
+          end
+        end
+
+        # Merge per-call display overrides into a field's formatting config,
+        # rejecting typos (`units:`) instead of silently ignoring them.
+        def money_format_options(config, overrides)
+          return config if overrides.empty?
+
+          unknown = overrides.keys - FORMAT_OPTIONS
+          raise ArgumentError, "#{LABEL}: unknown formatting option(s): #{unknown.join(', ')}" if unknown.any?
+
+          config.merge(overrides)
         end
       end
 
       class_methods do # rubocop:disable Metrics/BlockLength
         private
 
-        def define_money_accessors(cents_field, as, config)
-          name = money_name(cents_field, as)
+        def define_money_accessors(cents_field, name, config)
           subunit = config[:subunit_to_unit]
           self.monetizable_rules = monetizable_rules.merge(cents_field => name)
 
@@ -87,9 +111,28 @@ module ConcernsOnRails
                                 end
           end
 
-          define_method("formatted_#{name}") do
+          define_method("formatted_#{name}") do |**overrides|
             cents = self[cents_field]
-            cents.nil? ? nil : ConcernsOnRails::Support::Money.format(cents, config)
+            cents.nil? ? nil : ConcernsOnRails::Support::Money.format(cents, self.class.money_format_options(config, overrides))
+          end
+        end
+
+        # `sum_price` / `average_price` / `minimum_price` / `maximum_price` and
+        # their `formatted_` twins. Defined on the singleton so a relation
+        # (`Product.in_stock.sum_price`) delegates here inside its scoping;
+        # `public_send(aggregate)` then runs against the current scope.
+        def define_money_aggregates(cents_field, name, config)
+          subunit = config[:subunit_to_unit]
+          AGGREGATES.each do |aggregate|
+            define_singleton_method("#{aggregate}_#{name}") do
+              cents = public_send(aggregate, cents_field)
+              cents.nil? ? nil : BigDecimal(cents.to_s) / subunit
+            end
+
+            define_singleton_method("formatted_#{aggregate}_#{name}") do |**overrides|
+              cents = public_send(aggregate, cents_field)
+              cents.nil? ? nil : ConcernsOnRails::Support::Money.format(cents, money_format_options(config, overrides))
+            end
           end
         end
 

--- a/spec/concerns/models/monetizable_spec.rb
+++ b/spec/concerns/models/monetizable_spec.rb
@@ -130,4 +130,60 @@ describe ConcernsOnRails::Models::Monetizable do
       expect(ConcernsOnRails::Support::Money.format(-1, subunit_to_unit: 100_000)).to eq("$0.00")
     end
   end
+
+  describe "class-level aggregates and formatting overrides" do
+    let(:klass) do
+      product_class do
+        monetizable :price_cents
+        monetizable :total_cents, unit: "€", delimiter: ".", separator: ","
+      end
+    end
+
+    before do
+      klass.create!(price_cents: 1999, total_cents: 100_000)
+      klass.create!(price_cents: 501, total_cents: 250_050)
+      klass.create!(price_cents: nil, total_cents: 0)
+    end
+
+    it "sum_/average_/minimum_/maximum_<name> return BigDecimals in major units" do
+      expect(klass.sum_price).to eq(BigDecimal("25.00"))
+      expect(klass.average_price).to eq(BigDecimal("12.5")) # AVG skips the NULL row
+      expect(klass.minimum_price).to eq(BigDecimal("5.01"))
+      expect(klass.maximum_price).to eq(BigDecimal("19.99"))
+      expect(klass.sum_price).to be_a(BigDecimal)
+    end
+
+    it "is relation-aware and nil-safe on empty sets" do
+      expect(klass.where("price_cents > 1000").sum_price).to eq(BigDecimal("19.99"))
+      expect(klass.where(total_cents: 0).sum_total).to eq(0)
+      expect(klass.none.sum_price).to eq(0)
+      expect(klass.none.average_price).to be_nil
+      expect(klass.none.maximum_price).to be_nil
+    end
+
+    it "formatted_<aggregate>_<name> uses the field's formatting options" do
+      expect(klass.formatted_sum_price).to eq("$25.00")
+      expect(klass.formatted_average_price).to eq("$12.50")
+      expect(klass.formatted_sum_total).to eq("€3.500,50")
+      expect(klass.where("price_cents > 1000").formatted_maximum_price).to eq("$19.99")
+      expect(klass.none.formatted_average_price).to be_nil
+    end
+
+    it "formatted_<name> and the formatted aggregates accept per-call overrides" do
+      expect(klass.new(price_cents: 123_456).formatted_price(unit: "€", delimiter: ".", separator: ",")).to eq("€1.234,56")
+      expect(klass.formatted_sum_price(unit: "£")).to eq("£25.00")
+      expect(klass.new(price_cents: 1999).formatted_price).to eq("$19.99") # defaults untouched
+      expect { klass.new(price_cents: 1).formatted_price(units: "x") }
+        .to raise_error(ArgumentError, /unknown formatting option\(s\): units/)
+    end
+
+    it "derives the aggregate names from as: too" do
+      amounts = product_class { monetizable :balance, as: :amount, unit: "£" }
+      amounts.delete_all
+      amounts.create!(balance: 100)
+      amounts.create!(balance: 250)
+      expect(amounts.sum_amount).to eq(BigDecimal("3.50"))
+      expect(amounts.formatted_sum_amount).to eq("£3.50")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Every report view ends up doing `Order.paid.sum(:total_cents) / 100.0` and formatting it by hand — reintroducing the float drift and the duplicated formatting the concern exists to remove. This gives each monetized field the aggregates directly.

- **`sum_<name>` / `average_<name>` / `minimum_<name>` / `maximum_<name>`** — `SUM`/`AVG`/`MIN`/`MAX` of the cents column divided by `subunit_to_unit`, as `BigDecimal` (SQLite/MySQL `AVG` floats are cast through `BigDecimal(value.to_s)` before the division). `sum_` is `0` on an empty set, the others `nil`.
- **Scope-aware** — defined as singleton methods, so a relation delegates inside its scoping: `Product.in_stock.sum_price`, `Order.where(...).average_total`, `Order.none.maximum_total` (→ `nil`).
- **`formatted_<aggregate>_<name>`** — the same aggregates rendered through the field's `unit:`/`precision:`/`delimiter:`/`separator:` (`Order.paid.formatted_sum_total # => "€3.500,50"`).
- **Per-call formatting overrides** — `formatted_price(unit: "€", delimiter: ".", separator: ",")` on instances and on the formatted aggregates; an unknown key (`units:`) raises instead of being silently ignored.
- Names follow `as:` (`monetizable :balance, as: :amount` → `sum_amount`). Existing accessors are unchanged; `monetizable_rules` keeps its shape.

## Changelog entry

```
### Added
- **Monetizable**: class-level, scope-aware aggregates per field — `sum_<name>`, `average_<name>`,
  `minimum_<name>`, `maximum_<name>` (BigDecimal in major units; `Product.in_stock.sum_price`) and
  `formatted_<aggregate>_<name>` twins. `formatted_<name>` and the formatted aggregates accept
  per-call display overrides (`unit:`, `precision:`, `delimiter:`, `separator:`, `subunit_to_unit:`;
  unknown keys raise).
```

## Test plan

- [x] `spec/concerns/models/monetizable_spec.rb` — 5 new examples: the four aggregates as BigDecimals (AVG skips NULL rows), relation/`none` behaviour (`sum` 0, others nil), formatted aggregates with the field's options (`"€3.500,50"`) and through a `where`, per-call overrides on instance + aggregate and the unknown-key error, `as:`-derived names.
- [x] Full suite: 1262 examples, 0 failures. RuboCop clean.
- [x] README "Monetizable" section (Aggregates block, `formatted_price` row) and `docs/concerns/monetizable.md` (class-method rows, report example, aggregates gotcha).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
