### PR TITLE
Sluggable: candidates:, max_length: (word-boundary truncation) and regenerate_slug!

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,10 @@ sluggable_by :title, reserved_words: %w[new edit admin]
 
 # Let Model.find accept a slug directly (not just the id)
 sluggable_by :title, finders: true
+sluggable_by :title, candidates: [:title, %i[title city]]   # try "title", then "title-city", then friendly_id's uuid suffix on the first candidate
+sluggable_by :title, max_length: 60                        # truncate at a word boundary (uniqueness suffix added after)
+
+page.regenerate_slug!   # rebuild from the current source — even over a hand-assigned slug
 Post.find("hello-world")   # resolves by slug
 ```
 
@@ -282,6 +286,9 @@ Post.find("hello-world")   # resolves by slug
 - Schema must have a `slug` column (string).
 - `history: true` requires a `friendly_id_slugs` table — generate with `rails generate friendly_id` or add a manual migration.
 - `scope: :col` requires `col` to exist in the same table.
+- `candidates:` takes friendly_id's shapes — a Symbol/String method, a Proc, or an Array of those joined with `-` — tried in order until one is free (all taken → the first candidate plus a uuid); the slug still regenerates only when the **primary** field changes (a candidate-only change doesn't churn the URL), and a NULL slug backfills through the candidates.
+- `max_length:` truncates each candidate at the last `-` inside the limit (a single long word is hard-cut); friendly_id's conflict suffix is appended afterwards, so a colliding slug may exceed the limit — unlike friendly_id's own `slug_limit`, which squeezes the uuid inside it.
+- `regenerate_slug!` is the escape hatch for the explicit-slug rule: it forces regeneration and saves (`save!`), keeping uniqueness handling.
 - Falls back to `to_s` if the configured source field doesn't respond.
 - Uses friendly_id's `:slugged` (+ optionally `:history`, `:scoped`) strategies under the hood.
 

--- a/docs/concerns/sluggable.md
+++ b/docs/concerns/sluggable.md
@@ -86,6 +86,8 @@ sluggable_by :title, finders: true
 | `scope:` | Symbol / nil | `nil` | Activates `friendly_id`'s `:scoped` module. Slug uniqueness is enforced only within the given column (e.g. `account_id`), allowing the same slug across different scope values. The named column must exist in the table. |
 | `reserved_words:` | Array\<String\> / nil | `nil` | Activates `friendly_id`'s `:reserved` module. Records whose generated slug matches any entry in this list fail validation with an error message containing "reserved". Values are coerced to strings. |
 | `finders:` | Boolean | `false` | Activates `friendly_id`'s `:finders` module. `Model.find` accepts a slug string in addition to a numeric id, so no `Model.friendly.find` call is needed at call sites. |
+| `candidates:` | Array / nil | `nil` | friendly_id slug candidates, tried in order until one is available: each entry is a Symbol/String (a method on the record), a Proc, or an Array of those (values joined with the sequence separator) — `[:title, %i[title city], %i[title city year]]`. Only when every candidate is taken does friendly_id fall back to the first candidate plus its uuid suffix. Regeneration is still driven by the primary `field` changing; a NULL slug backfills through the candidates. Must be a non-empty Array. |
+| `max_length:` | Integer / nil | `nil` | Truncate each candidate to at most this many characters at the last separator (`-`) inside the limit — `"the-quick-brown-fox"` → `"the-quick"` at 12 — falling back to a hard cut for a single long word. Applied before the uniqueness check, so friendly_id's conflict suffix is appended *after* and may exceed the limit (friendly_id's own `slug_limit` instead squeezes the uuid inside it). Must be a positive Integer. |
 
 Options can be combined freely: `sluggable_by :title, history: true, scope: :account_id, finders: true`.
 
@@ -104,14 +106,16 @@ Post.find("hello-world")            # available only when finders: true
 
 | Signature | Description |
 |---|---|
-| `slug_source` | Returns the current value of the configured `sluggable_field` attribute. If the model does not respond to that attribute, falls back to `to_s`. Used internally by `friendly_id` to derive the slug. |
-| `should_generate_new_friendly_id?` | Returns `true` when the configured source attribute has a pending change (via `will_save_change_to_<field>?`). Overrides `friendly_id`'s default behavior so slugs regenerate on every update that changes the source field. |
+| `slug_source` | Returns the current value of the configured `sluggable_field` attribute (falling back to `to_s`), or — with `candidates:` — the candidates Array for friendly_id to resolve. Used internally by `friendly_id` to derive the slug. |
+| `regenerate_slug!` | Rebuilds the slug from the current source (candidates included) and `save!`s — even over a slug that was assigned by hand, which a normal save deliberately leaves alone. A conflict still gets friendly_id's uuid suffix. Returns `true`; raises `ActiveRecord::RecordInvalid` like `save!`. |
+| `should_generate_new_friendly_id?` | Returns `true` when the configured source attribute has a pending change (via `will_save_change_to_<field>?`), when the slug is blank, or during `regenerate_slug!`; `false` while the slug column itself is being assigned. Overrides `friendly_id`'s default behavior so slugs regenerate on every update that changes the source field. |
+| `normalize_friendly_id(value)` | friendly_id's normalization plus the `max_length:` word-boundary truncation. Defined on the including class so it takes precedence over friendly_id's module. |
 
 ### Class methods
 
 | Signature | Description |
 |---|---|
-| `sluggable_by(field, history:, scope:, reserved_words:, finders:)` | Configures the slug source column and optionally enables additional `friendly_id` modules. Raises `ArgumentError` if `field` or the `scope:` column does not exist in the schema. |
+| `sluggable_by(field, history:, scope:, reserved_words:, finders:, candidates:, max_length:)` | Configures the slug source column and optionally enables additional `friendly_id` modules. Raises `ArgumentError` if `field` or the `scope:` column does not exist in the schema. |
 
 ## Examples
 

--- a/lib/concerns_on_rails/models/sluggable.rb
+++ b/lib/concerns_on_rails/models/sluggable.rb
@@ -17,10 +17,16 @@ module ConcernsOnRails
       extend ActiveSupport::Concern
 
       # instance methods
+      LABEL = "ConcernsOnRails::Models::Sluggable".freeze
+
       included do
         # declare class attributes and set default values
         class_attribute :sluggable_field, instance_accessor: false
         self.sluggable_field ||= :name
+        # `candidates:` — friendly_id slug candidates tried in order before the
+        # uuid fallback; `max_length:` — word-boundary truncation of the slug.
+        class_attribute :sluggable_candidates, instance_accessor: false, default: nil
+        class_attribute :sluggable_max_length, instance_accessor: false, default: nil
 
         extend FriendlyId
 
@@ -32,6 +38,8 @@ module ConcernsOnRails
         # we must override should_generate_new_friendly_id? to support update slug
         # if we don't override this method, friendly_id will not generate the new slug when update
         define_method :should_generate_new_friendly_id? do
+          return true if @sluggable_force_regenerate # regenerate_slug!
+
           field = self.class.sluggable_field
           slug_column = self.class.friendly_id_config.slug_column
 
@@ -49,6 +57,21 @@ module ConcernsOnRails
 
           source_changed || slug_missing
         end
+
+        # Defined on the class (like the method above) so it sits ABOVE
+        # FriendlyId::Slugged in the ancestor chain — a module-level override
+        # here would be shadowed by friendly_id's own. Truncates each candidate
+        # at a word (separator) boundary; the uniqueness suffix friendly_id
+        # appends on a conflict is added AFTER, on purpose — friendly_id's own
+        # `slug_limit` hard-cuts characters and squeezes the uuid inside the
+        # limit, which is rarely what a URL wants.
+        define_method :normalize_friendly_id do |value|
+          normalized = super(value)
+          limit = self.class.sluggable_max_length
+          return normalized unless limit && normalized.respond_to?(:truncate)
+
+          normalized.truncate(limit, omission: "", separator: friendly_id_config.sequence_separator)
+        end
       end
 
       # class methods
@@ -65,8 +88,13 @@ module ConcernsOnRails
         #   sluggable_by :title, scope: :account_id       # slugs unique per scope column
         #   sluggable_by :title, reserved_words: %w[new]  # block these slugs (a UUID is appended instead)
         #   sluggable_by :title, finders: true            # Model.find accepts a slug directly
-        def sluggable_by(field, history: false, scope: nil, reserved_words: nil, finders: false)
+        #   sluggable_by :title, candidates: [:title, %i[title city]]   # try "title", then "title-city", then a uuid
+        #   sluggable_by :title, max_length: 60                        # truncate at a word boundary
+        def sluggable_by(field, history: false, scope: nil, reserved_words: nil, finders: false,
+                         candidates: nil, max_length: nil)
           self.sluggable_field = field.to_sym
+          self.sluggable_candidates = sluggable_validate_candidates!(candidates)
+          self.sluggable_max_length = sluggable_validate_max_length!(max_length)
           # Validate the slug column too (a missing one used to fail at first save
           # with an opaque friendly_id error); an association scope: is exempt.
           scope_column = scope && reflect_on_association(scope.to_sym) ? nil : scope
@@ -80,6 +108,28 @@ module ConcernsOnRails
         end
 
         private
+
+        # friendly_id's candidate shapes: a Symbol/String (method), a Proc, or an
+        # Array of those (joined with the separator).
+        def sluggable_validate_candidates!(candidates)
+          return nil if candidates.nil?
+          unless candidates.is_a?(Array) && candidates.any?
+            raise ArgumentError,
+                  "#{LABEL}: candidates: must be an Array of Symbols/Procs/Arrays (got #{candidates.inspect})"
+          end
+
+          candidates
+        end
+
+        def sluggable_validate_max_length!(max_length)
+          return nil if max_length.nil?
+          unless max_length.is_a?(Integer) && max_length.positive?
+            raise ArgumentError,
+                  "#{LABEL}: max_length: must be a positive Integer (got #{max_length.inspect})"
+          end
+
+          max_length
+        end
 
         # Re-runs friendly_id with the extra modules. friendly_id merges config
         # across calls, so this layers :history / :scoped / :finders / :reserved onto :slugged.
@@ -109,8 +159,21 @@ module ConcernsOnRails
       # Example:
       #   record.slug_source
       def slug_source
+        candidates = self.class.sluggable_candidates
+        return candidates if candidates
+
         field = self.class.sluggable_field
         respond_to?(field) ? send(field) : to_s
+      end
+
+      # Rebuild the slug from the current source (candidates included) and
+      # save — even over a slug that was assigned by hand, which a normal save
+      # deliberately leaves alone. Conflicts still get friendly_id's suffix.
+      def regenerate_slug!
+        @sluggable_force_regenerate = true
+        save!
+      ensure
+        @sluggable_force_regenerate = false
       end
     end
   end

--- a/spec/concerns/models/sluggable_spec.rb
+++ b/spec/concerns/models/sluggable_spec.rb
@@ -266,4 +266,78 @@ describe ConcernsOnRails::Sluggable do
       expect(FindablePage.find("hello-world")).to eq(page)
     end
   end
+
+  describe "candidates:, max_length: and regenerate_slug!" do
+    before do
+      ActiveRecord::Schema.define do
+        create_table :candidate_pages, force: true do |t|
+          t.string :title
+          t.string :subtitle
+          t.string :slug
+          t.timestamps
+        end
+      end
+    end
+
+    def candidate_class(**opts)
+      stub_const("CandidatePage", Class.new(TestModel) do
+        self.table_name = "candidate_pages"
+        include ConcernsOnRails::Sluggable
+
+        sluggable_by :title, **opts
+      end)
+      CandidatePage
+    end
+
+    it "tries the candidates in order before falling back to friendly_id's uuid suffix" do
+      klass = candidate_class(candidates: [:title, %i[title subtitle]])
+      expect(klass.create!(title: "Hello", subtitle: "one").slug).to eq("hello")
+      expect(klass.create!(title: "Hello", subtitle: "two").slug).to eq("hello-two")
+      # friendly_id resolves a total conflict by suffixing the FIRST candidate with a uuid
+      expect(klass.create!(title: "Hello", subtitle: "two").slug).to match(/\Ahello-[0-9a-f-]{36}\z/)
+      expect(klass.sluggable_candidates).to eq([:title, %i[title subtitle]])
+    end
+
+    it "keeps regenerating from the primary field only, and backfills through the candidates" do
+      klass = candidate_class(candidates: [:title, %i[title subtitle]])
+      page = klass.create!(title: "Hello", subtitle: "one")
+      page.update!(subtitle: "changed")
+      expect(page.slug).to eq("hello") # a candidate-only field change does not churn the URL
+      page.update!(title: "Bye")
+      expect(page.slug).to eq("bye")
+
+      page.update_column(:slug, nil)
+      page.reload.save!
+      expect(page.slug).to eq("bye")
+    end
+
+    it "max_length: truncates the slug at a word boundary (the uniqueness suffix is added after)" do
+      klass = candidate_class(max_length: 12)
+      first = klass.create!(title: "The quick brown fox jumps")
+      expect(first.slug).to eq("the-quick")
+      second = klass.create!(title: "The quick brown fox jumps")
+      expect(second.slug).to match(/\Athe-quick-[0-9a-f-]{36}\z/)
+      expect(klass.create!(title: "Short").slug).to eq("short")
+    end
+
+    it "regenerate_slug! rebuilds the slug from the current source, even over a manually assigned one" do
+      page = Page.create!(title: "First Post")
+      page.update!(slug: "custom-handle")
+      expect(page.reload.slug).to eq("custom-handle") # explicit assignment still wins on a normal save
+
+      expect(page.regenerate_slug!).to be(true)
+      expect(page.reload.slug).to eq("first-post")
+
+      Page.create!(title: "Taken")
+      other = Page.create!(title: "Other")
+      other.update!(title: "Taken")
+      other.regenerate_slug!
+      expect(other.slug).to match(/\Ataken-[0-9a-f-]{36}\z/) # still unique
+    end
+
+    it "validates candidates: and max_length:" do
+      expect { candidate_class(candidates: :title) }.to raise_error(ArgumentError, /candidates: must be an Array/)
+      expect { candidate_class(max_length: 0) }.to raise_error(ArgumentError, /max_length: must be a positive Integer/)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Three things people reach into friendly_id for directly today, surfaced through `sluggable_by` with the concern's own regeneration rules kept intact:

- **`candidates:`** — `sluggable_by :title, candidates: [:title, %i[title city], %i[title city year]]`. friendly_id's own candidate shapes (a Symbol/String method, a Proc, or an Array of those joined with `-`), tried in order until one is free; only when all are taken does friendly_id fall back to the first candidate plus its uuid. `slug_source` returns the candidate list when configured. Regeneration is still driven by the **primary** field changing (a candidate-only change doesn't churn the URL) and a NULL slug backfills through the candidates.
- **`max_length:`** — truncates each candidate at the last `-` inside the limit (`"the-quick-brown-fox-jumps"` → `"the-quick"` at 12; a single long word is hard-cut), via a `normalize_friendly_id` override **defined on the including class** — a module-level override would sit below `FriendlyId::Slugged` in the ancestor chain and never run. The uniqueness suffix is appended *after* the truncation on purpose: friendly_id's own `slug_limit` hard-cuts characters and squeezes the uuid inside the limit, which is rarely what a URL wants (documented).
- **`regenerate_slug!`** — the escape hatch for the "an explicitly assigned slug wins" rule: forces regeneration from the current source (candidates included) and `save!`s, with normal uniqueness handling.
- Both options validated at declaration (`candidates:` non-empty Array, `max_length:` positive Integer).

## Changelog entry

```
### Added
- **Sluggable**: `candidates:` (friendly_id slug candidates tried in order before the uuid fallback;
  regeneration still keyed to the primary field), `max_length:` (word-boundary truncation, suffix
  appended after) and `regenerate_slug!` (rebuild from the current source even over a hand-assigned
  slug).
```

## Test plan

- [x] `spec/concerns/models/sluggable_spec.rb` — 5 new examples: candidate order + first-candidate uuid fallback + introspection; candidate-only change leaves the slug, primary change regenerates, NULL backfills through candidates; `max_length:` truncation, suffix after truncation, short title untouched; `regenerate_slug!` over a manual slug and with a conflict; validation of both options.
- [x] Full suite: 1262 examples, 0 failures. RuboCop clean.
- [x] README "Sluggable" (options + notes) and `docs/concerns/sluggable.md` (option rows, method rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
