### PR TITLE
Duplicable: per-call only:/except: association selection ("duplicate without line items")

### DIFF
--- a/README.md
+++ b/README.md
@@ -1422,6 +1422,8 @@ end
 
 copy = invoice.duplicate                # unsaved deep copy
 copy = invoice.duplicate!(title: "Q3")  # saved (one transaction, autosaved children)
+copy = invoice.duplicate!(except: :line_items)          # this copy skips the line items
+copy = invoice.duplicate!(only: [])                     # shallow copy — attributes only
 ```
 
 **Auto-reset identity columns** (no configuration): `created_at`/`updated_at`, Sluggable slug, Tokenizable/Hashable tokens, Sequenceable sequence + `into:` columns, Auditable trail, SoftDeletable timestamp, Lockable attempts/locked_at. Business state (Publishable, Stateable, …) is a judgment call — list it in `reset:`.
@@ -1430,6 +1432,7 @@ copy = invoice.duplicate!(title: "Q3")  # saved (one transaction, autosaved chil
 
 **Notes**
 - The macro is optional — bare `include` gives `duplicate`/`duplicate!` with the auto resets.
+- `only:` / `except:` on `duplicate` / `duplicate!` pick which of the declared associations this particular copy carries ("Duplicate with line items?" checkbox); names outside the allow-list raise. They are reserved keys — pass overrides for attributes literally named `only`/`except` as a braced Hash.
 - Override `on_duplicate(copy)` for custom tweaks; it receives the unsaved copy last.
 - Reach for [`amoeba`](https://github.com/amoeba-rb/amoeba) when you need per-attribute regex/prepend rules or belongs_to graph copying.
 

--- a/docs/concerns/duplicable.md
+++ b/docs/concerns/duplicable.md
@@ -60,8 +60,8 @@ Business state (Publishable, Stateable, Activatable, Expirable, …) is a judgme
 
 | Signature | Description |
 |---|---|
-| `duplicate(overrides = {})` | Returns an **unsaved** deep copy: `dup` + identity resets + `reset:` + `suffix:` + `overrides` (assigned through writers) + copied associations + the `on_duplicate` hook. |
-| `duplicate!(overrides = {})` | `duplicate` then `save!` in one transaction — the copy and its copied children persist together via autosave. Returns the saved copy. |
+| `duplicate(overrides = {}, only: nil, except: nil)` | Returns an **unsaved** deep copy: `dup` + identity resets + `reset:` + `suffix:` + `overrides` (assigned through writers) + copied associations + the `on_duplicate` hook. `only:` / `except:` (a name or Array of names from the macro's `associations:` allow-list) choose which associations **this** copy carries; `only: []` copies none. Both together, or a name that isn't allow-listed, raise `ArgumentError`. Braceless overrides (`duplicate(title: "Q3", except: :line_items)`) work — `only`/`except` are reserved keys, so an attribute literally named that must be passed in a braced Hash. |
+| `duplicate!(overrides = {}, only: nil, except: nil)` | `duplicate` then `save!` in one transaction — the copy and its copied children persist together via autosave. Returns the saved copy. Same `only:` / `except:` semantics. |
 | `on_duplicate(copy)` | Override point (no-op default) — receives the unsaved copy as the last step of `duplicate`. |
 
 ## Examples
@@ -104,8 +104,28 @@ class SurveyTemplate < ApplicationRecord
 end
 ```
 
+**Per-copy association selection**
+
+```ruby
+class Invoice < ApplicationRecord
+  include ConcernsOnRails::Models::Duplicable
+
+  has_many :line_items
+  has_one  :note
+  has_and_belongs_to_many :tags
+  duplicable_by associations: %i[line_items note tags], suffix: { title: " (copy)" }
+end
+
+invoice.duplicate!                                  # everything the macro allows
+invoice.duplicate!(except: :line_items)             # "Duplicate without items" — note + tags still copied
+invoice.duplicate!(only: :tags)                     # just re-link the tags
+invoice.duplicate!(title: "Q3", only: [])           # shallow copy with an override
+invoice.duplicate(only: :payments)                  # ArgumentError — not in the allow-list
+```
+
 ## Notes & gotchas
 
+- **`only:` / `except:` filter, they don't extend.** The macro's `associations:` list is the ceiling: a per-call name outside it raises, so a controller param can never smuggle in an association you didn't vet. Children copied through their *own* Duplicable rules still use their own macro lists — the filter applies to the top level only.
 - **Declare associations before the macro** (the CounterCacheable convention) — `duplicable_by` validates each name against `reflect_on_association` and raises at class-load time, not at request time.
 - **`belongs_to` is deliberately rejected.** The copy keeps the foreign key from `dup`, so it *shares* its parents; copying a parent from the child side is almost always an accident.
 - **`has_many :through` is deliberately rejected.** Duplicate the direct association — the through rows follow from it.

