### PR TITLE
Activatable: before/after_(de)activate lifecycle hooks and timestamps: (activated_at / deactivated_at)

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,6 +741,10 @@ class Subscription < ApplicationRecord
 
   activatable_by               # defaults to :active
   # activatable_by :enabled    # custom column name
+  # activatable_by timestamps: true                                    # stamps activated_at / deactivated_at
+  # activatable_by timestamps: { activated_at: :enabled_at, deactivated_at: nil }
+
+  def after_deactivate = Billing.pause!(self)   # before/after_activate, before/after_deactivate hooks
 end
 
 sub = Subscription.create!(active: true)
@@ -761,7 +765,7 @@ Subscription.active.deactivate_all     # => 3
 ```
 
 Both target the relation, return an Integer count, and run in a transaction. With
-`activate!`/`deactivate!` unoverridden and no validations on the model — neither
+`activate!`/`deactivate!` and the four hooks unoverridden and no validations on the model — neither
 `validates`/`validates_with`, a custom `validate :method`, nor an association's autosave
 validation (a bare `has_many` registers one, so most models with associations take the
 streaming path) — they collapse to a single
@@ -772,6 +776,8 @@ no batch analogue.
 
 **Notes**
 - `NULL` is treated as inactive (same convention as most apps' "unset = off").
+- Hooks (`before_activate` / `after_activate` / `before_deactivate` / `after_deactivate`) share one transaction with the write: a raising after-hook rolls the flip back, a failed `update` (validation) skips the after-hook and returns `false`. `toggle_active!` and the batch verbs go through the same path.
+- `timestamps: true` stamps `activated_at` on activate and `deactivated_at` on deactivate (the other column keeps its last value, so you can see both the last activation and the last deactivation); a Hash renames either column or drops a side with `nil`. Columns are validated at declaration.
 - The configured column must exist; `activatable_by` raises `ArgumentError` otherwise.
 - `SoftDeletable` also defines a `.active` scope (alias of `.without_deleted`). If both concerns are included on the same model, the later one wins — include the one whose `.active` semantics you want last, or stick to one of them.
 

--- a/docs/concerns/activatable.md
+++ b/docs/concerns/activatable.md
@@ -58,13 +58,15 @@ end
 
 ## Configuration
 
-### `activatable_by(field = :active)`
+### `activatable_by(field = :active, prefix: nil, suffix: nil, timestamps: false)`
 
 Called once at the class level. Registers the backing column, validates its existence, and defines the `.active` and `.inactive` scopes.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `field` | Symbol | `:active` | The name of the boolean column that stores the active/inactive state. Must already exist in the database when the macro is evaluated; raises `ArgumentError` otherwise. |
+| `prefix:` / `suffix:` | Symbol / `true` | `nil` | Affix the `.active` / `.inactive` scope names so they don't collide with a sibling concern's. |
+| `timestamps:` | `true`, `false` or `Hash` | `false` | `true` stamps `activated_at` when a record is activated and `deactivated_at` when it is deactivated (`activate!`, `deactivate!`, `toggle_active!`, `activate_all`, `deactivate_all`). A Hash renames either column (`{ activated_at: :enabled_at }`) or drops a side (`deactivated_at: nil`); unknown keys raise. Columns must exist as `datetime` (validated at declaration). The other column keeps its previous value, so the last activation and the last deactivation are both visible. |
 
 The macro accepts only the positional `field` argument. There are no keyword options.
 
@@ -90,8 +92,9 @@ Subscription.inactive  # WHERE active = FALSE OR active IS NULL
 |-----------|-------------|
 | `active?` | Returns `true` if the backing column equals `true`; `false` for `false` or `nil`. |
 | `inactive?` | Returns `!active?`. |
-| `activate!` | Persists `true` to the backing column via `update`. Returns the result of `update`. |
-| `deactivate!` | Persists `false` to the backing column via `update`. Returns the result of `update`. |
+| `activate!` | Runs `before_activate`, persists `true` (and the `activated_at` stamp when configured) via `update`, then `after_activate` — all in one transaction. Returns the result of `update`; a `false` (validation failure) skips the after-hook, a raising after-hook rolls the write back. |
+| `deactivate!` | The mirror image: `before_deactivate`, `false` (+ `deactivated_at`), `after_deactivate`. |
+| `before_activate` / `after_activate` / `before_deactivate` / `after_deactivate` | No-op override points. Overriding any of them (or the bang methods) moves `activate_all` / `deactivate_all` to the per-record path so the hooks run for every record. |
 | `toggle_active!` | Calls `deactivate!` if currently active, `activate!` otherwise. A `NULL` column is treated as inactive, so toggling it sets the column to `true`. |
 
 ### Class methods
@@ -148,6 +151,25 @@ sub = Subscription.create!(name: "Trial")  # active column is NULL
 sub.active?   # => false  (NULL treated as inactive)
 sub.toggle_active!
 sub.reload.active # => true
+```
+
+**Hooks and timestamps**
+
+```ruby
+class Subscription < ApplicationRecord
+  include ConcernsOnRails::Activatable
+
+  activatable_by timestamps: true
+
+  def after_activate   = Billing.resume!(self)
+  def after_deactivate = Billing.pause!(self)
+end
+
+sub = Subscription.create!(active: false)
+sub.activate!          # before_activate → UPDATE active = true, activated_at = now → after_activate
+sub.activated_at       # => 2026-09-05 10:00:00 UTC
+sub.deactivate!        # deactivated_at = now; activated_at keeps 10:00 (last activation)
+Subscription.inactive.activate_all   # hooks overridden → per record, so Billing.resume! runs for each
 ```
 
 ## Notes & gotchas

