### PR TITLE
Includable: nested include paths (comments.author), requested_includes(as:) shapes, default: and strategy:

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,8 @@ and may be called multiple times, rather than the `<concern>_by` form.)
 - **`Sortable`** — allow-listed, multi-column ordering from `params[:sort]` (uses `reorder`).
 - **`Respondable`** — standard JSON success/error envelopes (`render_success`/`render_error`).
 - **`ErrorHandleable`** — `rescue_from` for RecordNotFound / ParameterMissing / RecordInvalid.
-- **`Includable`** — allow-listed association sideloading + sparse fieldsets.
+- **`Includable`** — allow-listed association sideloading (nested include trees via `Support::IncludeTree`,
+  `requested_includes(as: :query | :paths | :json)`, `default:`, `strategy:`) + sparse fieldsets.
 - **`SecureHeadable`** — security response headers + native CSP DSL passthrough.
 - **`Localizable`** — per-request `I18n.locale` from params / `Accept-Language` (q-values).
 - **`Authorizable`** — declarative per-action authorization (`authorize_by`, `require_role`).
@@ -233,7 +234,8 @@ query-param coercion shared by the paginators/Filterable), `UniqueRetry` (bounde
 renderer used by seven controller concerns), `FilterParameterRegistry` (live
 filter_parameters registry consulted by the proc `ConcernsOnRails::Railtie` appends at
 boot), `Encryptor` (AES-256-GCM codec with a bounded PBKDF2 key cache), `RandomValue`,
