### PR TITLE
Sortable (model): reposition!(ids, missing:) — apply a drag-and-drop order in one UPDATE

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,10 @@ end
 Task.create!(name: "A")
 Task.create!(name: "B")
 Task.last.move_higher
+
+# Save a drag-and-drop order in ONE UPDATE (CASE id WHEN …): the ids' order becomes their positions
+Task.reposition!(params[:ids])                    # => 12 — rows not listed are pushed after, in their current order
+Task.where(list_id: 1).reposition!(ids, missing: :raise)   # scoped; a partial list is an error
 ```
 
 **Configuration**
@@ -314,8 +318,8 @@ sortable_by :position, add_new_at: :top          # new rows insert at the top (a
 ```
 
 **Notes**
-- The configured field must exist as a column.
-- Direction values other than `:asc` / `:desc` silently fall back to `:asc`.
+- The configured field must exist as a column; a direction other than `:asc` / `:desc` raises at declaration.
+- `reposition!` runs inside the current relation (`Task.where(list_id: 1)` — the same set acts_as_list's `scope:` would use), rejects ids outside it and duplicates before writing anything, coerces String ids from params, and on a descending list gives the first id the highest value. It bypasses acts_as_list callbacks by design (one `update_all`, no per-row shifting).
 
 ---
 

--- a/docs/concerns/sortable.md
+++ b/docs/concerns/sortable.md
@@ -115,6 +115,7 @@ Position values are automatically assigned on `create` and compacted on `destroy
 | Method | Signature | Description |
 |--------|-----------|-------------|
 | `sortable_by` | `sortable_by(field_config = nil, use_acts_as_list: true, scope: nil, add_new_at: nil, default_scope: true, **field_options)` | Configures the sort column and direction, validates the column exists, optionally sets up `acts_as_list`, and (since 1.22) controls whether the sticky ordering `default_scope` is installed. |
+| `reposition!` | `reposition!(ids, missing: :append)` | Applies an explicit id order as positions in **one** `UPDATE … SET <field> = CASE id WHEN … END` inside the current relation (`Task.where(list_id: 1).reposition!(ids)`), inside a transaction. The first id gets the top position (`acts_as_list`'s `top_of_list`, default 1); on a `:desc` list the first id gets the *highest* value so the list reads in the given order. Rows in the relation but not in `ids` are appended after, in their current order (`missing: :append`) or make the call raise (`missing: :raise`). Ids outside the relation, duplicates, or an unknown `missing:` raise `ArgumentError` before anything is written. String ids (from params) are cast through the primary key's type. Returns the number of rows updated. Bypasses acts_as_list callbacks (`update_all`). |
 
 ## Examples
 
@@ -180,6 +181,22 @@ t3 = Task.create!(name: "B1", project_id: project_b.id)  # position: 1 in Beta
 t1.reload.position  # => 2
 t2.position         # => 1
 t3.position         # => 1  (own sequence inside Beta)
+```
+
+**Saving a drag-and-drop order**
+
+```ruby
+class TasksController < ApplicationController
+  def reorder
+    list = List.find(params[:list_id])
+    list.tasks.reposition!(params.require(:ids))    # ids in the order the user dropped them
+    head :no_content
+  end
+end
+
+# before: A(1) B(2) C(3)     params[:ids] = ["3", "1"]
+Task.reposition!(%w[3 1])   # => 3   C(1) A(2) B(3) — B wasn't listed, so it keeps its place after the listed rows
+Task.reposition!(%w[3 1], missing: :raise)   # ArgumentError — a paginated/partial list must be explicit
 ```
 
 ## Notes & gotchas

--- a/lib/concerns_on_rails/models/sortable.rb
+++ b/lib/concerns_on_rails/models/sortable.rb
@@ -49,6 +49,9 @@ module ConcernsOnRails
       # Example: Task.sortable_by(priority: :asc)
       # A real module (not `class_methods do`) so the helpers aren't constrained
       # by Metrics/BlockLength (the Stateable precedent).
+      LABEL = "ConcernsOnRails::Models::Sortable".freeze
+      MISSING_MODES = %i[append raise].freeze
+
       module ClassMethods
         include ConcernsOnRails::Support::ColumnGuard
 
@@ -83,7 +86,69 @@ module ConcernsOnRails
           acts_as_list(list_options)
         end
 
+        # Apply an explicit id order as positions — the "save this drag-and-drop
+        # order" operation acts_as_list lacks — in ONE UPDATE (`SET position =
+        # CASE id WHEN … END`) inside the current relation, in a transaction.
+        # Rows in the relation but not in `ids` are pushed after them in their
+        # current order (`missing: :append`) or make the call raise
+        # (`missing: :raise`); ids outside the relation, duplicates and an
+        # unknown `missing:` raise before anything is written. The first id gets
+        # the top position; on a :desc list it gets the highest value instead.
+        # Returns the number of rows updated. Bypasses acts_as_list callbacks by
+        # design (no per-row shifting).
+        def reposition!(ids, missing: :append)
+          unless MISSING_MODES.include?(missing)
+            raise ArgumentError,
+                  "#{LABEL}: missing: must be :append or :raise (got #{missing.inspect})"
+          end
+
+          ordered = sortable_reposition_order(sortable_cast_ids(ids), missing)
+          return 0 if ordered.empty?
+
+          node = Arel::Nodes::Case.new(arel_table[primary_key])
+          sortable_positions_for(ordered).each { |id, position| node.when(id).then(position) }
+          transaction { unscoped.where(primary_key => ordered).update_all(sortable_field => node) }
+        end
+
         private
+
+        # Params arrive as Strings; compare on the primary key's own type.
+        def sortable_cast_ids(ids)
+          type = type_for_attribute(primary_key)
+          Array(ids).map { |id| type.cast(id.respond_to?(:id) ? id.id : id) }
+        end
+
+        # The relation's members in the requested order, validated: no
+        # duplicates, nothing foreign, and the unlisted rest appended (or raised).
+        def sortable_reposition_order(ids, missing)
+          duplicates = ids.tally.select { |_id, n| n > 1 }.keys
+          raise ArgumentError, "#{LABEL}: duplicate id(s) #{duplicates.join(', ')} in ids" if duplicates.any?
+
+          current = all.reorder(sortable_field => sortable_direction, primary_key => :asc).pluck(primary_key)
+          unknown = ids - current
+          raise ArgumentError, "#{LABEL}: id(s) #{unknown.join(', ')} are not in this relation" if unknown.any?
+
+          rest = current - ids
+          if rest.any? && missing == :raise
+            raise ArgumentError,
+                  "#{LABEL}: #{rest.size} record(s) in this relation are missing from ids (pass missing: :append to push them after)"
+          end
+
+          ids + rest
+        end
+
+        # [[id, position], ...] from the top of the list; reversed for :desc so
+        # the first id sorts first.
+        def sortable_positions_for(ordered)
+          top = sortable_top_of_list
+          positions = Array.new(ordered.size) { |index| top + index }
+          positions.reverse! if sortable_direction == :desc
+          ordered.zip(positions)
+        end
+
+        def sortable_top_of_list
+          method_defined?(:acts_as_list_top) ? new.acts_as_list_top : 1
+        end
 
         def resolve_sortable_config(field_config, field_options)
           if field_config.nil? && field_options.any?

--- a/spec/concerns/models/sortable_spec.rb
+++ b/spec/concerns/models/sortable_spec.rb
@@ -306,4 +306,80 @@ describe ConcernsOnRails::Sortable do
       expect(first.reload.position).to eq(2)
     end
   end
+
+  describe ".reposition! (bulk reorder from an id list)" do
+    let!(:a) { Task.create!(name: "A") }
+    let!(:b) { Task.create!(name: "B") }
+    let!(:c) { Task.create!(name: "C") }
+
+    it "sets positions to match the id order in one UPDATE and returns the count" do
+      queries = []
+      callback = ->(*, payload) { queries << payload[:sql] if payload[:sql] =~ /\AUPDATE/i }
+      count = ActiveSupport::Notifications.subscribed(callback, "sql.active_record") { Task.reposition!([c.id, a.id, b.id]) }
+
+      expect(count).to eq(3)
+      expect(queries.size).to eq(1)
+      expect(queries.first).to match(/CASE .*"tasks"\."id" WHEN/i)
+      expect(Task.pluck(:name)).to eq(%w[C A B])
+      expect(Task.pluck(:position)).to eq([1, 2, 3])
+      expect(Task.reposition!(%w[1 2 3].map { |i| Task.find_by!(position: i).id.to_s })).to eq(3) # String ids from params
+    end
+
+    it "pushes rows missing from the list after it (in their current order) — or raises with missing: :raise" do
+      expect(Task.reposition!([c.id])).to eq(3)
+      expect(Task.pluck(:name)).to eq(%w[C A B])
+
+      expect { Task.reposition!([b.id], missing: :raise) }
+        .to raise_error(ArgumentError, /2 record\(s\) in this relation are missing from ids \(pass missing: :append/)
+      expect(Task.pluck(:name)).to eq(%w[C A B]) # nothing written
+      expect { Task.reposition!([b.id], missing: :nope) }.to raise_error(ArgumentError, /missing: must be :append or :raise/)
+    end
+
+    it "rejects ids outside the relation and duplicates, and stays inside a scoped relation" do
+      ActiveRecord::Schema.define do
+        create_table :scoped_tasks, force: true do |t|
+          t.string :name
+          t.integer :list_id
+          t.integer :position
+        end
+      end
+      klass = Class.new(TestModel) do
+        self.table_name = "scoped_tasks"
+        include ConcernsOnRails::Sortable
+
+        sortable_by :position, scope: :list_id
+      end
+      l1 = %w[x y z].map { |n| klass.create!(name: n, list_id: 1) }
+      l2 = klass.create!(name: "other", list_id: 2)
+
+      expect(klass.where(list_id: 1).reposition!([l1[2].id, l1[0].id, l1[1].id])).to eq(3)
+      expect(klass.where(list_id: 1).pluck(:name)).to eq(%w[z x y])
+      expect(l2.reload.position).to eq(1)
+
+      expect { klass.where(list_id: 1).reposition!([l2.id, l1[0].id]) }
+        .to raise_error(ArgumentError, /id\(s\) #{l2.id} are not in this relation/)
+      expect { klass.where(list_id: 1).reposition!([l1[0].id, l1[0].id]) }.to raise_error(ArgumentError, /duplicate id\(s\)/)
+      expect(klass.where(list_id: 3).reposition!([])).to eq(0)
+    end
+
+    it "gives the first id the highest position on a descending list" do
+      ActiveRecord::Schema.define do
+        create_table :ranked_tasks, force: true do |t|
+          t.string :name
+          t.integer :priority
+        end
+      end
+      klass = Class.new(TestModel) do
+        self.table_name = "ranked_tasks"
+        include ConcernsOnRails::Sortable
+
+        sortable_by priority: :desc, use_acts_as_list: false
+      end
+      x, y, z = %w[x y z].map { |n| klass.create!(name: n) }
+
+      expect(klass.reposition!([y.id, z.id, x.id])).to eq(3)
+      expect(klass.pluck(:name)).to eq(%w[y z x])
+      expect(klass.pluck(:priority)).to eq([3, 2, 1])
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Every sortable list ends up with a drag-and-drop UI, and the request it sends is "here is the new order of ids". acts_as_list offers `insert_at` per row — N updates, N shift cascades — but nothing that applies a whole order at once. This adds it.

- **`Model.reposition!(ids, missing: :append)`** — one `UPDATE … SET position = CASE "id" WHEN 3 THEN 1 WHEN 1 THEN 2 … END WHERE id IN (…)` inside a transaction, scoped to the current relation (`list.tasks.reposition!(params[:ids])` — the same set acts_as_list's `scope:` would use). Returns the number of rows updated.
- **Partial lists are explicit** — rows in the relation but not in `ids` are appended after the listed ones in their current order by default; `missing: :raise` turns a partial list (a paginated UI, a stale tab) into an error. Ids outside the relation, duplicates and an unknown `missing:` raise `ArgumentError` before anything is written.
- **Params-friendly** — String ids are cast through the primary key's type. The first id gets acts_as_list's `top_of_list` (1 by default); on a `:desc` list it gets the *highest* value so the list reads in the given order.
- Bypasses acts_as_list callbacks by design (`update_all`, no per-row shifting) — documented. README's stale "invalid direction silently falls back to :asc" note corrected (it raises since 1.26).

## Changelog entry

```
### Added
- **Sortable (model)**: `Model.reposition!(ids, missing: :append | :raise)` applies a drag-and-drop id
  order as positions in one `UPDATE … CASE` inside the current relation (unlisted rows appended or
  raised, foreign/duplicate ids rejected, String ids cast, `:desc` lists inverted). Returns the count.
```

## Test plan

- [x] `spec/concerns/models/sortable_spec.rb` — 4 new examples: single `UPDATE … CASE` statement (asserted via `sql.active_record`), resulting order + positions, String ids; append vs `missing: :raise` (nothing written) and the unknown-mode error; scoped relation (`list_id`), foreign id / duplicate errors, empty relation → 0; descending list gives the first id the highest value.
- [x] Full suite: 1261 examples, 0 failures. RuboCop clean.
- [x] README "Sortable" (example + notes) and `docs/concerns/sortable.md` (class-method row, controller example).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
