### PR TITLE
Paginatable: page_param: / per_page_param: and style: :jsonapi (page[number] / page[size]) — Link header follows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1486,6 +1486,14 @@ render_success(data: paginated(result.hits, total: result.total_hits), meta: pag
 | `?page=`     | `1`     | Page numbers below 1 are clamped to 1 |
 | `?per_page=` | `25`    | Capped at `max_per_page` (default 200) |
 
+Rename them, or speak JSON:API — the `Link` header URLs follow whatever you pick:
+
+```ruby
+paginate_by page_param: :p, per_page_param: :limit                 # ?p=2&limit=10
+paginate_by style: :jsonapi                                        # ?page[number]=2&page[size]=10
+paginate_by page_param: %i[paging page], per_page_param: %i[paging per]   # any nested path
+```
+
 **Response headers**: `X-Total-Count`, `X-Page`, `X-Per-Page`, `X-Total-Pages`, and an RFC 8288 `Link`
 header with `first` / `prev` / `next` / `last` URLs rebuilt from the current request (other query params
 preserved; `prev`/`next` only when such a page exists; nothing for an empty collection) — the GitHub

--- a/docs/concerns/paginatable.md
+++ b/docs/concerns/paginatable.md
@@ -35,6 +35,9 @@ end
 | `per_page` | Integer | `25` | Default number of records per page when the caller supplies no `?per_page=` param, or supplies a value less than 1. Coerced with `.to_i`. |
 | `max_per_page` | Integer | `200` | Hard upper bound on `per_page`. Any caller-supplied value above this cap is silently reduced to this value. When set to `0` or a negative integer the cap is disabled and any requested `per_page` is honored. Coerced with `.to_i`. |
 | `link_header` | Boolean | `true` | Emit the RFC 8288 `Link` header (`first`/`prev`/`next`/`last`) on every paginated response. Set `false` to send only the `X-*` headers. |
+| `page_param` | Symbol/String or Array | `:page` | Where the page number is read from: a top-level param name, or an Array path into nested params (`%i[page number]` → `?page[number]=2`). Must be a name or a non-empty path of names. |
+| `per_page_param` | Symbol/String or Array | `:per_page` | Same for the page size (`%i[page size]` → `?page[size]=10`). |
+| `style` | `:flat` or `:jsonapi` | `:flat` | Shortcut: `:jsonapi` sets `page_param: %i[page number]` and `per_page_param: %i[page size]` (the JSON:API page-based strategy); `:flat` keeps `page` / `per_page`. Explicit `page_param:`/`per_page_param:` win over the style. |
 
 **URL params read from `params`**
 
@@ -42,6 +45,8 @@ end
 |---|---|---|
 | `?page=` | `1` | Values below 1 (including negative numbers and zero) are clamped to `1`. |
 | `?per_page=` | value of `paginatable_per_page` | Values below 1 fall back to the class default; values above `max_per_page` are capped. |
+
+Both names are configurable (`page_param:` / `per_page_param:` / `style: :jsonapi`). Nested paths are read by digging through the params (`params[:page][:number]`); a non-Hash where a Hash is expected, or an Array/Hash where a scalar is expected, falls back to the default exactly like garbage in the flat form.
 
 ## Methods
 
@@ -70,7 +75,7 @@ The four `X-*` headers set on `response`:
 | `X-Page` | The resolved current page number (always >= 1). |
 | `X-Per-Page` | The resolved per-page value after applying defaults and the cap. |
 | `X-Total-Pages` | `ceil(total / per_page)`. Returns `"0"` when the relation is empty. |
-| `Link` | RFC 8288 web links: `<…?page=1>; rel="first", <…?page=1>; rel="prev", <…?page=3>; rel="next", <…?page=5>; rel="last"`. URLs are the current request's base URL + path with `page` replaced and every other query param preserved. `prev`/`next` appear only when such a page exists (past the end, `prev` points at the last page). Not emitted for an empty collection, when `link_header: false`, or when the controller has no request. Appended to an existing `Link` header, never replacing it. |
+| `Link` | RFC 8288 web links: `<…?page=1>; rel="first", <…?page=1>; rel="prev", <…?page=3>; rel="next", <…?page=5>; rel="last"`. URLs are the current request's base URL + path with the page param replaced — under the configured name, nested ones encoded by Rack (`page%5Bnumber%5D=3`) with the rest of that nested Hash (`page[size]`) preserved — and every other query param kept. `prev`/`next` appear only when such a page exists (past the end, `prev` points at the last page). Not emitted for an empty collection, when `link_header: false`, or when the controller has no request. Appended to an existing `Link` header, never replacing it. |
 
 ## Examples
 
@@ -139,6 +144,26 @@ class ReportsController < ApplicationController
     render json: paginated(Report.all)
   end
 end
+```
+
+**JSON:API page-based pagination**
+
+```ruby
+class Api::ArticlesController < ApplicationController
+  include ConcernsOnRails::Controllers::Paginatable
+
+  paginate_by style: :jsonapi, per_page: 20, max_per_page: 100
+
+  def index
+    articles = paginated(Article.order(:id))
+    render json: { data: articles, meta: pagination_meta }
+  end
+end
+
+# GET /api/articles?page[number]=2&page[size]=10&filter[state]=live
+# X-Page: 2   X-Per-Page: 10
+# Link: <…?page%5Bnumber%5D=1&page%5Bsize%5D=10&filter%5Bstate%5D=live>; rel="first",
+#       <…?page%5Bnumber%5D=1…>; rel="prev", <…?page%5Bnumber%5D=3…>; rel="next", <…?page%5Bnumber%5D=9…>; rel="last"
 ```
 
 ## Notes & gotchas

--- a/lib/concerns_on_rails/controllers/paginatable.rb
+++ b/lib/concerns_on_rails/controllers/paginatable.rb
@@ -41,17 +41,47 @@ module ConcernsOnRails
         class_attribute :paginatable_per_page, default: DEFAULT_PER_PAGE
         class_attribute :paginatable_max_per_page, default: DEFAULT_MAX_PER_PAGE
         class_attribute :paginatable_link_header, default: true
+        # Where page / per_page are read from — a path of param names (`["page"]`,
+        # or `["page", "number"]` for JSON:API's page[number]).
+        class_attribute :paginatable_page_param, default: %w[page].freeze
+        class_attribute :paginatable_per_page_param, default: %w[per_page].freeze
       end
 
-      class_methods do
+      # A real module (not `class_methods do`) so the macro and its private
+      # helpers share one `private` without tripping RuboCop's scope analysis.
+      module ClassMethods
         # Configure the default page size, the hard cap on per_page, and whether
         # the RFC 8288 Link header is emitted.
         # Example:
         #   paginate_by per_page: 50, max_per_page: 500, link_header: false
-        def paginate_by(per_page: DEFAULT_PER_PAGE, max_per_page: DEFAULT_MAX_PER_PAGE, link_header: true)
+        def paginate_by(per_page: DEFAULT_PER_PAGE, max_per_page: DEFAULT_MAX_PER_PAGE, link_header: true,
+                        page_param: nil, per_page_param: nil, style: :flat)
           self.paginatable_per_page = per_page.to_i
           self.paginatable_max_per_page = max_per_page.to_i
           self.paginatable_link_header = link_header ? true : false
+          defaults = paginatable_style_params!(style)
+          self.paginatable_page_param = paginatable_param_path!(:page_param, page_param || defaults[0])
+          self.paginatable_per_page_param = paginatable_param_path!(:per_page_param, per_page_param || defaults[1])
+        end
+
+        private
+
+        # :flat → page / per_page; :jsonapi → page[number] / page[size].
+        def paginatable_style_params!(style)
+          case style.to_sym
+          when :flat then [%w[page], %w[per_page]]
+          when :jsonapi then [%w[page number], %w[page size]]
+          else raise ArgumentError, "#{LABEL}: style: must be :flat or :jsonapi (got #{style.inspect})"
+          end
+        end
+
+        # A name or a non-empty path of names, normalized to Strings.
+        def paginatable_param_path!(option, value)
+          path = Array(value)
+          valid = path.any? && path.all? { |segment| (segment.is_a?(Symbol) || segment.is_a?(String)) && !segment.to_s.empty? }
+          raise ArgumentError, "#{LABEL}: #{option}: must be a param name or a path of names (got #{value.inspect})" unless valid
+
+          path.map(&:to_s).freeze
         end
       end
 
@@ -162,14 +192,40 @@ module ConcernsOnRails
       # Both readers route through ScalarParam: `?page[]=1` / `?page[x]=1`
       # arrive as Array/Parameters, and calling .to_i on those was a 500.
       def pagination_page
-        [ConcernsOnRails::Support::ScalarParam.to_i(params[:page], default: 0), 1].max
+        [ConcernsOnRails::Support::ScalarParam.to_i(pagination_param(self.class.paginatable_page_param), default: 0), 1].max
       end
 
       def pagination_per_page
-        requested = ConcernsOnRails::Support::ScalarParam.to_i(params[:per_page], default: 0)
+        requested = ConcernsOnRails::Support::ScalarParam.to_i(pagination_param(self.class.paginatable_per_page_param), default: 0)
         requested = self.class.paginatable_per_page if requested < 1
         cap = self.class.paginatable_max_per_page
         cap.positive? ? [requested, cap].min : requested
+      end
+
+      # Dig the configured path out of params: `["page"]` → params[:page];
+      # `["page", "number"]` → params[:page][:number]. A scalar where a Hash
+      # is expected yields nil (→ the default), like any other garbage.
+      def pagination_param(path)
+        path.reduce(params) do |node, key|
+          break nil unless node.respond_to?(:[]) && !node.is_a?(String) && !node.is_a?(Array)
+
+          node[key]
+        end
+      end
+
+      # The `overrides` for LinkHeader.url_for that set the page number under the
+      # configured name — replacing the whole nested Hash for a path so the
+      # other keys in it (page[size]) survive.
+      def pagination_page_override(number)
+        path = self.class.paginatable_page_param
+        return { path.first.to_sym => number } if path.size == 1
+
+        nested = request.query_parameters.to_h.transform_keys(&:to_s)[path.first]
+        nested = nested.is_a?(Hash) ? nested.deep_dup : {}
+        node = nested
+        path[1...-1].each { |key| node = (node[key] = node[key].is_a?(Hash) ? node[key] : {}) }
+        node[path.last] = number
+        { path.first.to_sym => nested }
       end
 
       def set_pagination_headers(total:, page:, per_page:, total_pages:)
@@ -188,7 +244,7 @@ module ConcernsOnRails
       def set_pagination_links(page:, total_pages:)
         return unless pagination_links_applicable?(total_pages)
 
-        page_url = ->(number) { ConcernsOnRails::Support::LinkHeader.url_for(request, page: number) }
+        page_url = ->(number) { ConcernsOnRails::Support::LinkHeader.url_for(request, **pagination_page_override(number)) }
         ConcernsOnRails::Support::LinkHeader.append(
           response,
           first: page_url.call(1),

--- a/lib/concerns_on_rails/support/link_header.rb
+++ b/lib/concerns_on_rails/support/link_header.rb
@@ -20,15 +20,24 @@ module ConcernsOnRails
       end
 
       # The request's URL with `overrides` merged into its query string (a nil
-      # value or a key in `drop:` removes that param). Existing params keep
-      # their order; nested params survive via Rack's nested-query encoding.
+      # value or a key in `drop:` removes that param; a Hash value replaces a
+      # nested param wholesale — `page: { "number" => 3, "size" => 10 }`).
+      # Existing params keep their order; nested params survive via Rack's
+      # nested-query encoding.
       def url_for(request, drop: [], **overrides)
         query = request.query_parameters.to_h.transform_keys(&:to_s)
-        overrides.each { |key, value| value.nil? ? query.delete(key.to_s) : query[key.to_s] = value.to_s }
+        overrides.each { |key, value| value.nil? ? query.delete(key.to_s) : query[key.to_s] = stringify_deep(value) }
         Array(drop).each { |key| query.delete(key.to_s) }
 
         base = "#{request.base_url}#{request.path}"
         query.empty? ? base : "#{base}?#{Rack::Utils.build_nested_query(query)}"
+      end
+
+      # build_nested_query wants String keys and String leaves.
+      def stringify_deep(value)
+        return value.to_h { |k, v| [k.to_s, stringify_deep(v)] } if value.is_a?(Hash)
+
+        value.to_s
       end
 
       # `links` is { rel => url }; nil urls are skipped and nothing is set when

--- a/spec/concerns/controllers/paginatable_spec.rb
+++ b/spec/concerns/controllers/paginatable_spec.rb
@@ -373,4 +373,81 @@ describe ConcernsOnRails::Controllers::Paginatable do
       expect(controller.response.headers["X-Total-Count"]).to eq("10")
     end
   end
+
+  describe "page_param: / per_page_param: / style: :jsonapi" do
+    def ids(klass, params)
+      klass.new(params: params).paginated(Widget.order(:id)).map(&:id)
+    end
+
+    it "reads custom top-level param names" do
+      klass = Class.new(FakeController) do
+        include ConcernsOnRails::Controllers::Paginatable
+
+        paginate_by page_param: :p, per_page_param: :limit
+      end
+      controller = klass.new(params: { p: "2", limit: "10", page: "9", per_page: "3" })
+      expect(controller.paginated(Widget.order(:id)).map(&:id)).to eq((11..20).to_a)
+      expect(controller.response.headers).to include("X-Page" => "2", "X-Per-Page" => "10")
+      expect(klass.paginatable_page_param).to eq(["p"])
+    end
+
+    it "reads nested JSON:API page[number] / page[size] via style: :jsonapi, tolerating garbage" do
+      klass = Class.new(FakeController) do
+        include ConcernsOnRails::Controllers::Paginatable
+
+        paginate_by style: :jsonapi
+      end
+      expect(ids(klass, page: { number: "3", size: "10" })).to eq((21..30).to_a)
+      expect(ids(klass, page: { number: "3", size: "10" }).size).to eq(10)
+      expect(ids(klass, page: "abc").size).to eq(25) # not a Hash → defaults
+      expect(ids(klass, page: { number: ["1"] }).first).to eq(1)
+      expect(ids(klass, {}).first).to eq(1)
+      expect(klass.paginatable_page_param).to eq(%w[page number])
+      expect(klass.paginatable_per_page_param).to eq(%w[page size])
+    end
+
+    it "accepts an explicit nested path and validates the options" do
+      klass = Class.new(FakeController) do
+        include ConcernsOnRails::Controllers::Paginatable
+
+        paginate_by page_param: %i[paging page], per_page_param: %i[paging per]
+      end
+      expect(ids(klass, paging: { page: 2, per: 5 })).to eq((6..10).to_a)
+
+      build = lambda do |**opts|
+        Class.new(FakeController) do
+          include ConcernsOnRails::Controllers::Paginatable
+
+          paginate_by(**opts)
+        end
+      end
+      expect { build.call(style: :weird) }.to raise_error(ArgumentError, /style: must be :flat or :jsonapi/)
+      expect { build.call(page_param: []) }.to raise_error(ArgumentError, /page_param: must be a param name or a path/)
+      expect { build.call(per_page_param: 5) }.to raise_error(ArgumentError, /per_page_param: must be a param name or a path/)
+    end
+
+    it "builds the Link header with the configured names — nested ones encoded the Rack way" do
+      jsonapi = IntegrationHarness.build_controller do
+        include ConcernsOnRails::Controllers::Paginatable
+
+        paginate_by style: :jsonapi
+        define_method(:index) { render json: paginated(Widget.order(:id)).map(&:id) }
+      end
+      result = IntegrationHarness.dispatch(jsonapi, :index, query: "page[number]=2&page[size]=10&q=abc")
+      header = result.header("Link")
+      expect(header).to include(%(<http://example.org/?page%5Bnumber%5D=3&page%5Bsize%5D=10&q=abc>; rel="next"))
+      expect(header).to include(%(<http://example.org/?page%5Bnumber%5D=5&page%5Bsize%5D=10&q=abc>; rel="last"))
+      expect(header).to include(%(<http://example.org/?page%5Bnumber%5D=1&page%5Bsize%5D=10&q=abc>; rel="first"))
+      expect(result.header("X-Page")).to eq("2")
+
+      flat = IntegrationHarness.build_controller do
+        include ConcernsOnRails::Controllers::Paginatable
+
+        paginate_by page_param: :p, per_page_param: :limit
+        define_method(:index) { render json: paginated(Widget.order(:id)).map(&:id) }
+      end
+      result = IntegrationHarness.dispatch(flat, :index, query: "p=2&limit=10")
+      expect(result.header("Link")).to include(%(<http://example.org/?p=3&limit=10>; rel="next"))
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Stacked on #62 (→ #45 → #40; same file). `page` / `per_page` are hard-coded, so a JSON:API endpoint (`?page[number]=2&page[size]=10`) or an API that already uses `?p=&limit=` can't adopt Paginatable without rewriting params in a before_action — and the `Link` header would still point at `?page=3`.

- **`paginate_by page_param: :p, per_page_param: :limit`** — a top-level name, or an Array path into nested params (`%i[page number]`). **`style: :jsonapi`** sets `page[number]` / `page[size]` (JSON:API's page-based strategy); `:flat` is the default and explicit `*_param:` options win over the style. Anything else raises at declaration.
- **Readers dig the path** — `params[:page][:number]` — through `ScalarParam`, so a scalar where a Hash is expected, or an Array/Hash leaf, falls back to the default exactly like garbage in the flat form (no 500s).
- **Link header follows the configured name** — for a nested path the whole nested Hash is replaced with the page number set, so its other keys (`page[size]`) survive; Rack encodes it (`page%5Bnumber%5D=3`). `Support::LinkHeader.url_for` now accepts Hash override values (deep-stringified) to make that possible — a strictly additive change to #45's helper.
- Existing behaviour (`?page=&per_page=`, `X-*` headers, Link URLs) is byte-for-byte unchanged. `paginate_by` moved into `module ClassMethods` to satisfy RuboCop's scope rule for the new private helpers.

## Changelog entry

```
### Added
- **Paginatable**: `paginate_by page_param:` / `per_page_param:` (a name or a nested path) and
  `style: :jsonapi` (`?page[number]=&page[size]=`); the Link header URLs are rebuilt under the
  configured names (nested paths encoded by Rack, sibling keys preserved). `Support::LinkHeader.url_for`
  accepts Hash override values.
```

## Test plan

- [x] `spec/concerns/controllers/paginatable_spec.rb` — 4 new examples: custom flat names (and the default names ignored); `style: :jsonapi` nested reads with garbage tolerance + introspection; explicit nested path + three declaration errors; Link header through the real ActionController stack for nested (`first`/`next`/`last`, `page[size]` and `q` preserved, Rack-encoded) and for flat custom names.
- [x] Full suite on the stack: 1303 examples, 0 failures. RuboCop clean.
- [x] README "Paginatable" (rename/JSON:API block) and `docs/concerns/paginatable.md` (option rows, params note, Link wording, JSON:API example).

Merge order: #40 → #45 → #62 → this (GitHub retargets as each base merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