--- a/docs/concerns/activatable.md
+++ b/docs/concerns/activatable.md
@@ -68,7 +68,7 @@ Called once at the class level. Registers the backing column, validates its exis
 | `prefix:` / `suffix:` | Symbol / `true` | `nil` | Affix the `.active` / `.inactive` scope names so they don't collide with a sibling concern's. |
 | `timestamps:` | `true`, `false` or `Hash` | `false` | `true` stamps `activated_at` when a record is activated and `deactivated_at` when it is deactivated (`activate!`, `deactivate!`, `toggle_active!`, `activate_all`, `deactivate_all`). A Hash renames either column (`{ activated_at: :enabled_at }`) or drops a side (`deactivated_at: nil`); unknown keys raise. Columns must exist as `datetime` (validated at declaration). The other column keeps its previous value, so the last activation and the last deactivation are both visible. |
 
-The macro accepts only the positional `field` argument. There are no keyword options.
+Besides the positional `field`, the macro takes the `prefix:`, `suffix:` and `timestamps:` keywords documented in the table above.
 
 ## Scopes
 
@@ -94,7 +94,7 @@ Subscription.inactive  # WHERE active = FALSE OR active IS NULL
 | `inactive?` | Returns `!active?`. |
 | `activate!` | Runs `before_activate`, persists `true` (and the `activated_at` stamp when configured) via `update`, then `after_activate` — all in one transaction. Returns the result of `update`; a `false` (validation failure) skips the after-hook, a raising after-hook rolls the write back. |
 | `deactivate!` | The mirror image: `before_deactivate`, `false` (+ `deactivated_at`), `after_deactivate`. |
-| `before_activate` / `after_activate` / `before_deactivate` / `after_deactivate` | No-op override points. Overriding any of them (or the bang methods) moves `activate_all` / `deactivate_all` to the per-record path so the hooks run for every record. |
+| `before_activate` / `after_activate` / `before_deactivate` / `after_deactivate` | No-op override points. Gating is per direction: overriding a direction's bang method or either of its two hooks moves **that** verb to the per-record path, so the hooks run for every record. Overriding `after_deactivate` leaves `activate_all` on the single-`UPDATE` fast path. |
 | `toggle_active!` | Calls `deactivate!` if currently active, `activate!` otherwise. A `NULL` column is treated as inactive, so toggling it sets the column to `true`. |
 
 ### Class methods

--- a/lib/concerns_on_rails/models/activatable.rb
+++ b/lib/concerns_on_rails/models/activatable.rb
@@ -19,25 +19,36 @@ module ConcernsOnRails
     #
     # NULL is treated as inactive, mirroring how unset booleans behave in most apps.
     #
