### PR TITLE
Sequenceable: assign: :manual — number invoices when finalized (assign_<field>!, <field>_assigned?, pending_<field>)

### DIFF
--- a/README.md
+++ b/README.md
@@ -854,6 +854,7 @@ Invoice.next_sequence(account_id: 1)   # => 4  (peek the next value, without cre
 | `scope:`             | `nil`       | Column (or array of columns) the counter is scoped to — e.g. one sequence per `account_id`. |
 | `reset:`             | `:never`    | `:never` / `:year` / `:month` / `:day` — restart numbering each period (needs `created_at`). |
 | `template:`          | `nil`       | `->(seq, record) { ... }` full custom formatter; overrides `prefix` / `padding` / period. |
+| `assign:`            | `:create`   | `:create` numbers every record in `before_create`; `:manual` leaves the column NULL until `assign_<field>!` is called — for invoices that get their number when finalized, not when drafted. |
 
 **Default format**
 
@@ -870,10 +871,14 @@ Invoice.next_sequence(account_id: 1)   # => 4  (peek the next value, without cre
 |-----------------------------------|---------------------------------------------------------------------------------------|
 | `formatted_<field>`               | The formatted string — the persisted `into:` value when set, otherwise computed.      |
 | `Model.next_<field>(scope_attrs)` | Peek the next integer for a scope without creating a record.                           |
+| `assign_<field>!`                 | Number the record now (`assign: :manual`, or any row still blank): next value + `into:` string, `save!`d when persisted, left for your save when new. `true` when assigned, `false` when already numbered. |
+| `<field>_assigned?`               | Whether the record has its number.                                                    |
+| `Model.pending_<field>`           | Scope: rows still awaiting a number (`WHERE <field> IS NULL`).                          |
 
 **Notes**
 - The next value is `MAX(<field>) + 1` within the scope (and period), so numbering is dense and ordered — not random.
 - Caller-supplied values are respected: `Invoice.create!(sequence: 100)` is not overwritten (and its `into:` string is still formatted from `100`).
