### PR TITLE
CounterCacheable: recount_counter_caches!(association, parents:) — repair only the parents you touched

### DIFF
--- a/README.md
+++ b/README.md
@@ -1328,6 +1328,7 @@ end
 
 post.comments_count                # maintained on create / destroy / update
 Comment.recount_counter_caches!    # repair drift / backfill every counter
+Comment.recount_counter_caches!(:post, parents: imported_posts)   # repair just these parents (ids, records or a relation)
 ```
 
 Counters are adjusted with `update_counters` (a single atomic SQL `COALESCE(col,0) ± 1`) inside the record's own save transaction. The update path handles the full matrix: a **foreign-key reparent** moves the count from the old parent to the new one, a **condition flip** increments/decrements in place, and the two compose.
@@ -1337,7 +1338,7 @@ Counters are adjusted with `update_counters` (a single atomic SQL `COALESCE(col,
 **Notes**
 - The `belongs_to` must be declared **before** the macro (the reflection is validated at declaration). Polymorphic associations are not supported.
 - Don't also set native `counter_cache: true` on the same column — both would fire and double-count.
-- Counters track the **persisted** record; writes that skip callbacks (`update_column(s)`, `update_all`, `delete`) are not tracked — run `recount_counter_caches!` to reconcile. It rewrites every parent (portable across adapters, but O(n) for conditional counters) — a maintenance operation, run it offline.
+- Counters track the **persisted** record; writes that skip callbacks (`update_column(s)`, `update_all`, `delete`) are not tracked — run `recount_counter_caches!` to reconcile. Bare, it rewrites every parent (portable across adapters, but O(n) for conditional counters) — a maintenance operation, run it offline. With `parents:` it zeroes and re-tallies only those parents (O(their children)), so repairing one imported post is safe on the request path.
 - Reach for [`counter_culture`](https://github.com/magnusvk/counter_culture) when you need multi-level rollups, delta columns, or after-commit execution.
 
 ---

--- a/docs/concerns/counter-cacheable.md
+++ b/docs/concerns/counter-cacheable.md
@@ -54,7 +54,7 @@ Repeatable — each call maintains another counter. Rules accumulate (reassigned
 
 Class method. Recomputes every counter (or only those for one association) from scratch and returns `{ count_column => parents_with_a_nonzero_count }`. Portable across adapters: unconditional counters use `group(fk).count`, conditional counters tally in Ruby.
 
-`parents:` limits the repair to specific parents — ids, records, or a relation of the parent class (`Post.where(...)`) — which are zeroed and re-tallied while every other row is left untouched. A listed parent with no matching children ends at `0`; an empty list/relation is a no-op returning `0` per column. Because the ids belong to one parent table, `parents:` needs the `association` argument when the child declares counters for more than one association (`ArgumentError` otherwise).
+`parents:` limits the repair to specific parents — ids, records, or a relation of the parent class (`Post.where(...)`) — which are zeroed and re-tallied while every other row is left untouched. A listed parent with no matching children ends at `0`; an empty list/relation is a no-op returning `0` per column. Because the ids belong to one parent table, `parents:` needs the `association` argument when the child declares counters for more than one association (`ArgumentError` otherwise), and records or a relation of a different class are rejected with `ArgumentError` rather than zeroing whichever rows happen to share those ids.
 
 | Call | Cost | Use |
 |---|---|---|

--- a/docs/concerns/counter-cacheable.md
+++ b/docs/concerns/counter-cacheable.md
@@ -50,9 +50,17 @@ Repeatable — each call maintains another counter. Rules accumulate (reassigned
 | `if:` | callable or `nil` | `nil` | Evaluated with `instance_exec` on the record; the record counts only when it returns truthy. For updates the **previous** state is reconstructed from the changed attributes. |
 | `touch:` | `true` / `false` | `false` | Also bump the parent's `updated_at` when the counter changes. |
 
-### `recount_counter_caches!(association = nil)`
+### `recount_counter_caches!(association = nil, parents: nil)`
 
 Class method. Recomputes every counter (or only those for one association) from scratch and returns `{ count_column => parents_with_a_nonzero_count }`. Portable across adapters: unconditional counters use `group(fk).count`, conditional counters tally in Ruby.
+
+`parents:` limits the repair to specific parents — ids, records, or a relation of the parent class (`Post.where(...)`) — which are zeroed and re-tallied while every other row is left untouched. A listed parent with no matching children ends at `0`; an empty list/relation is a no-op returning `0` per column. Because the ids belong to one parent table, `parents:` needs the `association` argument when the child declares counters for more than one association (`ArgumentError` otherwise).
+
+| Call | Cost | Use |
+|---|---|---|
+| `Comment.recount_counter_caches!` | O(all children) — rewrites every parent | offline backfill / drift audit |
+| `Comment.recount_counter_caches!(:post)` | same, one association | offline |
+| `Comment.recount_counter_caches!(:post, parents: post)` | O(that post's children) | after an import, a `delete_all`, a merge — safe in a job or request |
 
 ## How updates are handled
 
@@ -84,6 +92,11 @@ other_post.reload.comments_count    # => 1
 # Repair after a counter_cache-less write:
 Comment.delete_all                  # skips callbacks
 Comment.recount_counter_caches!     # => { comments_count: 0, approved_comments_count: 0 }
+
+# Repair just the parents you touched — e.g. after importing comments for a few posts:
+Comment.where(post_id: imported_ids).insert_all(rows)                 # bulk insert, no callbacks
+Comment.recount_counter_caches!(:post, parents: imported_ids)         # => { comments_count: 3, approved_comments_count: 1 }
+Comment.recount_counter_caches!(:post, parents: Post.where(author: me))
 ```
 
 ## Notes & gotchas
@@ -93,7 +106,7 @@ Comment.recount_counter_caches!     # => { comments_count: 0, approved_comments_
 - **Counters track the persisted record.** Writes that skip callbacks — `update_column(s)`, `update_all`, `delete`, raw SQL — leave the cache stale; run `recount_counter_caches!` to reconcile.
 - **Transaction-consistent.** Because the adjustment runs inside the save transaction, a rolled-back save rolls back the counter too.
 - **`if:` should read the record's own columns.** The previous-state reconstruction restores the changed attributes, not the associations.
-- **`recount_counter_caches!` rewrites every parent** (zeroes the column, then applies the tally) and scans children in Ruby for conditional counters — portable, but O(n). Treat it as a maintenance task, not a request-path call.
+- **Bare `recount_counter_caches!` rewrites every parent** (zeroes the column, then applies the tally) and scans children in Ruby for conditional counters — portable, but O(n). Treat it as a maintenance task, not a request-path call. **`parents:` scopes both the zeroing and the tally** to the listed ids, so it is proportional to their children and fine to run inline after a bulk write.
 - **Standard primary keys assumed.** Custom-`primary_key` parents and `has_many :through` rollups are out of scope — reach for [`counter_culture`](https://github.com/magnusvk/counter_culture) when you need multi-level rollups, delta columns, or after-commit execution.
 
 ## Changed in 1.22.0

--- a/lib/concerns_on_rails/models/counter_cacheable.rb
+++ b/lib/concerns_on_rails/models/counter_cacheable.rb
@@ -120,9 +120,28 @@ module ConcernsOnRails
                   "#{LABEL}: parents: needs the association when more than one is declared (#{associations.join(', ')})"
           end
 
-          return parents.pluck(parents.primary_key) if parents.is_a?(ActiveRecord::Relation)
+          parent_class = reflect_on_association(associations.first).klass
+          if parents.is_a?(ActiveRecord::Relation)
+            counter_cacheable_check_parent_class!(parents.klass, parent_class)
+            return parents.pluck(parents.primary_key)
+          end
 
-          Array(parents).map { |parent| parent.respond_to?(:id) ? parent.id : parent }
+          Array(parents).map do |parent|
+            next parent unless parent.is_a?(ActiveRecord::Base)
+
+            counter_cacheable_check_parent_class!(parent.class, parent_class)
+            parent.id
+          end
+        end
+
+        # Ids from the wrong table would zero and rewrite whichever parent rows
+        # happen to share them — silent corruption from a plausible mix-up, in
+        # the one method whose job is destructive repair.
+        def counter_cacheable_check_parent_class!(given, expected)
+          return if given <= expected
+
+          raise ArgumentError,
+                "#{LABEL}: parents: must contain #{expected.name} records (got #{given.name})"
         end
 
         def validate_counter_cacheable!(association, reflection, condition, touch)

--- a/lib/concerns_on_rails/models/counter_cacheable.rb
+++ b/lib/concerns_on_rails/models/counter_cacheable.rb
@@ -91,17 +91,39 @@ module ConcernsOnRails
         end
 
         # Recompute every (or one) counter from scratch — drift repair / backfill.
+        # `parents:` (ids, records, or a relation of the parent class) limits the
+        # repair to those parents — zeroed and re-tallied — leaving every other
+        # row untouched, so fixing one imported post is O(its children), not
+        # O(the table). Needs the association when more than one is declared.
         # Returns { count_column => parents_with_a_nonzero_count }.
-        def recount_counter_caches!(only_association = nil)
+        def recount_counter_caches!(only_association = nil, parents: nil)
           rules = counter_cacheable_rules
           rules = rules.select { |r| r[:association] == only_association.to_sym } if only_association
+          parent_ids = counter_cacheable_parent_ids(parents, rules)
+          return rules.to_h { |rule| [rule[:count_column], 0] } if parent_ids && parent_ids.empty?
 
           rules.to_h do |rule|
-            [rule[:count_column], counter_cacheable_recount_rule(rule)]
+            [rule[:count_column], counter_cacheable_recount_rule(rule, parent_ids)]
           end
         end
 
         private
+
+        # nil → every parent. Otherwise normalize records/relations to ids; the
+        # rules must all target one association or the ids are ambiguous.
+        def counter_cacheable_parent_ids(parents, rules)
+          return nil if parents.nil?
+
+          associations = rules.map { |rule| rule[:association] }.uniq
+          if associations.size > 1
+            raise ArgumentError,
+                  "#{LABEL}: parents: needs the association when more than one is declared (#{associations.join(', ')})"
+          end
+
+          return parents.pluck(parents.primary_key) if parents.is_a?(ActiveRecord::Relation)
+
+          Array(parents).map { |parent| parent.respond_to?(:id) ? parent.id : parent }
+        end
 
         def validate_counter_cacheable!(association, reflection, condition, touch)
           if reflection.nil?
@@ -142,23 +164,23 @@ module ConcernsOnRails
           ensure_columns_on!(LABEL, klass, count_column, types: :integer)
         end
 
-        def counter_cacheable_recount_rule(rule)
+        def counter_cacheable_recount_rule(rule, parent_ids = nil)
           reflection = reflect_on_association(rule[:association])
           fk = reflection.foreign_key
           parent_class = reflection.klass
           column = rule[:count_column]
           condition = rule[:condition]
 
-          tally = if condition
-                    counter_cacheable_recount_tally(fk, condition)
-                  else
-                    unscoped.where.not(fk => nil).group(fk).count
-                  end
+          children = unscoped.where.not(fk => nil)
+          children = children.where(fk => parent_ids) if parent_ids
+          tally = condition ? counter_cacheable_recount_tally(children, fk, condition) : children.group(fk).count
 
           # One transaction so a crash mid-repair can't leave every counter at
           # the zeroed intermediate state.
           parent_class.transaction do
-            parent_class.unscoped.update_all(column => 0)
+            targets = parent_class.unscoped
+            targets = targets.where(parent_class.primary_key => parent_ids) if parent_ids
+            targets.update_all(column => 0)
             counter_cacheable_apply_tally(parent_class, column, tally)
           end
           tally.count { |_id, n| n.to_i.positive? }
@@ -177,9 +199,9 @@ module ConcernsOnRails
           end
         end
 
-        def counter_cacheable_recount_tally(foreign_key, condition)
+        def counter_cacheable_recount_tally(children, foreign_key, condition)
           tally = Hash.new(0)
-          unscoped.where.not(foreign_key => nil).find_each do |record|
+          children.find_each do |record|
             tally[record[foreign_key]] += 1 if record.instance_exec(&condition)
           end
           tally

--- a/spec/concerns/models/counter_cacheable_spec.rb
+++ b/spec/concerns/models/counter_cacheable_spec.rb
@@ -348,5 +348,17 @@ describe ConcernsOnRails::Models::CounterCacheable do
       expect(Comment.recount_counter_caches!(:author, parents: author)).to eq(posts_count: 1)
       expect(author.reload.posts_count).to eq(1)
     end
+
+    it "refuses parents: from the wrong class instead of rewriting whatever shares those ids" do
+      author = User.create!
+      expect { Comment.recount_counter_caches!(:post, parents: author) }
+        .to raise_error(ArgumentError, /parents: must contain Post records \(got User\)/)
+      expect { Comment.recount_counter_caches!(:post, parents: User.where(id: author.id)) }
+        .to raise_error(ArgumentError, /parents: must contain Post records \(got User\)/)
+
+      # Still the drifted 99 the before block wrote: the refused calls neither
+      # zeroed nor rewrote anything.
+      expect(post.reload.comments_count).to eq(99)
+    end
   end
 end

--- a/spec/concerns/models/counter_cacheable_spec.rb
+++ b/spec/concerns/models/counter_cacheable_spec.rb
@@ -302,4 +302,51 @@ describe ConcernsOnRails::Models::CounterCacheable do
       expect(updates.length).to eq(2) # old parent −, new parent + (both counters batched)
     end
   end
+
+  describe ".recount_counter_caches! with parents:" do
+    let(:third) { Post.create! }
+
+    before do
+      Comment.create!(post: post, approved: true)
+      Comment.create!(post: post)
+      Comment.create!(post: other)
+      3.times { Comment.create!(post: third) }
+      Post.update_all(comments_count: 99, approved_comments_count: 99) # drift everywhere
+    end
+
+    it "repairs only the given parents — ids, records or a relation — and leaves the rest alone" do
+      result = Comment.recount_counter_caches!(:post, parents: [post.id, other])
+      expect(result).to eq(comments_count: 2, approved_comments_count: 1)
+      expect(post.reload.values_at(:comments_count, :approved_comments_count)).to eq([2, 1])
+      expect(other.reload.values_at(:comments_count, :approved_comments_count)).to eq([1, 0])
+      expect(third.reload.values_at(:comments_count, :approved_comments_count)).to eq([99, 99])
+
+      Comment.recount_counter_caches!(:post, parents: Post.where(id: third.id))
+      expect(third.reload.values_at(:comments_count, :approved_comments_count)).to eq([3, 0])
+      expect(post.reload.comments_count).to eq(2)
+    end
+
+    it "zeroes a listed parent that has no children and treats an empty parents: as a no-op" do
+      lonely = Post.create!
+      Post.where(id: lonely.id).update_all(comments_count: 5)
+
+      expect(Comment.recount_counter_caches!(:post, parents: lonely)).to eq(comments_count: 0, approved_comments_count: 0)
+      expect(lonely.reload.comments_count).to eq(0)
+
+      expect(Comment.recount_counter_caches!(:post, parents: Post.none)).to eq(comments_count: 0, approved_comments_count: 0)
+      expect(Comment.recount_counter_caches!(:post, parents: [])).to eq(comments_count: 0, approved_comments_count: 0)
+      expect(third.reload.comments_count).to eq(99)
+    end
+
+    it "requires the association when parents: would be ambiguous" do
+      expect { Comment.recount_counter_caches!(parents: [post.id]) }
+        .to raise_error(ArgumentError, /parents: needs the association when more than one is declared \(post, author\)/)
+
+      author = User.create!
+      Comment.create!(author: author)
+      User.update_all(posts_count: 42)
+      expect(Comment.recount_counter_caches!(:author, parents: author)).to eq(posts_count: 1)
+      expect(author.reload.posts_count).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`recount_counter_caches!` is the only repair path, and it zeroes and rewrites **every** parent — fine as an offline backfill, unusable after `insert_all`-ing comments for three posts in a request or job. This adds a scoped repair.

- **`recount_counter_caches!(association, parents:)`** — `parents:` takes ids, records, or a relation of the parent class (`Post.where(author: me)`). Only those parents are zeroed and re-tallied (both the children tally and the parent `UPDATE … SET col = 0` are restricted to the ids), inside the existing transaction; every other row is untouched. Cost is O(the listed parents' children).
- A listed parent with no matching children ends at `0`; an empty list/relation is a no-op returning `0` per column.
- Because ids belong to one parent table, `parents:` requires the association argument when the child declares counters for more than one association (`ArgumentError` naming them); with one association it can be omitted.
- The bare call and the one-association call behave exactly as before; `counter_cacheable_recount_tally` now takes the children relation instead of rebuilding it.

## Changelog entry

```
### Added
- **CounterCacheable**: `recount_counter_caches!(association, parents:)` repairs only the given
  parents (ids, records or a relation) — zeroed and re-tallied in one transaction, other rows
  untouched — so a post-import fix is O(their children). Empty `parents:` is a no-op; the
  association is required when more than one is declared.
```

## Test plan

- [x] `spec/concerns/models/counter_cacheable_spec.rb` — 3 new examples: ids + records repair two drifted posts (conditional and unconditional counters) while a third keeps its drift, then a relation repairs the third; a listed childless parent → 0 and `Post.none` / `[]` no-ops leaving drift alone; ambiguity error without the association and a scoped repair on the `author` counter.
- [x] Full suite: 1260 examples, 0 failures. RuboCop clean.
- [x] README "CounterCacheable" (example line + note) and `docs/concerns/counter-cacheable.md` (signature section with a cost table, import example, gotcha).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