-`SequenceCalculator`, `HtmlSanitizers`, `Masker`, `Money`, `AddressData`, `Affix` (affixed
+`SequenceCalculator`, `HtmlSanitizers`, `Masker`, `Money`, `AddressData`, `IncludeTree` (nested include
+allow-list trees + the includes/paths/as_json shapes for Includable), `Affix` (affixed
 scope/accessor-name computation + `prefix: true` normalization, shared by Activatable,
 Expirable, Lockable, Anonymizable, Stateable, Storable, Publishable, SoftDeletable and
 Schedulable; the latter three additionally use its guarded scope capture/retirement — a

--- a/README.md
+++ b/README.md
@@ -1655,18 +1655,20 @@ end
 
 ## 🔗 Includable
 
-Whitelisted association sideloading + sparse fieldsets for JSON APIs — zero arbitrary `.includes` from user input.
+Whitelisted association sideloading + sparse fieldsets for JSON APIs — zero arbitrary `.includes` from user input, nested paths included.
 
 ```ruby
 class ArticlesController < ApplicationController
   include ConcernsOnRails::Controllers::Includable
 
-  includable :author, :comments,
-             fields: { articles: %i[id title published_at], authors: %i[id name] }
+  includable :author, comments: :author,                    # flat + nested, like `includes` arguments
+             fields: { articles: %i[id title published_at], authors: %i[id name] },
+             default: :author,                              # loaded when the client sends no ?include at all
+             strategy: :preload                             # :includes (default) | :preload | :eager_load
 
   def index
     render json: with_includes(Article.all),
-           include: requested_includes,
+           include: requested_includes(as: :json),
            fields:  requested_fields
   end
 end
@@ -1675,19 +1677,21 @@ end
 **URL params**
 
 ```
-GET /articles?include=author,comments&fields[articles]=id,title&fields[authors]=id,name
+GET /articles?include=author,comments.author&fields[articles]=id,title&fields[authors]=id,name
 ```
 
 **API**
 
-| Method               | What it does                                                                               |
-|----------------------|--------------------------------------------------------------------------------------------|
-| `with_includes(rel)` | Parses `params[:include]`, intersects with the allow-list, calls `relation.includes(...)`  |
-| `requested_includes` | Returns the sanitized `[:author, :comments]` array (pass to `render json:, include:`)     |
-| `requested_fields`   | Returns `{ articles: [:id, :title] }` sanitized map (pass to your serializer)             |
+| Method                        | What it does                                                                                     |
+|-------------------------------|--------------------------------------------------------------------------------------------------|
+| `with_includes(rel)`          | Parses `params[:include]`, keeps only allow-listed paths, applies them with the configured strategy |
+| `requested_includes(as:)`     | `:query` (default) → `[:author, { comments: :author }]` for `includes`/`preload`; `:paths` → `["author", "comments.author"]` for JSON:API serializers; `:json` → `[:author, { comments: { include: :author } }]` for `as_json`/`render json:` |
+| `requested_include_paths`     | The sanitized dotted paths in request order (what `as: :paths` returns)                            |
+| `requested_fields`            | Returns `{ articles: [:id, :title] }` sanitized map (pass to your serializer)                      |
 
 **Notes**
-- Non-whitelisted associations are **silently dropped** — no error, no arbitrary eager-loading.
+- A path is kept only if **every** segment follows the allow-list tree (`comments.author` needs `comments: :author`); anything else is **silently dropped** — no error, no arbitrary eager-loading.
+- `default:` applies only when `?include` is absent; `?include=` (blank) means "nothing" and is honoured. Defaults are validated against the allow-list at class load.
 - Non-whitelisted tables in `params[:fields]` are dropped; non-whitelisted columns within an allowed table are dropped.
 - Pass `requested_fields` to your serializer (e.g. AMS / Blueprinter) — `Includable` itself does not alter the JSON output, only the query.
 

--- a/docs/concerns/includable.md
+++ b/docs/concerns/includable.md
@@ -1,4 +1,4 @@
-`Includable` is a controller concern that enforces a strict allow-list for association sideloading and sparse fieldsets in JSON APIs. It solves two related problems: arbitrary `?include=` parameters from clients that could trigger `.includes` on any association (N+1 risk and unintended data exposure), and unfiltered `?fields[table]=col,...` parameters that could return columns the application never intended to serialize. Only associations and columns you declare in the `includable` macro can be requested by clients — everything else is silently dropped before it reaches the query or serializer.
+`Includable` is a controller concern that enforces a strict allow-list for association sideloading and sparse fieldsets in JSON APIs. It solves two related problems: arbitrary `?include=` parameters from clients that could trigger `.includes` on any association (N+1 risk and unintended data exposure), and unfiltered `?fields[table]=col,...` parameters that could return columns the application never intended to serialize. Only associations and columns you declare in the `includable` macro can be requested by clients — everything else is silently dropped before it reaches the query or serializer. The allow-list is a tree, so nested JSON:API paths (`?include=comments.author`) work exactly as far as you permit them; `default:` picks what loads when the client asks for nothing, and `strategy:` chooses between `includes`, `preload` and `eager_load`.
 
 ## When to use it
 
@@ -7,6 +7,8 @@
 - Multiple controllers share the same underlying model but expose different association subsets; each controller declares its own allow-list independently.
 - An endpoint aggregates several resource types and the field allow-list differs per resource table (e.g. `articles` exposes `id,title` while `authors` exposes `id,name`).
 - A security audit requires proof that no client-supplied string can ever be passed unfiltered to `ActiveRecord::Base.includes`.
+- A JSON:API client sends nested paths (`?include=comments.author,comments.reactions`) and you want to permit exactly those two levels — not `comments.author.payment_methods`.
+- An endpoint should always sideload one association unless the client explicitly asks for something else (`default: :author`).
 
 ## Installation
 
@@ -16,12 +18,14 @@ Include `ConcernsOnRails::Controllers::Includable` in any controller and call th
 class ArticlesController < ApplicationController
   include ConcernsOnRails::Controllers::Includable
 
-  includable :author, :comments,
-             fields: { articles: %i[id title published_at], authors: %i[id name] }
+  includable :author, comments: :author,
+             fields: { articles: %i[id title published_at], authors: %i[id name] },
+             default: :author,
+             strategy: :preload
 
   def index
     render json: with_includes(Article.all),
-           include: requested_includes,
+           include: requested_includes(as: :json),
            fields:  requested_fields
   end
 end
@@ -29,32 +33,49 @@ end
 
 ## Configuration
 
-The `includable` macro accepts one or more association name arguments and an optional `fields:` keyword.
+The `includable` macro accepts association arguments in the same shapes `ActiveRecord::QueryMethods#includes` does — Symbols, dotted Strings, Arrays and nested Hashes — plus `fields:`, `default:` and `strategy:` keywords.
+
+```
+includable(*associations, fields: {}, default: nil, strategy: :includes)
+```
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| `*associations` | `Symbol` / `String` (variadic) | `[]` | The associations that clients are allowed to request via `?include=`. Any value not listed here is silently dropped. Stored as `Array<Symbol>` on `includable_associations`. |
+| `*associations` | `Symbol`, dotted `String`, `Array`, nested `Hash` (variadic) | `[]` | The association **tree** clients may request via `?include=`: `:author` allows `author`; `comments: :author` allows `comments` and `comments.author`; `comments: [:author, { reactions: :user }]` goes deeper. A requested path is kept only when every segment exists in the tree. Stored as a nested Hash on `includable_tree`; the top-level names on `includable_associations` (`Array<Symbol>`). |
 | `fields:` | `Hash{ Symbol/String => Array<Symbol/String> }` | `{}` | Sparse fieldset allow-list keyed by resource table name. Each value is the list of column names the client may request for that table via `?fields[table]=col,...`. Keys and values are normalized to `Symbol`. Stored as `Hash{ Symbol => Array<Symbol> }` on `includable_fields`. |
+| `default:` | same shapes as `*associations` | `nil` | Paths eager-loaded (and returned by `requested_includes`) when the request has **no** `include` parameter at all. Every default path must be allow-listed, or `ArgumentError` is raised at class load. A blank `?include=` disables them for that request. Stored as dotted Strings on `includable_default_paths`. |
+| `strategy:` | `:includes`, `:preload` or `:eager_load` | `:includes` | The relation method `with_includes` calls. `:includes` lets ActiveRecord choose (it switches to a JOIN when the association is referenced in a `where`), `:preload` always issues separate queries, `:eager_load` always JOINs. Anything else raises `ArgumentError`. |
 
-Both `includable_associations` and `includable_fields` are `class_attribute`s initialized to `[]` / `{}` at include time; calling `includable` replaces them entirely (not merges).
+All of `includable_tree`, `includable_associations`, `includable_fields`, `includable_default_paths` and `includable_strategy` are `class_attribute`s; calling `includable` replaces them entirely (not merges).
 
 ## Methods
 
 ### Instance methods
 
 **`with_includes(relation) → ActiveRecord::Relation`**
-Parses `params[:include]`, intersects the result with `includable_associations`, and calls `relation.includes(*associations)` when at least one valid association is present. Returns `relation` unchanged when `params[:include]` is absent or contains no whitelisted entries. The returned relation is the same object as the argument when nothing is eager-loaded.
+Resolves the allow-listed include paths for this request (see `requested_include_paths`) and applies them with the configured `strategy:` — `relation.includes(:author, { comments: :author })` by default. Returns `relation` unchanged when nothing valid was requested and no `default:` applies.
 
-**`requested_includes → Array<Symbol>`**
-Parses `params[:include]` as a comma-separated string and returns the intersection with `includable_associations` as an array of symbols. Returns `[]` when the parameter is absent. Safe to pass directly to `render json:, include:`.
+**`requested_includes(as: :query) → Array`**
+The sanitized includes in the shape you need:
+
+| `as:` | Returns | Hand it to |
+|---|---|---|
+| `:query` (default) | `[:author, { comments: :author }]` | `includes`/`preload`/`eager_load`, ActiveModelSerializers `include:`, Blueprinter |
+| `:paths` | `["author", "comments.author"]` | jsonapi-serializer / JSON:API `include:` options |
+| `:json` | `[:author, { comments: { include: :author } }]` | `as_json(include:)` / `render json: records, include:` |
+
+Flat allow-lists keep returning a plain `Array<Symbol>` under `:query`, so existing call sites are unchanged. An unknown `as:` raises `ArgumentError`.
+
+**`requested_include_paths → Array<String>`**
+The allow-listed dotted paths from `params[:include]` in request order, deduplicated. Accepts a comma-separated String or an Array of them; a hash-shaped param yields `[]`. When the param is absent entirely the `default:` paths are returned; when it is present but blank, `[]`.
 
 **`requested_fields → Hash{ Symbol => Array<Symbol> }`**
 Parses `params[:fields]` as a hash of `{ table => col_list }` pairs. Tables not present in `includable_fields` are dropped. Within each allowed table, the requested columns are intersected with the declared allow-list. Tables for which the intersection is empty are also dropped from the result. Returns `{}` when `params[:fields]` is absent or is not a hash-like object. Safe to pass directly to a serializer's `fields:` keyword.
 
 ### Class methods
 
-**`includable(*associations, fields: {}) → void`**
-Declares the allow-lists for this controller. Calling the macro more than once replaces the previous allow-lists — it does not accumulate. Symbols and strings are both accepted for association names and field keys/values; all are normalized to `Symbol` internally.
+**`includable(*associations, fields: {}, default: nil, strategy: :includes) → void`**
+Declares the allow-lists for this controller. Calling the macro more than once replaces the previous allow-lists — it does not accumulate. Symbols, dotted Strings, Arrays and nested Hashes are accepted for associations (normalized into the `includable_tree`); Symbols and Strings for field keys/values. `default:` paths are validated against the tree and `strategy:` against `includes`/`preload`/`eager_load`, both raising `ArgumentError` at class load.
 
 ## Examples
 
@@ -102,8 +123,32 @@ requested_fields
 # :secret_column is dropped (not in allow-list); :unknown_table is dropped entirely
 ```
 
+**Nested paths, defaults and the three shapes**
+
+```ruby
+class StoriesController < ApplicationController
+  include ConcernsOnRails::Controllers::Includable
+
+  includable writer: :stories, remarks: :story, default: :writer, strategy: :preload
+end
+
+# GET /stories?include=remarks.story,writer.stories,writer.secret,remarks.story.writer
+requested_include_paths            # => ["remarks.story", "writer.stories"]   (the two unknown tails are dropped)
+requested_includes                 # => [{ remarks: :story }, { writer: :stories }]
+requested_includes(as: :json)      # => [{ remarks: { include: :story } }, { writer: { include: :stories } }]
+with_includes(Story.all)           # => Story.preload({ remarks: :story }, { writer: :stories })
+
+# GET /stories            (no include param)  → default applies
+requested_includes                 # => [:writer]
+# GET /stories?include=   (blank)             → the client asked for nothing
+requested_includes                 # => []
+```
+
 ## Notes & gotchas
 
+- **A path is all-or-nothing.** `comments.author.payment_methods` is dropped entirely when `payment_methods` is not in the tree — the concern never trims a path down to its allowed prefix, because the client asked for something specific and silently serving less would be confusing. Ask for `comments.author` explicitly if that is what you want.
+- **`default:` means "absent", not "blank".** JSON:API semantics: a client that sends `?include=` is opting out of defaults. Treat the two cases differently in your tests.
+- **`strategy: :eager_load` + sparse fieldsets.** `eager_load` JOINs every requested association into one query; combining it with a `select` of a few columns needs the joined tables' columns too. Prefer `:preload` when you also select columns.
 - **Non-whitelisted values are silently dropped, not raised.** Both `requested_includes` and `requested_fields` return sanitized results without raising errors or setting response status. A client requesting `?include=secret` receives a response as if the parameter were absent.
 - **`with_includes` returns the relation unchanged when nothing valid is requested.** `includes_values` on the returned relation will be `[]`, not `nil`, matching ActiveRecord's default behavior.
 - **`params[:fields]` must be a hash-like object.** `requested_fields` checks `raw.respond_to?(:each_pair)` before iterating. A non-hash value (e.g. a string) returns `{}` rather than raising.

--- a/lib/concerns_on_rails.rb
+++ b/lib/concerns_on_rails.rb
@@ -67,6 +67,7 @@ module ConcernsOnRails
 
   module Support
     autoload :ColumnGuard,             "concerns_on_rails/support/column_guard"
+    autoload :IncludeTree,             "concerns_on_rails/support/include_tree"
     autoload :ScalarParam,             "concerns_on_rails/support/scalar_param"
     autoload :UniqueRetry,             "concerns_on_rails/support/unique_retry"
     autoload :ErrorEnvelope,           "concerns_on_rails/support/error_envelope"

--- a/lib/concerns_on_rails/controllers/includable.rb
+++ b/lib/concerns_on_rails/controllers/includable.rb
@@ -1,4 +1,5 @@
 require "active_support/concern"
+require "concerns_on_rails/support/include_tree"
 
 module ConcernsOnRails
   module Controllers
@@ -10,52 +11,110 @@ module ConcernsOnRails
     #   class ArticlesController < ApplicationController
     #     include ConcernsOnRails::Controllers::Includable
     #
-    #     includable :author, :comments,
-    #                fields: { articles: %i[id title], authors: %i[id name] }
+    #     includable :author, comments: :author,        # nested paths: ?include=comments.author
+    #                fields: { articles: %i[id title], authors: %i[id name] },
+    #                default: :author,                  # eager-loaded when the client sends no ?include
+    #                strategy: :preload                 # :includes (default) | :preload | :eager_load
     #
     #     def index
     #       render json: with_includes(Article.all),
-    #              include: requested_includes,
+    #              include: requested_includes(as: :json),
     #              fields: requested_fields
     #     end
     #   end
     #
     # URL params:
-    #   ?include=author,comments         -> eager-loads only whitelisted associations
+    #   ?include=author,comments.author  -> eager-loads only whitelisted paths
     #   ?fields[articles]=id,title       -> sanitized down to the allowed columns
     #
-    # `requested_includes` / `requested_fields` return sanitized values you can
-    # hand to your serializer; they never mutate the rendered output themselves.
+    # `requested_includes` returns the sanitized includes in the shape you need —
+    # `as: :query` (default, what `includes`/`preload` take: `[:author,
+    # { comments: :author }]`), `as: :paths` (dotted Strings for JSON:API
+    # serializers) or `as: :json` (what `as_json(include:)` takes) — and
+    # `requested_fields` the sanitized fieldsets; neither mutates the rendered
+    # output itself.
     module Includable
       extend ActiveSupport::Concern
 
+      LABEL = "ConcernsOnRails::Controllers::Includable".freeze
+      STRATEGIES = %i[includes preload eager_load].freeze
+      SHAPES = %i[query paths json].freeze
+      TREE = ConcernsOnRails::Support::IncludeTree
+
       included do
         class_attribute :includable_associations, default: []
+        class_attribute :includable_tree, default: {}
         class_attribute :includable_fields, default: {}
+        class_attribute :includable_default_paths, default: []
+        class_attribute :includable_strategy, default: :includes
       end
 
-      class_methods do
-        # Whitelist sideloadable associations and (optionally) the columns
-        # exposable per resource via sparse fieldsets.
-        def includable(*associations, fields: {})
-          self.includable_associations = associations.map(&:to_sym)
+      module ClassMethods
+        # Whitelist sideloadable associations — flat Symbols and/or nested
+        # Hashes, exactly like `includes` arguments — and (optionally) the
+        # columns exposable per resource via sparse fieldsets. `default:` names
+        # the paths loaded when the client sends no `?include` at all (validated
+        # against the allow-list); `strategy:` picks the eager-loading method.
+        # Nested Hash entries arrive as **nested (Ruby 3 keyword rules) and are
+        # folded back into the association tree.
+        def includable(*associations, fields: {}, default: nil, strategy: :includes, **nested)
+          tree = TREE.from(associations + [nested], label: LABEL).freeze
+          self.includable_tree = tree
+          self.includable_associations = tree.keys
           self.includable_fields = fields.each_with_object({}) do |(table, cols), memo|
             memo[table.to_sym] = Array(cols).map(&:to_sym)
+          end
+          self.includable_strategy = includable_strategy!(strategy)
+          self.includable_default_paths = includable_default_paths!(default, tree)
+        end
+
+        private
+
+        def includable_strategy!(strategy)
+          strategy = strategy.to_sym
+          return strategy if STRATEGIES.include?(strategy)
+
+          raise ArgumentError, "#{LABEL}: strategy: must be one of #{STRATEGIES.join(', ')} (got #{strategy.inspect})"
+        end
+
+        def includable_default_paths!(default, tree)
+          TREE.paths(TREE.from(default, label: LABEL)).each do |path|
+            raise ArgumentError, "#{LABEL}: default: #{path} is not an includable path" unless TREE.allowed?(path, tree)
           end
         end
       end
 
-      # Eager-load only the whitelisted associations requested via ?include=.
+      # Eager-load only the whitelisted paths requested via ?include= (or the
+      # `default:` ones when the param is absent) with the configured strategy.
       # Returns the relation unchanged when nothing valid was requested.
       def with_includes(relation)
-        associations = requested_includes
-        associations.empty? ? relation : relation.includes(*associations)
+        includes = requested_includes
+        includes.empty? ? relation : relation.public_send(self.class.includable_strategy, *includes)
       end
 
-      # Sanitized association list: requested ∩ allow-list.
-      def requested_includes
-        requested = params[:include].to_s.split(",").map { |token| token.strip.to_sym }
-        requested & self.class.includable_associations
+      # Sanitized includes in the shape you need:
+      #   as: :query  (default) [:author, { comments: :author }]   — includes/preload/eager_load, most serializers
+      #   as: :paths            ["author", "comments.author"]      — JSON:API serializers
+      #   as: :json             [:author, { comments: { include: :author } }] — as_json / render json: include:
+      def requested_includes(as: :query)
+        paths = requested_include_paths
+        case as
+        when :query then TREE.query_shape(TREE.from_paths(paths))
+        when :json then TREE.json_shape(TREE.from_paths(paths))
+        when :paths then paths
+        else raise ArgumentError, "#{LABEL}: as: must be :query, :paths or :json (got #{as.inspect})"
+        end
+      end
+
+      # Allow-listed dotted paths from ?include= in request order (deduplicated).
+      # An absent param yields the `default:` paths; a blank one yields none.
+      def requested_include_paths
+        raw = params[:include]
+        return self.class.includable_default_paths if raw.nil?
+        return [] if raw.respond_to?(:each_pair) # ?include[x]=y — not a list
+
+        tree = self.class.includable_tree
+        includable_tokens(raw).select { |path| TREE.valid_path?(path) && TREE.allowed?(path, tree) }.uniq
       end
 
       # Sanitized sparse fieldsets: { table => [cols] }, each intersected with
@@ -79,6 +138,11 @@ module ConcernsOnRails
       end
 
       private
+
+      # ?include=a,b or ?include[]=a&include[]=b,c → ["a", "b", "c"]
+      def includable_tokens(raw)
+        (raw.is_a?(Array) ? raw : [raw]).flat_map { |value| value.to_s.split(",") }.map(&:strip)
+      end
 
       def split_field_list(cols)
         list = cols.is_a?(Array) ? cols : cols.to_s.split(",")

--- a/lib/concerns_on_rails/support/include_tree.rb
+++ b/lib/concerns_on_rails/support/include_tree.rb
@@ -1,0 +1,74 @@
+module ConcernsOnRails
+  module Support
+    # Nested association allow-lists for Controllers::Includable. A tree is a
+    # Hash of Symbol => child tree — `{ writer: {}, remarks: { story: {} } }` —
+    # built from ActiveRecord-style includes arguments or dotted request paths
+    # ("remarks.story"), and rendered back into the shapes `includes`/`preload`
+    # (`[:writer, { remarks: :story }]`) and `as_json(include:)`
+    # (`[:writer, { remarks: { include: :story } }]`) expect.
+    module IncludeTree
+      module_function
+
+      PATH = /\A[^.\s,]+(\.[^.\s,]+)*\z/
+
+      # AR-style includes arguments — Symbols, Strings (dotted allowed), Arrays,
+      # Hashes, nested freely — to a tree. Anything else raises.
+      def from(spec, label:)
+        case spec
+        when nil then {}
+        when Symbol, String then from_path(spec.to_s)
+        when Array then spec.each_with_object({}) { |entry, memo| merge!(memo, from(entry, label: label)) }
+        when Hash then spec.each_with_object({}) { |(key, children), memo| merge!(memo, key.to_sym => from(children, label: label)) }
+        else raise ArgumentError, "#{label}: associations must be Symbols, Strings, Arrays or Hashes (got #{spec.class})"
+        end
+      end
+
+      # "remarks.story" → { remarks: { story: {} } }
+      def from_path(path)
+        path.split(".").reverse.reduce({}) { |children, segment| { segment.strip.to_sym => children } }
+      end
+
+      def from_paths(paths)
+        paths.each_with_object({}) { |path, memo| merge!(memo, from_path(path)) }
+      end
+
+      def merge!(target, addition)
+        addition.each { |key, children| target[key] = merge!(target[key] || {}, children) }
+        target
+      end
+
+      # Leaf paths: { writer: {}, remarks: { story: {} } } → ["writer", "remarks.story"]
+      def paths(tree, prefix = nil)
+        tree.flat_map do |key, children|
+          path = [prefix, key].compact.join(".")
+          children.empty? ? [path] : paths(children, path)
+        end
+      end
+
+      # Well-formed dotted path: no blank segments, no stray dots/spaces.
+      def valid_path?(path)
+        path.match?(PATH)
+      end
+
+      # Does every segment of the path exist in the tree, in order?
+      def allowed?(path, tree)
+        node = path.split(".").reduce(tree) { |current, segment| current && current[segment.to_sym] }
+        !node.nil?
+      end
+
+      # Tree → `includes`/`preload`/`eager_load` arguments: [:writer, { remarks: :story }]
+      def query_shape(tree)
+        tree.map { |key, children| children.empty? ? key : { key => collapse(query_shape(children)) } }
+      end
+
+      # Tree → `as_json(include:)` arguments: [:writer, { remarks: { include: :story } }]
+      def json_shape(tree)
+        tree.map { |key, children| children.empty? ? key : { key => { include: collapse(json_shape(children)) } } }
+      end
+
+      def collapse(list)
+        list.size == 1 ? list.first : list
+      end
+    end
+  end
+end

--- a/spec/concerns/controllers/includable_spec.rb
+++ b/spec/concerns/controllers/includable_spec.rb
@@ -95,4 +95,77 @@ describe ConcernsOnRails::Controllers::Includable do
       expect(StoriesController.new.requested_fields).to eq({})
     end
   end
+
+  describe "nested includes, default: and strategy:" do
+    let(:klass) do
+      Class.new(FakeController) do
+        include ConcernsOnRails::Controllers::Includable
+
+        includable writer: :stories, remarks: :story, default: :writer, strategy: :preload
+      end
+    end
+
+    it "accepts dotted paths that follow the allow-list tree and drops the rest" do
+      c = klass.new(params: { include: "remarks.story, writer.stories,writer.secret,remarks.story.writer,remarks,,bogus" })
+      expect(c.requested_includes(as: :paths)).to eq(%w[remarks.story writer.stories remarks])
+      expect(c.requested_includes).to eq([{ remarks: :story }, { writer: :stories }])
+      expect(klass.includable_associations).to eq(%i[writer remarks])
+    end
+
+    it "mixes flat and nested entries in the query shape and nests the as_json shape" do
+      c = klass.new(params: { include: "writer,remarks.story" })
+      expect(c.requested_includes).to eq([:writer, { remarks: :story }])
+      expect(c.requested_includes(as: :json)).to eq([:writer, { remarks: { include: :story } }])
+
+      writer = Writer.create!(name: "Ann")
+      story = Story.create!(title: "T", writer: writer)
+      Remark.create!(content: "nice", story: story)
+      json = story.as_json(include: c.requested_includes(as: :json))
+      expect(json["writer"]["name"]).to eq("Ann")
+      expect(json["remarks"].first["story"]["title"]).to eq("T")
+    end
+
+    it "with_includes applies the configured strategy and really loads the nested graph" do
+      writer = Writer.create!(name: "Ann")
+      story = Story.create!(title: "T", writer: writer)
+      Remark.create!(content: "nice", story: story)
+
+      relation = klass.new(params: { include: "remarks.story" }).with_includes(Story.all)
+      expect(relation.preload_values).to eq([{ remarks: :story }])
+      expect(relation.includes_values).to eq([])
+      loaded = relation.to_a.first
+      expect(loaded.association(:remarks)).to be_loaded
+      expect(loaded.remarks.first.association(:story)).to be_loaded
+    end
+
+    it "uses default: when ?include is absent, and nothing when the client sends a blank include" do
+      expect(klass.new.requested_includes(as: :paths)).to eq(["writer"])
+      expect(klass.new.with_includes(Story.all).preload_values).to eq([:writer])
+      expect(klass.new(params: { include: "" }).requested_includes).to eq([])
+      expect(klass.new(params: { include: "remarks" }).requested_includes).to eq([:remarks])
+    end
+
+    it "accepts Array params, ignores hash-shaped garbage and rejects an unknown as:" do
+      c = klass.new(params: { include: ["writer", "remarks,secret"] })
+      expect(c.requested_includes).to eq(%i[writer remarks])
+      expect(klass.new(params: { include: { "x" => "y" } }).requested_includes).to eq([])
+      expect { c.requested_includes(as: :xml) }.to raise_error(ArgumentError, /as: must be :query, :paths or :json/)
+    end
+
+    it "validates default: against the allow-list, strategy:, and the declaration shape at class load" do
+      build = lambda do |**opts|
+        Class.new(FakeController) do
+          include ConcernsOnRails::Controllers::Includable
+
+          includable(*opts.delete(:assoc), **opts)
+        end
+      end
+      expect { build.call(assoc: [:writer], default: :remarks) }
+        .to raise_error(ArgumentError, /default: remarks is not an includable path/)
+      expect { build.call(assoc: [{ remarks: :story }], default: "remarks.story") }.not_to raise_error
+      expect { build.call(assoc: [:writer], strategy: :join) }
+        .to raise_error(ArgumentError, /strategy: must be one of includes, preload, eager_load/)
+      expect { build.call(assoc: [42]) }.to raise_error(ArgumentError, /associations must be Symbols, Strings, Arrays or Hashes/)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`Includable` only understood flat `?include=author`, while every JSON:API client sends nested paths (`comments.author`) and most serializers want the includes in their own shape. This makes the allow-list a tree and hands the sanitized result over in whichever shape the consumer needs.

- **Nested allow-list** — `includable :author, comments: :author` (any `includes`-style shape: Symbols, dotted Strings, Arrays, nested Hashes; trailing Hash entries arrive as keywords and are folded back in). `?include=comments.author` is accepted; `comments.author.payment_methods` is dropped whole — a path is kept only when *every* segment is in the tree, never trimmed to its allowed prefix.
- **`requested_includes(as:)`** — `:query` (default) `[:author, { comments: :author }]` for `includes`/`preload`/AMS/Blueprinter; `:paths` `["author", "comments.author"]` for jsonapi-serializer; `:json` `[:author, { comments: { include: :author } }]` for `as_json`/`render json: … include:` (verified against a real `as_json`). Flat declarations still return a plain `Array<Symbol>`, so existing call sites are untouched. `requested_include_paths` exposes the sanitized dotted paths.
- **`default:`** — paths loaded when the request has no `include` param at all; a blank `?include=` opts out (JSON:API semantics). Validated against the tree at class load.
- **`strategy:`** — `:includes` (default) / `:preload` / `:eager_load` for `with_includes`.
- Array-valued (`?include[]=a&include[]=b,c`) and hash-shaped params are handled. The tree/shape logic lives in a new `Support::IncludeTree` (autoloaded; CLAUDE.md updated).

## Changelog entry

```
### Added
- **Includable**: nested include allow-lists — `includable :author, comments: :author` accepts
  `?include=comments.author` (any `includes`-style shape; a path must match every segment).
  `requested_includes(as: :query | :paths | :json)` returns the sanitized includes for
  `includes`/`preload`, JSON:API serializers, or `as_json(include:)`; `requested_include_paths`
  exposes the dotted paths. `default:` loads named paths when `?include` is absent (blank opts
  out; validated at class load); `strategy:` picks `includes`/`preload`/`eager_load`.
  New `Support::IncludeTree`.
```

## Test plan

- [x] `spec/concerns/controllers/includable_spec.rb` — 6 new examples: dotted paths vs tree (unknown tails, duplicates, blanks, `includable_associations`), mixed flat+nested query shape and `as_json` shape verified against real records, `with_includes` with `strategy: :preload` really loading the nested graph (`association(...).loaded?`), `default:` absent vs blank vs explicit, Array params / hash garbage / unknown `as:`, class-load validation (default not allow-listed, dotted default accepted, bad strategy, bad declaration shape). Existing 8 examples unchanged.
- [x] Full suite: 1263 examples, 0 failures. RuboCop clean.
- [x] README "Includable" section, `docs/concerns/includable.md` (option rows, shapes table, `requested_include_paths`, worked example, all-or-nothing / absent-vs-blank / eager_load gotchas), CLAUDE.md bullets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