+- With `assign: :manual`, numbering follows **assignment** order (the first invoice finalized is #1, whenever it was drafted); with `reset:` the period is still taken from the row's `created_at`, exactly as on create.
 - Generation reads `MAX` then inserts, so two concurrent inserts can race. It's **best-effort** — add a **scoped unique index** on `<field>` (and on `into:`) for a real guarantee, the same way you would for any `MAX`-based numbering.
 - `reset:` requires a `created_at` column; the period is taken from each row's creation time.
 - For fixed-width display (`00042`), make the `into:` column a **string** — integer columns drop leading zeros.

--- a/docs/concerns/sequenceable.md
+++ b/docs/concerns/sequenceable.md
@@ -68,6 +68,7 @@ end
 | `scope:` | Symbol / Array of Symbols / nil | `nil` | Column or array of columns that partition the counter. Each distinct combination of scope-column values maintains its own independent counter. |
 | `reset:` | Symbol | `:never` | Restarts the counter at `start_at` each calendar period. Valid values: `:never`, `:year`, `:month`, `:day`. Any value other than `:never` requires a `created_at` column. |
 | `template:` | Callable / nil | `nil` | A callable (e.g. a lambda) with signature `->(seq, record)` that returns the formatted string. When set, it completely overrides `prefix`, `padding`, `separator`, and the period token. Must respond to `#call`. |
+| `assign:` | Symbol | `:create` | When the number is assigned. `:create` registers the `before_create` callback (the default). `:manual` registers none — the column stays `NULL` until `assign_<field>!` is called, so a draft can exist without consuming a number and numbering follows finalization order. Any other value raises `ArgumentError`. |
 
 ### Default format by `reset:` value
 
@@ -94,7 +95,19 @@ Returns the formatted display string for the configured field. When an `into:` c
 
 Computes and assigns the next sequence value and, when `into:` is configured, the formatted string. Skips assignment if the integer column already has a value (caller-supplied values are respected). If the computed candidate is already taken, the value is incremented until a free slot is found, up to `MAX_GENERATION_ATTEMPTS` (10) retries.
 
+**`assign_<field>!`**
+
+Numbers the record now: computes the next value for its scope (and period), writes the integer and the `into:` string, and — when the record is persisted — `save!`s. On a new record the attributes are set and left for your own save. Returns `true` when a number was assigned and `false` when the record already had one (nothing is rewritten), so a "finalize" action can be retried safely. Available in both modes; it is the only way to number a record under `assign: :manual`.
+
+**`<field>_assigned?`**
+
+`true` when the integer column has a value.
+
 ### Class methods
+
+**`pending_<field>`**
+
+Scope: records still awaiting a number (`WHERE <field> IS NULL`) — the drafts, under `assign: :manual`.
 
 **`next_<field>(scope_attrs = {})`**
 
@@ -167,6 +180,28 @@ end
 
 Ticket.create!(department_code: "ENG").reference  # => "TKT-ENG-1000"
 Ticket.create!(department_code: "OPS").reference  # => "TKT-OPS-1001"
+```
+
+**Number when finalized, not when drafted**
+
+```ruby
+class Invoice < ApplicationRecord
+  include ConcernsOnRails::Sequenceable
+
+  sequenceable_by :sequence, into: :number, prefix: "INV-", padding: 5, scope: :account_id, assign: :manual
+
+  def finalize!
+    transaction do
+      assign_sequence!          # => true the first time, false on a retry
+      update!(state: "final")
+    end
+  end
+end
+
+draft = Invoice.create!(account_id: 1)   # sequence: nil, number: nil
+Invoice.pending_sequence                 # => [draft]
+draft.finalize!
+draft.number                             # => "INV-00001"
 ```
 
 ## Notes & gotchas

--- a/lib/concerns_on_rails/models/sequenceable.rb
+++ b/lib/concerns_on_rails/models/sequenceable.rb
@@ -33,6 +33,7 @@ module ConcernsOnRails
       extend ActiveSupport::Concern
 
       RESET_PERIODS = %i[never year month day].freeze
+      ASSIGN_MODES = %i[create manual].freeze
       NAME = "ConcernsOnRails::Models::Sequenceable".freeze
 
       included do
@@ -54,26 +55,29 @@ module ConcernsOnRails
         #   scope:     column or array of columns the counter is scoped to (default nil)
         #   reset:     :never (default) | :year | :month | :day — restart per period (needs created_at)
         #   template:  ->(seq, record) { ... } full custom formatter; overrides prefix/padding/period
+        #   assign:    :create (default) numbers every record in before_create; :manual leaves the
+        #              column NULL until `assign_<field>!` — invoices numbered when finalized
         def sequenceable_by(field = :sequence, into: nil, prefix: "", padding: 0,
-                            separator: "-", start_at: 1, scope: nil, reset: :never, template: nil)
+                            separator: "-", start_at: 1, scope: nil, reset: :never, template: nil, assign: :create)
           field      = field.to_sym
           into       = into&.to_sym
           reset      = reset.to_sym
+          assign     = assign.to_sym
           scope_cols = Array(scope).map(&:to_sym)
 
           ensure_columns!(NAME, field, types: :integer)
           ensure_columns!(NAME, into, types: :string) if into
           ensure_columns!(NAME, *scope_cols) unless scope_cols.empty?
           ensure_columns!(NAME, :created_at, types: :datetime) unless reset == :never
-          validate_sequenceable_options!(reset, template)
+          validate_sequenceable_options!(reset, template, assign)
 
           self.sequenceable_config = sequenceable_config.merge(
             field => { into: into, prefix: prefix.to_s, padding: padding.to_i,
                        separator: separator.to_s, start_at: start_at.to_i,
-                       scope: scope_cols, reset: reset, template: template }
+                       scope: scope_cols, reset: reset, template: template, assign: assign }
           )
 
-          before_create -> { assign_sequenceable_value(field) }
+          before_create -> { assign_sequenceable_value(field) } if assign == :create
           define_sequenceable_methods(field)
         end
       end
@@ -93,13 +97,21 @@ module ConcernsOnRails
           define_singleton_method("next_#{field}") do |scope_attrs = {}|
             sequence_base_value(field, nil, scope_attrs)
           end
+
+          # On-demand numbering (the only way under assign: :manual), a
+          # predicate, and the "still awaiting a number" scope.
+          define_method("assign_#{field}!") { sequenceable_assign!(field) }
+          define_method("#{field}_assigned?") { self[field].present? }
+          scope "pending_#{field}", -> { where(field => nil) }
         end
 
-        def validate_sequenceable_options!(reset, template)
+        def validate_sequenceable_options!(reset, template, assign = :create)
           unless RESET_PERIODS.include?(reset)
             raise ArgumentError, "#{NAME}: unknown reset '#{reset}'. Valid values: #{RESET_PERIODS.join(', ')}"
           end
-
+          unless ASSIGN_MODES.include?(assign)
+            raise ArgumentError, "#{NAME}: unknown assign ':#{assign}'. Valid values: #{ASSIGN_MODES.join(', ')}"
+          end
           return if template.nil? || template.respond_to?(:call)
 
           raise ArgumentError, "#{NAME}: template must be callable (respond to #call)"
@@ -123,6 +135,19 @@ module ConcernsOnRails
 
         self[cfg[:into]] = self.class.send(:format_sequence, field, self[field], self)
       end
+
+      # Number the record now: the next value for its scope/period plus the
+      # into: string, save!d when the record is persisted and left for the
+      # caller's save when new. false (nothing rewritten) when already
+      # numbered, so a "finalize" action can be retried safely.
+      def sequenceable_assign!(field)
+        return false if self[field].present?
+
+        assign_sequenceable_value(field)
+        save! unless new_record?
+        true
+      end
+      private :sequenceable_assign!
 
       # Pin the row inside the period its number is drawn from: with reset:
       # enabled the period is computed from "now" during before_create, but

--- a/spec/concerns/models/sequenceable_spec.rb
+++ b/spec/concerns/models/sequenceable_spec.rb
@@ -27,7 +27,7 @@ describe ConcernsOnRails::Sequenceable do
 
     %i[Invoice StartAtInvoice PlainSequence ScopedInvoice YearlyInvoice TemplatedInvoice
        NoColumnInvoice NoIntoInvoice NoScopeColumnInvoice NoCreatedAtInvoice
-       BadResetInvoice BadTemplateInvoice].each do |const|
+       BadResetInvoice BadTemplateInvoice ManualInvoice ScopedManualInvoice BadAssignInvoice].each do |const|
       Object.send(:remove_const, const) if Object.const_defined?(const)
     end
   end
@@ -300,6 +300,84 @@ describe ConcernsOnRails::Sequenceable do
           sequenceable_by :sequence, template: "not-callable"
         end
       end.to raise_error(ArgumentError, /template must be callable/)
+    end
+  end
+
+  describe "assign: :manual (number on demand, e.g. when an invoice is finalized)" do
+    before do
+      class ManualInvoice < TestModel
+        self.table_name = "invoices"
+        include ConcernsOnRails::Sequenceable
+
+        sequenceable_by :sequence, into: :number, prefix: "INV-", padding: 5, assign: :manual
+      end
+    end
+
+    it "leaves the sequence blank on create and assigns it on demand, idempotently" do
+      invoice = ManualInvoice.create!
+      expect(invoice.sequence).to be_nil
+      expect(invoice.number).to be_nil
+      expect(invoice.sequence_assigned?).to be(false)
+      expect(ManualInvoice.pending_sequence).to eq([invoice])
+
+      expect(invoice.assign_sequence!).to be(true)
+      expect(invoice.sequence).to eq(1)
+      expect(invoice.number).to eq("INV-00001")
+      expect(invoice.reload.number).to eq("INV-00001") # persisted
+      expect(invoice.sequence_assigned?).to be(true)
+      expect(ManualInvoice.pending_sequence).to be_empty
+
+      expect(invoice.assign_sequence!).to be(false) # already numbered — nothing rewritten
+      expect(invoice.sequence).to eq(1)
+
+      second = ManualInvoice.create!
+      second.assign_sequence!
+      expect(second.number).to eq("INV-00002")
+    end
+
+    it "numbers in assignment order (not creation order) and respects scope:" do
+      class ScopedManualInvoice < TestModel
+        self.table_name = "invoices"
+        include ConcernsOnRails::Sequenceable
+
+        sequenceable_by :sequence, scope: :account_id, assign: :manual
+      end
+      a = ScopedManualInvoice.create!(account_id: 1)
+      b = ScopedManualInvoice.create!(account_id: 1)
+      c = ScopedManualInvoice.create!(account_id: 2)
+
+      b.assign_sequence!
+      a.assign_sequence!
+      c.assign_sequence!
+      expect([b.sequence, a.sequence, c.sequence]).to eq([1, 2, 1])
+      expect(ScopedManualInvoice.next_sequence(account_id: 1)).to eq(3)
+    end
+
+    it "assigns on an unsaved record without saving it, and validates assign:" do
+      invoice = ManualInvoice.new
+      expect(invoice.assign_sequence!).to be(true)
+      expect(invoice.sequence).to eq(1)
+      expect(invoice.number).to eq("INV-00001")
+      expect(invoice).to be_new_record
+      invoice.save!
+      expect(ManualInvoice.find(invoice.id).sequence).to eq(1)
+
+      expect do
+        class BadAssignInvoice < TestModel
+          self.table_name = "invoices"
+          include ConcernsOnRails::Sequenceable
+
+          sequenceable_by :sequence, assign: :later
+        end
+      end.to raise_error(ArgumentError, /unknown assign ':later'. Valid values: create, manual/)
+    end
+
+    it "keeps the create-time default: automatic numbering, assign_<field>! a no-op afterwards" do
+      invoice = Invoice.create!
+      expect(invoice.sequence).to eq(1)
+      expect(invoice.sequence_assigned?).to be(true)
+      expect(invoice.assign_sequence!).to be(false)
+      expect(Invoice.pending_sequence).to be_empty
     end
   end
 end


### PR DESCRIPTION
## Summary

Sequenceable numbers every row at `create` — but the invoicing rule in most jurisdictions is that a number is consumed when the invoice is *issued*, not when a draft is saved, and gaps from deleted drafts are not allowed. This adds the deferred mode.

- **`assign: :manual`** — no `before_create` callback; the integer and `into:` columns stay `NULL` until asked. Numbering therefore follows finalization order (the first invoice issued is #1, whenever it was drafted). `:create` (default) is unchanged; anything else raises at declaration.
- **`assign_<field>!`** — computes the next value for the record's scope (and period — taken from `created_at`, exactly as on create), writes the integer and the formatted string, `save!`s when the record is persisted and leaves a new record for the caller's own save. Returns `true` when a number was assigned and `false` (nothing rewritten) when the record already had one, so a "finalize" action is safe to retry. Defined in both modes — under `:create` it is simply a no-op on already-numbered rows.
- **`<field>_assigned?`** and the **`pending_<field>`** scope (`WHERE <field> IS NULL`) — the drafts awaiting a number.
- README (option row, generated-API rows, note) and `docs/concerns/sequenceable.md` (option row, method sections, finalize example) updated.

## Changelog entry

```
### Added
- **Sequenceable**: `assign: :manual` defers numbering until `assign_<field>!` (idempotent — `true` when
  assigned, `false` when already numbered; `save!`s persisted records, leaves new ones for the caller's
  save), plus `<field>_assigned?` and a `pending_<field>` scope. Numbering then follows finalization
  order; `reset:` periods still come from `created_at`.
```

## Test plan

- [x] `spec/concerns/models/sequenceable_spec.rb` — 4 new examples: blank on create → assigned on demand (integer + `into:` persisted, predicate, `pending_` scope, second call `false`, next record #2); assignment order beats creation order under `scope:` and `next_<field>` still peeks; unsaved record numbered without saving, then saved; bad `assign:` error; default mode unchanged with `assign_<field>!` a no-op.
- [x] Full suite: 1261 examples, 0 failures. RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