--- a/lib/concerns_on_rails/models/duplicable.rb
+++ b/lib/concerns_on_rails/models/duplicable.rb
@@ -121,7 +121,7 @@ module ConcernsOnRails
       # literally named that goes in a braced Hash.
       def duplicate(overrides = {}, **options)
         overrides = overrides.merge(options.except(:only, :except))
-        associations = duplicable_selected_associations(options.slice(:only, :except))
+        associations = duplicable_selected_associations(options.slice(:only, :except).compact)
 
         copy = dup
         duplicable_reset_attributes(copy)
@@ -146,13 +146,12 @@ module ConcernsOnRails
       # a controller param can never smuggle in an unvetted association.
       def duplicable_selected_associations(selection)
         declared = self.class.duplicable_config[:associations]
-        only = selection[:only]
-        except = selection[:except]
-        raise ArgumentError, "#{LABEL}: pass either :only or :except, not both" if only && except
-        return declared if only.nil? && except.nil?
+        raise ArgumentError, "#{LABEL}: pass either :only or :except, not both" if selection.size > 1
+        return declared if selection.empty?
 
-        chosen = duplicable_validate_selection!(Array(only || except).map(&:to_sym), declared)
-        only ? declared & chosen : declared - chosen
+        mode, names = selection.first
+        chosen = duplicable_validate_selection!(Array(names).map(&:to_sym), declared)
+        mode == :only ? declared & chosen : declared - chosen
       end
 
       def duplicable_validate_selection!(chosen, declared)

--- a/lib/concerns_on_rails/models/duplicable.rb
+++ b/lib/concerns_on_rails/models/duplicable.rb
@@ -113,25 +113,55 @@ module ConcernsOnRails
       # Unsaved deep copy: attributes via `dup`, identity columns blanked,
       # `reset:` columns blanked, `suffix:` strings appended, `overrides`
       # assigned, allow-listed associations copied, then `on_duplicate`.
-      def duplicate(overrides = {})
+      #
+      # `only:` / `except:` pick which of the macro's associations THIS copy
+      # carries (`duplicate!(except: :line_items)`; `only: []` is a shallow
+      # copy). Braceless overrides arrive through **options too (Ruby 3
+      # keyword rules), so `only`/`except` are reserved keys — an attribute
+      # literally named that goes in a braced Hash.
+      def duplicate(overrides = {}, **options)
+        overrides = overrides.merge(options.except(:only, :except))
+        associations = duplicable_selected_associations(options.slice(:only, :except))
+
         copy = dup
         duplicable_reset_attributes(copy)
         duplicable_apply_suffixes(copy)
         overrides.each { |attribute, value| copy.public_send("#{attribute}=", value) }
-        duplicable_copy_associations(copy)
+        duplicable_copy_associations(copy, associations)
         on_duplicate(copy)
         copy
       end
 
       # Persisted deep copy — the copy and its copied children save together
       # (autosave) inside one transaction. Returns the saved copy.
-      def duplicate!(overrides = {})
-        copy = duplicate(overrides)
+      def duplicate!(overrides = {}, **)
+        copy = duplicate(overrides, **)
         transaction { copy.save! }
         copy
       end
 
       private
+
+      # The macro's list is the ceiling: a per-call name outside it raises, so
+      # a controller param can never smuggle in an unvetted association.
+      def duplicable_selected_associations(selection)
+        declared = self.class.duplicable_config[:associations]
+        only = selection[:only]
+        except = selection[:except]
+        raise ArgumentError, "#{LABEL}: pass either :only or :except, not both" if only && except
+        return declared if only.nil? && except.nil?
+
+        chosen = duplicable_validate_selection!(Array(only || except).map(&:to_sym), declared)
+        only ? declared & chosen : declared - chosen
+      end
+
+      def duplicable_validate_selection!(chosen, declared)
+        chosen.each do |name|
+          next if declared.include?(name)
+
+          raise ArgumentError, "#{LABEL}: #{name} is not a duplicable association (declared: #{declared.join(', ')})"
+        end
+      end
 
       def duplicable_reset_attributes(copy)
         (duplicable_auto_reset_columns + self.class.duplicable_config[:reset]).each do |column|
@@ -177,8 +207,8 @@ module ConcernsOnRails
         self.class.include?(concern)
       end
 
-      def duplicable_copy_associations(copy)
-        self.class.duplicable_config[:associations].each do |name|
+      def duplicable_copy_associations(copy, associations)
+        associations.each do |name|
           reflection = self.class.reflect_on_association(name)
           case reflection.macro
           when :has_many