+    # Lifecycle: `before_activate` / `after_activate` / `before_deactivate` /
+    # `after_deactivate` no-op hooks share one transaction with the write
+    # (Publishable's pattern). `timestamps: true` stamps `activated_at` /
+    # `deactivated_at` on the transitions (a Hash renames a column or drops a
+    # side with nil); the other column keeps its last value.
+    #
     # Note: SoftDeletable also defines a `.active` scope (alias of `.without_deleted`).
     # If both concerns are included on the same model, the later one wins.
     module Activatable
       extend ActiveSupport::Concern
 
       DEFAULT_FIELD = :active
+      LABEL = "ConcernsOnRails::Models::Activatable".freeze
+      TIMESTAMP_KEYS = %i[activated_at deactivated_at].freeze
+      HOOKS = { activate: %i[before_activate after_activate], deactivate: %i[before_deactivate after_deactivate] }.freeze
 
       included do
         class_attribute :activatable_field, instance_accessor: false, default: DEFAULT_FIELD
         class_attribute :activatable_scope_names, instance_accessor: false,
                                                   default: { active: :active, inactive: :inactive }.freeze
+        class_attribute :activatable_timestamps, instance_accessor: false, default: {}.freeze
       end
 
       class_methods do # rubocop:disable Metrics/BlockLength
         include ConcernsOnRails::Support::ColumnGuard
 
-        def activatable_by(field = DEFAULT_FIELD, prefix: nil, suffix: nil)
+        def activatable_by(field = DEFAULT_FIELD, prefix: nil, suffix: nil, timestamps: false)
           self.activatable_field = field.to_sym
-          ensure_columns!("ConcernsOnRails::Models::Activatable", activatable_field, types: :boolean)
+          ensure_columns!(LABEL, activatable_field, types: :boolean)
+          self.activatable_timestamps = activatable_normalize_timestamps!(timestamps)
 
           prefix = ConcernsOnRails::Support::Affix.normalize(prefix, default: activatable_field)
           suffix = ConcernsOnRails::Support::Affix.normalize(suffix, default: activatable_field)
@@ -55,9 +66,9 @@ module ConcernsOnRails
         # Activate every inactive record in the relation; returns the count.
         def activate_all
           inactive = all.public_send(activatable_scope_names.fetch(:inactive))
-          if activatable_batch_fast_path?(:activate!)
+          if activatable_batch_fast_path?(:activate)
             return inactive.update_all(
-              ConcernsOnRails::Support::BatchOps.with_timestamps(self, activatable_field => true)
+              ConcernsOnRails::Support::BatchOps.with_timestamps(self, activatable_attributes(true, :activate))
             )
           end
 
@@ -72,9 +83,9 @@ module ConcernsOnRails
         # Deactivate every active record in the relation; returns the count.
         def deactivate_all
           active = all.public_send(activatable_scope_names.fetch(:active))
-          if activatable_batch_fast_path?(:deactivate!)
+          if activatable_batch_fast_path?(:deactivate)
             return active.update_all(
-              ConcernsOnRails::Support::BatchOps.with_timestamps(self, activatable_field => false)
+              ConcernsOnRails::Support::BatchOps.with_timestamps(self, activatable_attributes(false, :deactivate))
             )
           end
 
@@ -86,14 +97,45 @@ module ConcernsOnRails
           )
         end
 
+        # The column writes for a transition: the flag plus the configured
+        # stamp (activated_at / deactivated_at) for that direction. Shared by
+        # the per-record path and the batch fast path so both agree.
+        def activatable_attributes(value, kind, time = Time.current)
+          attributes = { activatable_field => value }
+          stamp = activatable_timestamps[kind == :activate ? :activated_at : :deactivated_at]
+          attributes[stamp] = time if stamp
+          attributes
+        end
+
         private
 
         # Whether the single-UPDATE fast path is safe — the whole decision
