### PR TITLE
Addressable: address_fingerprint, same_address_as?, address_changed? and fingerprint: — find duplicate addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -994,6 +994,7 @@ end
 | `allow_blank:`    | `false`                              | Per-field opt-out for the length check: an Array of parts (e.g. `%i[line2 state]`), or `true` for all parts. A blank value for an allowed part skips its length check. Independent of `required:`. |
 | `normalize_country:` | `false`                           | When `true`, canonicalize the country to its ISO 3166-1 alpha-2 code: an English name (`"Canada"`, `"United States"`) or a 3-letter alpha-3 (`"CAN"`, `"USA"`) maps to the alpha-2 (`"CA"`, `"US"`); unrecognized values are left untouched. This also lets postal/state validation recognize a named country. |
 | `verify_with:`    | `nil`                                | A callable for real-world verification (see below).                 |
+| `fingerprint:`    | `nil`                                | A `string` column to store `address_fingerprint` in (stamped in `before_validation`, after normalization) so duplicates are one indexed query away: `Location.with_address(record)`. |
 | `if:` / `unless:` | `nil`                                | Standard Rails validation conditions (Symbol, Proc, or Array) gating the address **validations** — e.g. `if: :on_addresses?`. Normalization still runs unconditionally. |
 
 **What it normalizes** (in `before_validation`)
@@ -1016,6 +1017,18 @@ end
 | `false`           | adds a generic `:base` error                    |
 | `String`          | added as a `:base` error                        |
 | `Array`           | each element added as a `:base` error           |
+
+**Dedupe helpers**
+
+```ruby
+loc.address_fingerprint        # => "9f2c…" — SHA-256 of the normalized parts: case, whitespace, postal spacing
+                               #    and a blank country (→ default_country) don't change it; nil for a blank address
+loc.same_address_as?(other)    # fingerprints equal (never true for two blanks)
+loc.address_changed?           # any mapped column dirty
+
+addressable_by fingerprint: :address_fingerprint     # add a string column + index
+Location.with_address(loc).where.not(id: loc.id)     # the duplicates of loc (or pass a fingerprint)
+```
 
 **Notes**
 - Scope is **format/structure only** — it checks shape, not real-world deliverability. Plug a USPS/Google/Smarty client into `verify_with:` for that.

--- a/docs/concerns/addressable.md
+++ b/docs/concerns/addressable.md
@@ -136,7 +136,7 @@ The macro `addressable_by` accepts any combination of column-override keyword pa
 | `with_address(record_or_fingerprint)` | Records whose stored fingerprint equals the given record's `address_fingerprint` (or the given hex String). Requires `fingerprint:`; raises `ArgumentError` otherwise. A `nil` fingerprint returns `none`. Chain `.where.not(id: record.id)` for "the duplicates of". |
 
 
-The `addressable_by` macro is the sole class-level entry point. There are no additional public class methods.
+`addressable_by` is the configuration macro; with `fingerprint:` it also defines the `with_address` scope documented above.
 
 ## Examples
 
@@ -237,11 +237,11 @@ class Location < ApplicationRecord
 end
 
 a = Location.create!(line1: "  1 Infinite  Loop ", city: "Cupertino", state: "ca", postal_code: "95014", country: "us")
-b = Location.create!(line1: "1 INFINITE LOOP", city: "cupertino", state: "CA", postal_code: "95014")   # country → default "US"
+b = Location.create!(line1: "1 INFINITE LOOP", city: "cupertino", state: "CA", postal_code: "95014", country: "US")
 
 a.same_address_as?(b)                      # => true
 Location.with_address(a).where.not(id: a.id)   # => [b]