--- a/spec/concerns/models/duplicable_spec.rb
+++ b/spec/concerns/models/duplicable_spec.rb
@@ -311,4 +311,51 @@ RSpec.describe ConcernsOnRails::Models::Duplicable do
       expect(copy.slug).not_to eq(original.slug)
     end
   end
+
+  describe "per-call association selection (only: / except:)" do
+    let(:original) do
+      invoice = DupInvoice.create!(title: "Q1")
+      invoice.dup_line_items.create!(description: "Widget", quantity: 2)
+      invoice.dup_line_items.create!(description: "Gadget", quantity: 5)
+      DupNote.create!(dup_invoice_id: invoice.id, body: "attached")
+      invoice.dup_tags << DupTag.create!(name: "urgent")
+      invoice.reload
+    end
+
+    it "except: skips the named associations for this copy only" do
+      copy = original.duplicate!(except: :dup_line_items)
+      expect(copy.dup_line_items.count).to eq(0)
+      expect(copy.dup_note.body).to eq("attached")
+      expect(copy.dup_tags.pluck(:name)).to eq(["urgent"])
+
+      expect(original.duplicate!.dup_line_items.count).to eq(2) # the macro's list is untouched
+    end
+
+    it "only: copies just the named associations; only: [] is a shallow copy" do
+      copy = original.duplicate!(only: [:dup_tags])
+      expect(copy.dup_tags.pluck(:name)).to eq(["urgent"])
+      expect(copy.dup_line_items.count).to eq(0)
+      expect(copy.dup_note).to be_nil
+
+      shallow = original.duplicate!(only: [])
+      expect(shallow.dup_line_items.count).to eq(0)
+      expect(shallow.dup_note).to be_nil
+      expect(shallow.dup_tags).to be_empty
+      expect(shallow.title).to eq("Q1 (copy)")
+    end
+
+    it "mixes with braceless overrides and validates the selection" do
+      copy = original.duplicate!(title: "Q3", except: :dup_note)
+      expect(copy.title).to eq("Q3")
+      expect(copy.dup_note).to be_nil
+      expect(copy.dup_line_items.count).to eq(2)
+
+      expect(original.duplicate({ title: "Q4" }, only: :dup_tags).title).to eq("Q4") # positional Hash form too
+
+      expect { original.duplicate(only: :dup_note, except: :dup_tags) }
+        .to raise_error(ArgumentError, /pass either :only or :except, not both/)
+      expect { original.duplicate(only: :bogus) }
+        .to raise_error(ArgumentError, /bogus is not a duplicable association \(declared: dup_line_items, dup_note, dup_tags\)/)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`duplicable_by associations:` fixes the copied graph at class level, but the UI decision is per copy: "Duplicate this invoice — with its line items? [x]". Today that needs a second model or a post-copy `line_items.clear`.

- **`duplicate(overrides = {}, only: nil, except: nil)` / `duplicate!(...)`** — pick which of the macro's `associations:` *this* copy carries: `duplicate!(except: :line_items)`, `duplicate!(only: :tags)`, `duplicate!(only: [])` for a shallow copy. Everything else (`reset:`, `suffix:`, identity blanking, `on_duplicate`) is unchanged.
- **The macro's list is the ceiling** — a per-call name outside it raises naming the declared associations, so a controller param can never smuggle in an association you didn't vet; `only:` with `except:` raises too. Children copied through their own Duplicable rules keep their own lists (top-level filter only; documented).
- **Braceless overrides keep working** — `duplicate!(title: "Q3", except: :note)`: overrides arrive through `**options` under Ruby 3's keyword rules and are merged back into `overrides`, so `only`/`except` are reserved keys (an attribute literally named that goes in a braced Hash — documented). The positional-Hash form `duplicate({ title: "Q4" }, only: :tags)` works as before.

## Changelog entry

```
### Added
- **Duplicable**: `duplicate` / `duplicate!` accept `only:` / `except:` to choose which of the
  declared associations a particular copy carries (`duplicate!(except: :line_items)`,
  `only: []` for a shallow copy). Names outside the macro's allow-list, or both options together,
  raise. Braceless attribute overrides still work.
```

## Test plan

- [x] `spec/concerns/models/duplicable_spec.rb` — 3 new examples: `except:` skips one association while the note/tags copy and the macro list is untouched on the next call; `only:` with a subset and `only: []` shallow copy (suffix still applied); braceless overrides + `except:`, positional-Hash + `only:`, both-options error, undeclared-name error.
- [x] Full suite: 1260 examples, 0 failures. RuboCop clean.
- [x] README "Duplicable" section (two new example lines + note) and `docs/concerns/duplicable.md` (method rows, per-copy example, filter-not-extend gotcha).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