-        # (bang method unoverridden AND the model declares no validations,
-        # plus why) lives in Support::BatchOps.fast_path?. Activatable defines
-        # no lifecycle hooks, so the bang method is the only one to check.
-        def activatable_batch_fast_path?(method)
-          ConcernsOnRails::Support::BatchOps.fast_path?(self, ConcernsOnRails::Models::Activatable, method)
+        # (bang method AND its two hooks unoverridden, AND the model declares
+        # no validations, plus why) lives in Support::BatchOps.fast_path?.
+        def activatable_batch_fast_path?(kind)
+          ConcernsOnRails::Support::BatchOps.fast_path?(self, ConcernsOnRails::Models::Activatable,
+                                                        :"#{kind}!", *HOOKS.fetch(kind))
+        end
+
+        # true -> both default columns; a Hash renames a side or drops it with
+        # nil; false/nil -> no stamps. Columns are validated as datetimes.
+        def activatable_normalize_timestamps!(option)
+          mapping = activatable_timestamps_mapping(option)
+          unknown = mapping.keys.map(&:to_sym) - TIMESTAMP_KEYS
+          raise ArgumentError, "#{LABEL}: unknown timestamps: key(s): #{unknown.join(', ')}" if unknown.any?
+
+          stamps = mapping.to_h { |key, column| [key.to_sym, column&.to_sym] }.compact
+          ensure_columns!(LABEL, *stamps.values, types: :datetime) if stamps.any?
+          stamps.freeze
+        end
+
+        def activatable_timestamps_mapping(option)
+          case option
+          when false, nil then {}
+          when true then TIMESTAMP_KEYS.to_h { |key| [key, key] }
+          when Hash then option
+          else raise ArgumentError, "#{LABEL}: timestamps: must be true, false or a Hash (got #{option.inspect})"
+          end
         end
       end
 
@@ -105,12 +147,20 @@ module ConcernsOnRails
         !active?
       end
 
+      # Lifecycle hooks — no-ops to override. They run around activate! /
+      # deactivate! (and so toggle_active! and the batch verbs' per-record
+      # path); overriding one moves the batch verbs off the single-UPDATE path.
+      def before_activate; end
+      def after_activate; end
+      def before_deactivate; end
+      def after_deactivate; end
+
       def activate!
-        update(self.class.activatable_field => true)
+        activatable_transition(true, :activate)
       end
 
       def deactivate!
-        update(self.class.activatable_field => false)
+        activatable_transition(false, :deactivate)
       end
 
       def toggle_active!
@@ -118,6 +168,21 @@ module ConcernsOnRails
         # an update (with_lock wraps a transaction + SELECT ... FOR UPDATE).
         with_lock { active? ? deactivate! : activate! }
       end
+
+      # Hooks and the write share one transaction: a raising after-hook rolls
+      # the flip back; a failed write (validation) returns false and skips the
+      # after-hook (Publishable / Expirable's contract).
+      def activatable_transition(value, kind)
+        before_hook, after_hook = HOOKS.fetch(kind)
+        result = false
+        transaction do
+          public_send(before_hook)
+          result = update(self.class.activatable_attributes(value, kind))
+          public_send(after_hook) if result
+        end
+        result
+      end
+      private :activatable_transition
     end
   end
 end

--- a/lib/concerns_on_rails/models/activatable.rb
+++ b/lib/concerns_on_rails/models/activatable.rb
@@ -100,7 +100,7 @@ module ConcernsOnRails
         # The column writes for a transition: the flag plus the configured
         # stamp (activated_at / deactivated_at) for that direction. Shared by
         # the per-record path and the batch fast path so both agree.
-        def activatable_attributes(value, kind, time = Time.current)
+        def activatable_attributes(value, kind, time = Time.zone.now)
           attributes = { activatable_field => value }
           stamp = activatable_timestamps[kind == :activate ? :activated_at : :deactivated_at]
           attributes[stamp] = time if stamp
@@ -124,9 +124,20 @@ module ConcernsOnRails
           unknown = mapping.keys.map(&:to_sym) - TIMESTAMP_KEYS
           raise ArgumentError, "#{LABEL}: unknown timestamps: key(s): #{unknown.join(', ')}" if unknown.any?
 
+          mapping.each { |key, column| activatable_check_timestamp_column!(key, column) }
+
           stamps = mapping.to_h { |key, column| [key.to_sym, column&.to_sym] }.compact
           ensure_columns!(LABEL, *stamps.values, types: :datetime) if stamps.any?
           stamps.freeze