-Location.group(:address_fingerprint).having("COUNT(*) > 1").count   # every duplicated address, one query
+Location.where.not(address_fingerprint: nil).group(:address_fingerprint).having("COUNT(*) > 1").count   # every duplicated address, one query
 ```
 
 ## Notes & gotchas

--- a/docs/concerns/addressable.md
+++ b/docs/concerns/addressable.md
@@ -109,6 +109,7 @@ The macro `addressable_by` accepts any combination of column-override keyword pa
 | `lengths:` | Hash | `{}` | Per-part length constraints keyed by canonical part name. An `Integer` value (e.g. `line1: 100`) sets a positive maximum with no minimum. A `Range` value (e.g. `city: 3..50`) sets both bounds; endless (`3..`) and beginless (`..50`) ranges are supported. Bounds must be non-negative integers; inverted, empty, or float ranges raise `ArgumentError` at load time. Length is measured on the normalized value. |
 | `allow_blank:` | Boolean or Array of Symbols | `false` | Parts whose length check is skipped when the value is blank. `true` exempts all parts; an Array (e.g. `%i[state line2]`) exempts specific parts. Independent of `required:` — a required part that is blank still fails presence validation regardless of this setting. |
 | `normalize_country:` | Boolean | `false` | When `true`, canonicalizes the country value to its ISO 3166-1 alpha-2 code during normalization: recognized English names (`"Canada"`, `"United States"`) and ISO alpha-3 codes (`"CAN"`, `"USA"`) are mapped to their alpha-2 equivalents. Unrecognized values are left unchanged. Also enables postal-code and state validation to recognize named countries. |
+| `fingerprint:` | `Symbol` | `nil` | A `string` column that receives `address_fingerprint` in `before_validation`, after normalization, whenever the value differs. Add a (non-unique) index on it; it is what `with_address` queries. Validated at declaration. |
 | `verify_with:` | Callable | `nil` | An optional callable (lambda or proc) that receives the record and performs real-world deliverability verification. Runs only after all structural validations pass. Return values are interpreted as described in the Examples section. |
 | `if:` | Symbol, Proc, or Array | `nil` | Standard Rails validation condition. When present, address validations are skipped unless the condition holds. Normalization (`before_validation`) always runs unconditionally. |
 | `unless:` | Symbol, Proc, or Array | `nil` | Standard Rails validation condition. When present, address validations are skipped when the condition holds. Normalization still runs unconditionally. |
@@ -124,8 +125,16 @@ The macro `addressable_by` accepts any combination of column-override keyword pa
 | `address_present?` | Returns `true` if any configured part has a value. |
 | `address_complete?` | Returns `true` if every `required:` part has a value (presence check only; no format validation). |
 | `address_attributes` | Returns a Hash of `{ canonical_part => value }` for every present part. Useful for passing to serializers or external verifiers. |
+| `address_fingerprint` | SHA-256 hex digest of the normalized address: every canonical part downcased and squished, the postal code with its spaces removed, the country resolved the way validation resolves it (a blank country becomes `default_country`, a name/alpha-3 becomes alpha-2 under `normalize_country: true`). Two rows that differ only in case, whitespace, postal formatting or an omitted default country hash the same; a change to any part (including `line2`) changes it. `nil` when no address part is present (a country alone does not count). |
+| `same_address_as?(other)` | `true` when both records have a fingerprint and they are equal. Two blank addresses are never "the same". |
+| `address_changed?` | `true` when any mapped address column has an unsaved change. |
 
 ### Class methods
+
+| Signature | Description |
+|-----------|-------------|
+| `with_address(record_or_fingerprint)` | Records whose stored fingerprint equals the given record's `address_fingerprint` (or the given hex String). Requires `fingerprint:`; raises `ArgumentError` otherwise. A `nil` fingerprint returns `none`. Chain `.where.not(id: record.id)` for "the duplicates of". |
+
 
 The `addressable_by` macro is the sole class-level entry point. There are no additional public class methods.
 
@@ -217,6 +226,23 @@ The verifier callable may return:
 - A `String` — added as a `:base` error
 - An `Array` — each element added as a `:base` error
 - Alternatively, the callable may call `record.errors.add(...)` directly and return any value
+
+**Deduplicating addresses**
+
+```ruby
+class Location < ApplicationRecord
+  include ConcernsOnRails::Addressable
+
+  addressable_by fingerprint: :address_fingerprint   # t.string :address_fingerprint, index: true
+end
+
+a = Location.create!(line1: "  1 Infinite  Loop ", city: "Cupertino", state: "ca", postal_code: "95014", country: "us")
+b = Location.create!(line1: "1 INFINITE LOOP", city: "cupertino", state: "CA", postal_code: "95014")   # country → default "US"
+
+a.same_address_as?(b)                      # => true
+Location.with_address(a).where.not(id: a.id)   # => [b]
+Location.group(:address_fingerprint).having("COUNT(*) > 1").count   # every duplicated address, one query
+```
 
 ## Notes & gotchas
 

--- a/lib/concerns_on_rails/models/addressable.rb
+++ b/lib/concerns_on_rails/models/addressable.rb
@@ -278,6 +278,11 @@ module ConcernsOnRails
 
       # Equal fingerprints — never true for two blank addresses.
       def same_address_as?(other)
+        # Tolerant like the sibling `with_address`, which accepts a record, a
+        # digest String or nil: a bare `other.address_fingerprint` turned
+        # `same_address_as?(nil)` into a NoMethodError.
+        return false unless other.respond_to?(:address_fingerprint)
+
         fingerprint = address_fingerprint
         !fingerprint.nil? && fingerprint == other.address_fingerprint
       end

--- a/lib/concerns_on_rails/models/addressable.rb
+++ b/lib/concerns_on_rails/models/addressable.rb
@@ -1,4 +1,5 @@
 require "active_support/concern"
+require "digest"
 require "concerns_on_rails/support/column_guard"
 require "concerns_on_rails/support/address_data"
 
@@ -49,6 +50,7 @@ module ConcernsOnRails
         class_attribute :addressable_allow_blank, instance_accessor: false, default: [].freeze
         class_attribute :addressable_normalize_country, instance_accessor: false, default: false
         class_attribute :addressable_validation_registered, instance_accessor: false, default: false
+        class_attribute :addressable_fingerprint_column, instance_accessor: false, default: nil
 
         # `validate :validate_address` is registered by `addressable_by` (not here) so it can
         # carry the optional if:/unless: condition. Normalization always runs.
@@ -65,7 +67,7 @@ module ConcernsOnRails
         # keyword pairs; everything else tunes behavior. See the module docs.
         def addressable_by(required: DEFAULT_REQUIRED, default_country: "US",
                            validate_state: false, verify_with: nil,
-                           lengths: {}, allow_blank: false, normalize_country: false, **mapping)
+                           lengths: {}, allow_blank: false, normalize_country: false, fingerprint: nil, **mapping)
           condition = extract_validation_condition!(mapping)
           self.addressable_fields = resolve_addressable_fields(mapping)
           self.addressable_required = Array(required).map(&:to_sym)
@@ -75,11 +77,35 @@ module ConcernsOnRails
           self.addressable_lengths = resolve_lengths(lengths)
           self.addressable_allow_blank = resolve_allow_blank(allow_blank)
           self.addressable_normalize_country = normalize_country
+          self.addressable_fingerprint_column = resolve_fingerprint_column(fingerprint)
           ensure_required_columns!
           register_address_validation(condition)
         end
 
+        # Records stored with the same address fingerprint as `value` (a record,
+        # or a fingerprint String). Needs `fingerprint:` — the digest has to be
+        # persisted to be queryable. A nil fingerprint (blank address) matches
+        # nothing rather than every other blank row.
+        def with_address(value)
+          column = addressable_fingerprint_column
+          unless column
+            raise ArgumentError,
+                  "#{LABEL}: with_address needs `addressable_by fingerprint:` (a column to store address_fingerprint in)"
+          end
+
+          fingerprint = value.respond_to?(:address_fingerprint) ? value.address_fingerprint : value
+          fingerprint.nil? ? none : where(column => fingerprint)
+        end
+
         private
+
+        def resolve_fingerprint_column(fingerprint)
+          return nil if fingerprint.nil?
+
+          column = fingerprint.to_sym
+          ensure_columns!(LABEL, column, types: :string)
+          column
+        end
 
         def resolve_addressable_fields(mapping)
           unknown = mapping.keys.map(&:to_sym) - DEFAULT_FIELDS.keys
@@ -192,6 +218,7 @@ module ConcernsOnRails
           normalized = normalize_part(part, country, value)
           self[column] = normalized unless normalized == value
         end
+        stamp_address_fingerprint
       end
 
       # --- Validation -----------------------------------------------------------
@@ -237,7 +264,57 @@ module ConcernsOnRails
         end
       end
 
+      # SHA-256 of the normalized address — every part downcased and squished,
+      # the postal code without spaces, the country resolved the way validation
+      # resolves it (blank → default_country) — so rows that differ only in
+      # case, whitespace, postal formatting or an omitted default country hash
+      # the same. nil for a blank address (a country alone is not an address).
+      def address_fingerprint
+        return nil unless address_fingerprintable?
+
+        parts = DEFAULT_FIELDS.keys.map { |part| address_fingerprint_part(part) }
+        Digest::SHA256.hexdigest(parts.join("\n"))
+      end
+
+      # Equal fingerprints — never true for two blank addresses.
+      def same_address_as?(other)
+        fingerprint = address_fingerprint
+        !fingerprint.nil? && fingerprint == other.address_fingerprint
+      end
+
+      # Any mapped address column has an unsaved change.
+      def address_changed?
+        self.class.addressable_fields.values.any? { |column| attribute_changed?(column) }
+      end
+
       private
+
+      # Something beyond the country must be present — a country alone is not
+      # an address, and the default country is always "present".
+      def address_fingerprintable?
+        self.class.addressable_fields.any? { |part, column| part != :country && self[column].present? }
+      end
+
+      def address_fingerprint_part(part)
+        column = self.class.addressable_fields[part]
+        return "" unless column
+
+        raw = self[column]
+        return (resolved_country || raw).to_s.squish.downcase if part == :country
+
+        value = raw.to_s.squish.downcase
+        part == :postal_code ? value.delete(" ") : value
+      end
+
+      # Keep the fingerprint column (when configured) in step with the
+      # normalized address; written only when it actually differs.
+      def stamp_address_fingerprint
+        column = self.class.addressable_fingerprint_column
+        return unless column
+
+        fingerprint = address_fingerprint
+        self[column] = fingerprint unless self[column] == fingerprint
+      end
 
       def ordered_parts
         DEFAULT_FIELDS.keys.select { |part| self.class.addressable_fields.key?(part) }

--- a/spec/concerns/models/addressable_spec.rb
+++ b/spec/concerns/models/addressable_spec.rb
@@ -737,6 +737,10 @@ describe ConcernsOnRails::Models::Addressable do
       other = klass.create!(apple.merge(line1: "500 Oracle Pkwy", city: "Redwood City", postal_code: "94065"))
       blank = klass.new(line1: nil, city: nil, postal_code: nil, country: nil)
       blank.save(validate: false) # required parts missing — bypass validation for the fixture
+      # save(validate: false) skips before_validation, so assert the nil-for-blank
+      # contract against the method itself too — the stored-column check alone
+      # would pass even if address_fingerprint digested an empty address.
+      expect(blank.address_fingerprint).to be_nil
 
       expect(first.reload[:address_fingerprint]).to eq(first.address_fingerprint)
       expect(second.reload[:address_fingerprint]).to eq(first[:address_fingerprint])
@@ -746,6 +750,9 @@ describe ConcernsOnRails::Models::Addressable do
       expect(klass.with_address(first).where.not(id: first.id)).to eq([second]) # "the duplicates of first"
       expect(klass.with_address(first[:address_fingerprint]).count).to eq(2)
       expect(klass.with_address(other).count).to eq(1)
+      # Tolerant like with_address: nil / a non-record answers false, not NoMethodError.
+      expect(first.same_address_as?(nil)).to be(false)
+      expect(first.same_address_as?("deadbeef")).to be(false)
       expect(klass.with_address(blank)).to be_empty
       expect(klass.with_address(nil)).to be_empty
 

--- a/spec/concerns/models/addressable_spec.rb
+++ b/spec/concerns/models/addressable_spec.rb
@@ -669,4 +669,94 @@ describe ConcernsOnRails::Models::Addressable do
       expect(loc.city).to eq("Town")
     end
   end
+
+  describe "address_fingerprint, same_address_as?, address_changed? and fingerprint:" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :fingerprinted_locations, force: true do |t|
+          t.string :line1
+          t.string :line2
+          t.string :city
+          t.string :state
+          t.string :postal_code
+          t.string :country
+          t.string :address_fingerprint
+        end
+      end
+    end
+
+    def fingerprinted(**opts)
+      Class.new(TestModel) do
+        self.table_name = "fingerprinted_locations"
+        include ConcernsOnRails::Models::Addressable
+
+        addressable_by(**opts)
+      end
+    end
+
+    let(:klass) { fingerprinted }
+    let(:apple) { { line1: "  1 Infinite  Loop ", city: "Cupertino", state: "ca", postal_code: "95014", country: "us" } }
+    let(:apple_shouty) { { line1: "1 INFINITE LOOP", city: "cupertino", state: "CA", postal_code: " 95014", country: "US" } }
+
+    it "is stable across case, whitespace, postal formatting and the default country; nil for a blank address" do
+      a = klass.new(apple)
+      b = klass.new(apple_shouty)
+      expect(a.address_fingerprint).to match(/\A\h{64}\z/)
+      expect(a.address_fingerprint).to eq(b.address_fingerprint)
+      expect(klass.new(apple.merge(line1: "2 Infinite Loop")).address_fingerprint).not_to eq(a.address_fingerprint)
+      expect(klass.new(apple.merge(line2: "Suite 4")).address_fingerprint).not_to eq(a.address_fingerprint)
+
+      expect(klass.new(apple.except(:country)).address_fingerprint).to eq(a.address_fingerprint) # blank → default_country "US"
+      canada = klass.new(line1: "1 Rue Sainte-Catherine", city: "Montréal", postal_code: "h2x1y4", country: "ca")
+      spaced = klass.new(line1: "1 Rue Sainte-Catherine", city: "Montréal", postal_code: "H2X 1Y4", country: "CA")
+      expect(canada.address_fingerprint).to eq(spaced.address_fingerprint)
+
+      expect(klass.new.address_fingerprint).to be_nil
+      expect(klass.new(country: "US").address_fingerprint).to be_nil # a country alone is not an address
+    end
+
+    it "same_address_as? compares fingerprints and address_changed? tracks the mapped columns" do
+      a = klass.new(apple)
+      expect(a.same_address_as?(klass.new(apple_shouty))).to be(true)
+      expect(a.same_address_as?(klass.new(apple.merge(city: "Palo Alto")))).to be(false)
+      expect(klass.new.same_address_as?(klass.new)).to be(false) # two blanks are not "the same address"
+
+      saved = klass.create!(apple)
+      expect(saved.address_changed?).to be(false)
+      saved.line1 = "2 Infinite Loop"
+      expect(saved.address_changed?).to be(true)
+      saved.restore_attributes
+      saved.state = "CA" # already normalized to that
+      expect(saved.address_changed?).to be(false)
+    end
+
+    it "fingerprint: stamps the column in before_validation (after normalization) and powers with_address" do
+      klass = fingerprinted(fingerprint: :address_fingerprint)
+      first = klass.create!(apple)
+      second = klass.create!(apple_shouty)
+      other = klass.create!(apple.merge(line1: "500 Oracle Pkwy", city: "Redwood City", postal_code: "94065"))
+      blank = klass.new(line1: nil, city: nil, postal_code: nil, country: nil)
+      blank.save(validate: false) # required parts missing — bypass validation for the fixture
+
+      expect(first.reload[:address_fingerprint]).to eq(first.address_fingerprint)
+      expect(second.reload[:address_fingerprint]).to eq(first[:address_fingerprint])
+      expect(blank.reload[:address_fingerprint]).to be_nil
+
+      expect(klass.with_address(first).order(:id)).to eq([first, second])
+      expect(klass.with_address(first).where.not(id: first.id)).to eq([second]) # "the duplicates of first"
+      expect(klass.with_address(first[:address_fingerprint]).count).to eq(2)
+      expect(klass.with_address(other).count).to eq(1)
+      expect(klass.with_address(blank)).to be_empty
+      expect(klass.with_address(nil)).to be_empty
+
+      first.update!(line1: "1 Infinite Loop, Building 2")
+      expect(first.reload[:address_fingerprint]).not_to eq(second[:address_fingerprint])
+    end
+
+    it "validates fingerprint: and requires it for with_address" do
+      expect { fingerprinted(fingerprint: :nope) }.to raise_error(ArgumentError, /'nope' does not exist/)
+      expect { klass.with_address("abc") }
+        .to raise_error(ArgumentError, /with_address needs `addressable_by fingerprint:` \(a column to store address_fingerprint in\)/)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Addressable normalizes and validates, but the question every address table eventually asks — "do we already have this address?" — still needs hand-rolled string munging. This adds a canonical fingerprint and the plumbing to query it.

- **`address_fingerprint`** — SHA-256 hex of the normalized address: each canonical part downcased and squished, the postal code with spaces removed (`H2X 1Y4` ≡ `h2x1y4`), the country resolved exactly as validation resolves it (blank → `default_country`; a name/alpha-3 → alpha-2 under `normalize_country: true`). Case, whitespace, postal formatting and an omitted default country don't change it; any part (including `line2`) does. `nil` unless something beyond the country is present.
- **`same_address_as?(other)`** — fingerprints present and equal (two blanks are never "the same"). **`address_changed?`** — any mapped column dirty.
- **`addressable_by fingerprint: :address_fingerprint`** — a `string` column stamped in `before_validation` right after normalization (only when the value differs), validated at declaration. **`Model.with_address(record_or_fingerprint)`** queries it (`.where.not(id: record.id)` = the duplicates); requires the option and raises otherwise; a `nil` fingerprint returns `none` rather than matching every blank row. `GROUP BY address_fingerprint HAVING COUNT(*) > 1` gives the whole duplicate report in one query (documented).

## Changelog entry

```
### Added
- **Addressable**: `address_fingerprint` (SHA-256 of the normalized address — case/whitespace/postal
  spacing/default-country insensitive; nil for a blank address), `same_address_as?(other)`,
  `address_changed?`, and `addressable_by fingerprint: :column` to persist it in `before_validation`
  so `Model.with_address(record_or_fingerprint)` finds duplicates with an indexed query.
```

## Test plan

- [x] `spec/concerns/models/addressable_spec.rb` — 4 new examples: stability across case/whitespace/postal spacing/omitted default country + Canadian postal formats, sensitivity to `line1`/`line2`, nil for blank and country-only; `same_address_as?` and `address_changed?` (including a no-op reassignment of an already-normalized value); `fingerprint:` stamping (matches the computed digest, nil for a blank row, refreshed on update) and `with_address` by record / by digest / duplicates-of / blank / nil; declaration validation and the `with_address` guard.
- [x] Full suite: 1261 examples, 0 failures. RuboCop clean.
- [x] README "Addressable" (option row + Dedupe helpers block) and `docs/concerns/addressable.md` (method rows, class-method table, option row, dedupe example).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