+        end
+
+        # `timestamps: { activated_at: true }` used to die with NoMethodError on
+        # to_sym instead of the concern's own ArgumentError.
+        def activatable_check_timestamp_column!(key, column)
+          return if column.nil? || column.is_a?(Symbol) || column.is_a?(String)
+
+          raise ArgumentError,
+                "#{LABEL}: timestamps: #{key} must be a column name (Symbol or String), got #{column.inspect}"
         end
 
         def activatable_timestamps_mapping(option)

--- a/spec/concerns/models/activatable_spec.rb
+++ b/spec/concerns/models/activatable_spec.rb
@@ -345,6 +345,9 @@ describe ConcernsOnRails::Activatable do
         .to raise_error(ArgumentError, /timestamps: must be true, false or a Hash/)
       expect { stamped_class { activatable_by timestamps: { bogus: :enabled_at } } }
         .to raise_error(ArgumentError, /unknown timestamps: key\(s\): bogus/)
+      # A truthy non-column value used to raise NoMethodError on to_sym.
+      expect { stamped_class { activatable_by timestamps: { activated_at: true } } }
+        .to raise_error(ArgumentError, /timestamps: activated_at must be a column name/)
     end
 
     it "batch verbs stamp on the single-UPDATE fast path and run the hooks on the per-record path" do

--- a/spec/concerns/models/activatable_spec.rb
+++ b/spec/concerns/models/activatable_spec.rb
@@ -246,4 +246,127 @@ describe ConcernsOnRails::Activatable do
       expect(invalid.reload.active).to be false
     end
   end
+
+  describe "lifecycle hooks and timestamps:" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :stamped_subscriptions, force: true do |t|
+          t.string :name
+          t.boolean :active
+          t.datetime :activated_at
+          t.datetime :deactivated_at
+          t.datetime :enabled_at
+          t.datetime :updated_at
+        end
+      end
+    end
+
+    def stamped_class(&declaration)
+      Class.new(TestModel) do
+        self.table_name = "stamped_subscriptions"
+        include ConcernsOnRails::Activatable
+
+        class_eval(&declaration)
+      end
+    end
+
+    it "runs before_/after_ hooks around activate! and deactivate!" do
+      klass = stamped_class do
+        activatable_by
+        attr_reader :log
+
+        def before_activate = (@log ||= []) << :before_activate
+        def after_activate = (@log ||= []) << :after_activate
+        def before_deactivate = (@log ||= []) << :before_deactivate
+        def after_deactivate = (@log ||= []) << :after_deactivate
+      end
+      record = klass.create!(active: false)
+      expect(record.activate!).to be(true)
+      expect(record.log).to eq(%i[before_activate after_activate])
+      expect(record.deactivate!).to be(true)
+      expect(record.log).to eq(%i[before_activate after_activate before_deactivate after_deactivate])
+    end
+
+    it "shares one transaction with the write: a raising after hook rolls it back, a failed update skips the after hook" do
+      boom = stamped_class do
+        activatable_by
+        def after_activate = raise("boom")
+      end
+      record = boom.create!(active: false)
+      expect { record.activate! }.to raise_error("boom")
+      expect(record.reload.active).to be(false)
+
+      invalid = stamped_class do
+        activatable_by
+        validates :name, presence: true
+        attr_reader :after_ran
+
+        def after_deactivate = @after_ran = true
+      end
+      record = invalid.new(active: true)
+      record.save(validate: false)
+      expect(record.deactivate!).to be(false)
+      expect(record.after_ran).to be_nil
+      expect(record.reload.active).to be(true)
+    end
+
+    it "timestamps: true stamps activated_at / deactivated_at on each transition (toggle included)" do
+      klass = stamped_class { activatable_by timestamps: true }
+      record = klass.create!(name: "x", active: false)
+      expect(record.activated_at).to be_nil
+
+      record.activate!
+      expect(record.activated_at).to be_within(2.seconds).of(Time.current)
+      expect(record.deactivated_at).to be_nil
+      first_activation = record.activated_at
+
+      record.deactivate!
+      expect(record.deactivated_at).to be_within(2.seconds).of(Time.current)
+      expect(record.activated_at).to eq(first_activation) # history of the last activation is kept
+
+      record.update_columns(activated_at: 1.day.ago)
+      record.toggle_active!
+      expect(record.active?).to be(true)
+      expect(record.reload.activated_at).to be_within(2.seconds).of(Time.current)
+    end
+
+    it "timestamps: accepts a Hash to rename or drop a side, and validates it" do
+      klass = stamped_class { activatable_by timestamps: { activated_at: :enabled_at, deactivated_at: nil } }
+      record = klass.create!(active: false)
+      record.activate!
+      expect(record.enabled_at).to be_within(2.seconds).of(Time.current)
+      expect(record.activated_at).to be_nil
+      expect(record.deactivate!).to be(true)
+      expect(record.deactivated_at).to be_nil
+
+      expect { stamped_class { activatable_by timestamps: { activated_at: :nope } } }
+        .to raise_error(ArgumentError, /'nope' does not exist/)
+      expect { stamped_class { activatable_by timestamps: :yes } }
+        .to raise_error(ArgumentError, /timestamps: must be true, false or a Hash/)
+      expect { stamped_class { activatable_by timestamps: { bogus: :enabled_at } } }
+        .to raise_error(ArgumentError, /unknown timestamps: key\(s\): bogus/)
+    end
+
+    it "batch verbs stamp on the single-UPDATE fast path and run the hooks on the per-record path" do
+      fast = stamped_class { activatable_by timestamps: true }
+      fast.create!(active: false)
+      fast.create!(active: nil)
+      expect(fast.activate_all).to eq(2)
+      expect(fast.pluck(:activated_at).compact.size).to eq(2)
+      expect(fast.deactivate_all).to eq(2)
+      expect(fast.pluck(:deactivated_at).compact.size).to eq(2)
+
+      hooked = stamped_class do
+        activatable_by timestamps: true
+        def self.log = (@log ||= [])
+        def after_activate = self.class.log << id
+      end
+      hooked.delete_all
+      hooked.create!(active: false)
+      hooked.create!(active: false)
+      expect(hooked.activate_all).to eq(2)
+      expect(hooked.log.size).to eq(2)
+      expect(hooked.pluck(:activated_at).compact.size).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Publishable, Expirable, SoftDeletable and Stateable all have lifecycle hooks (and Stateable/Expirable stamp times); Activatable — the concern most likely to drive billing side effects — had neither. Same patterns, same contracts:

- **Hooks** — `before_activate` / `after_activate` / `before_deactivate` / `after_deactivate` no-op override points. `activate!` / `deactivate!` run hook → `update` → hook in one transaction: a raising after-hook rolls the flip back; a failed `update` (validation) returns `false` and skips the after-hook. `toggle_active!` and the batch verbs' per-record path reuse the same method.
- **`timestamps:`** — `true` stamps `activated_at` on activation and `deactivated_at` on deactivation (the other column keeps its last value, so both the last activation and the last deactivation stay visible); a Hash renames a side (`{ activated_at: :enabled_at }`) or drops it (`deactivated_at: nil`). Unknown keys, non-Hash values and missing `datetime` columns raise at declaration.
- **Batch verbs** — `activate_all` / `deactivate_all` take the single-UPDATE fast path only when the bang method *and* its two hooks are unoverridden (plus the existing no-validations rule); the fast path writes the stamp too, through the same `activatable_attributes(value, kind)` builder the per-record path uses, so both paths agree.
- README and `docs/concerns/activatable.md` updated (macro signature, option rows, method rows, example, notes).

## Changelog entry

```
### Added
- **Activatable**: `before_activate` / `after_activate` / `before_deactivate` / `after_deactivate`
  hooks (one transaction with the write; a raising after-hook rolls back, a failed update skips it;
  overriding one moves the batch verbs to the per-record path) and `activatable_by timestamps:`
  (`true` → `activated_at` / `deactivated_at` stamped on each transition, or a Hash to rename/drop
  a side; validated at declaration). Batch fast path stamps too.
```

## Test plan

- [x] `spec/concerns/models/activatable_spec.rb` — 5 new examples: hook order across both transitions; raising after-hook rollback + failed-validation `false` with the after-hook skipped; `timestamps: true` on activate/deactivate/toggle (other column preserved, toggle re-stamps); Hash form (rename, `nil` side) + three declaration errors; batch fast path stamps both directions and the hooked per-record path runs the hook per record and stamps.
- [x] Full suite: 1262 examples, 0 failures. RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

