### PR TITLE
ErrorHandleable: handled_error.concerns_on_rails instrumentation via on_handled_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1751,6 +1751,15 @@ handle_errors only: %i[not_found parameter_missing record_invalid] # just the or
 declarations keep precedence. Unknown keys raise `ArgumentError` listing the valid ones;
 `error_handleable_keys` returns the keys still active on a controller.
 
+**Reporting** — every handled error instruments `handled_error.concerns_on_rails` (`controller`, `action`, `code`, `status`, `message`, `exception`, `exception_class`) via the public `on_handled_error(key, error, status:, message:)` override point, so the 409s reach your error tracker while the 404s stay quiet:
+
+```ruby
+def on_handled_error(key, error, **)
+  Sentry.capture_exception(error) if %i[record_not_unique foreign_key_violation stale_object].include?(key)
+  super   # keep the event
+end
+```
+
 **Notes**
 - When `Respondable` is also included, the handlers delegate to `render_error` so the envelope shape stays in one place. Otherwise they render the same envelope inline.
 - Exceptions are registered by name (string), so a class your Rails version lacks is simply never matched.

--- a/docs/concerns/error-handleable.md
+++ b/docs/concerns/error-handleable.md
@@ -79,6 +79,8 @@ handle_errors only: %i[not_found parameter_missing record_invalid] # the pre-exp
 
 All handlers are **public**, which is intentional: subclasses can override any one without re-declaring `rescue_from`. Each renders through the private `render_handled_error(key, message:, errors:)`, which takes `code` and status from the table; an override that wants the standard envelope with different wording can call `render_error_envelope(message:, code:, status:, errors:)`.
 
+**`on_handled_error(key, error, status:, message:)`** — public override point, called by the render funnel before each handled error is rendered. The default instruments `handled_error.concerns_on_rails` with `controller` (the controller path), `action`, `code` (the HANDLERS key), `status`, `message` (as rendered), `exception` and `exception_class`. `error` is the rescued exception — captured by an override of `rescue_with_handler`, so it is `nil` when a handler is called directly. Override it to report selectively (`Sentry.capture_exception(error) if key == :record_not_unique`); call `super` to keep the event, and rescue inside the override if the reporter itself can fail — it runs before the response is rendered.
+
 The private helper `render_error_envelope` is not part of the public API and should not be called directly.
 
 ## Examples
@@ -163,6 +165,29 @@ The JSON shape rendered is identical to the `Respondable` path:
 { "success": false, "error": { "message": "...", "code": "..." } }
 ```
 The `details` key is only present when there is something to list (validation messages, unpermitted parameter names).
+
+**Reporting handled errors selectively**
+
+```ruby
+class Api::BaseController < ApplicationController
+  include ConcernsOnRails::Controllers::Respondable
+  include ConcernsOnRails::Controllers::ErrorHandleable
+
+  REPORTABLE = %i[record_not_unique foreign_key_violation stale_object parse_error].freeze
+
+  def on_handled_error(key, error, **)
+    Sentry.capture_exception(error, tags: { handled_code: key }) if error && REPORTABLE.include?(key)
+    super
+  rescue StandardError => e
+    Rails.logger.warn("[errors] reporter failed: #{e.message}")   # never let the reporter break the 4xx
+  end
+end
+
+# config/initializers/handled_errors.rb — or subscribe instead of overriding:
+ActiveSupport::Notifications.subscribe("handled_error.concerns_on_rails") do |event|
+  StatsD.increment("api.handled_error", tags: ["code:#{event.payload[:code]}", "status:#{event.payload[:status]}"])
+end
+```
 
 ## Notes & gotchas
 

--- a/lib/concerns_on_rails/controllers/error_handleable.rb
+++ b/lib/concerns_on_rails/controllers/error_handleable.rb
@@ -42,6 +42,11 @@ module ConcernsOnRails
     #
     # Each handler is a public instance method, so subclasses can override the
     # message wording or response shape without re-declaring the `rescue_from`.
+    #
+    # Every handled error instruments `handled_error.concerns_on_rails`
+    # (controller, action, code, status, message, exception) through the public
+    # `on_handled_error(key, error, status:, message:)` override point — the
+    # place to report the 409s to Sentry while letting the 404s pass quietly.
     module ErrorHandleable
       extend ActiveSupport::Concern
 
@@ -128,6 +133,31 @@ module ConcernsOnRails
         private :error_handleable_selection, :error_handleable_known_keys
       end
 
+      # Called before each handled error is rendered. Default: instrument
+      # `handled_error.concerns_on_rails` with the controller path, action, the
+      # envelope code (the HANDLERS key), status, rendered message, and the
+      # exception (nil when a handler is called directly rather than rescued).
+      # Override to report selectively — call super to keep the event, and
+      # rescue inside your override if the reporter itself can fail.
+      def on_handled_error(key, error, status:, message:)
+        ActiveSupport::Notifications.instrument(
+          "handled_error.concerns_on_rails",
+          controller: error_handleable_controller_name, action: error_handleable_action_name,
+          code: key, status: status, message: message, exception: error, exception_class: error&.class&.name
+        )
+      end
+
+      # Remember the exception being rescued so the render funnel can hand it to
+      # `on_handled_error` — the handlers themselves only pass a message along.
+      # Rescuable's `rescue_with_handler(exception, object:, visited_exceptions:)`
+      # is what ActionController's rescue path calls.
+      def rescue_with_handler(exception, **)
+        @error_handleable_exception = exception
+        super
+      ensure
+        @error_handleable_exception = nil
+      end
+
       def handle_record_not_found(_error)
         # Use a generic message: the raw RecordNotFound message leaks the model
         # class name and the queried attribute/value to API clients. Subclasses
@@ -208,7 +238,17 @@ module ConcernsOnRails
 
       # Renders the envelope for a HANDLERS key: code = key, status from the table.
       def render_handled_error(key, message:, errors: nil)
-        render_error_envelope(message: message, code: key.to_s, status: HANDLERS.fetch(key)[:status], errors: errors)
+        status = HANDLERS.fetch(key)[:status]
+        on_handled_error(key, @error_handleable_exception, status: status, message: message)
+        render_error_envelope(message: message, code: key.to_s, status: status, errors: errors)
+      end
+
+      def error_handleable_controller_name
+        respond_to?(:controller_path) ? controller_path : self.class.name
+      end
+
+      def error_handleable_action_name
+        respond_to?(:action_name) ? action_name.to_s : nil
       end
 
       # Kept for subclasses that call it from a handler override.

--- a/spec/concerns/controllers/error_handleable_spec.rb
+++ b/spec/concerns/controllers/error_handleable_spec.rb
@@ -384,4 +384,61 @@ describe ConcernsOnRails::Controllers::ErrorHandleable do
         .to raise_error(ArgumentError, /not both/)
     end
   end
+
+  describe "instrumentation (#on_handled_error)" do
+    def handled_events(&block)
+      events = []
+      callback = ->(*args) { events << ActiveSupport::Notifications::Event.new(*args) }
+      ActiveSupport::Notifications.subscribed(callback, "handled_error.concerns_on_rails", &block)
+      events
+    end
+
+    it "instruments every rescued error with code, status, message, exception and action" do
+      controller.define_singleton_method(:action_name) { "show" }
+      error = ActiveRecord::RecordNotFound.new("Couldn't find User with 'id'=99")
+      events = handled_events { controller.rescue_with_handler(error) }
+
+      expect(events.size).to eq(1)
+      payload = events.first.payload
+      expect(payload).to include(code: :not_found, status: :not_found, action: "show",
+                                 exception: error, exception_class: "ActiveRecord::RecordNotFound")
+      expect(payload[:message]).to eq(controller.rendered[:json][:error][:message])
+      expect(payload).to have_key(:controller)
+    end
+
+    it "is an override point — replace it to report only some codes; skipping super silences the event" do
+      klass = Class.new(controller_class) do
+        def self.reports = (@reports ||= [])
+
+        def on_handled_error(key, error, **)
+          self.class.reports << [key, error.class.name] if key == :record_not_unique
+        end
+      end
+      c = klass.new
+      events = handled_events do
+        c.rescue_with_handler(ActiveRecord::RecordNotUnique.new("dup"))
+        c.rescue_with_handler(ActiveRecord::RecordNotFound.new("gone"))
+      end
+      expect(klass.reports).to eq([[:record_not_unique, "ActiveRecord::RecordNotUnique"]])
+      expect(events).to be_empty
+      expect(c.rendered[:status]).to eq(:not_found) # rendering is untouched
+    end
+
+    it "instruments a handler called directly too, with a nil exception" do
+      events = handled_events { controller.handle_stale_object(ActiveRecord::StaleObjectError.new) }
+      expect(events.first.payload).to include(code: :stale_object, status: :conflict, exception: nil, exception_class: nil)
+    end
+
+    it "fires through the real ActionController stack with the controller path" do
+      klass = IntegrationHarness.build_controller do
+        include ConcernsOnRails::Controllers::ErrorHandleable
+
+        define_method(:index) { raise ActiveRecord::RecordNotUnique, "dup" }
+      end
+      events = handled_events { IntegrationHarness.dispatch(klass, :index) }
+      expect(events.size).to eq(1)
+      expect(events.first.payload).to include(code: :record_not_unique, status: :conflict, action: "index")
+      expect(events.first.payload[:controller]).to eq(klass.controller_path)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Stacked on #42 (same file). Once ErrorHandleable turns an exception into a tidy 4xx, the error tracker never sees it — which is right for a 404 and wrong for the `RecordNotUnique` race or a `ParseError` storm. Same observability shape as Authorizable (#68), Throttleable (#44) and Deprecatable:

- **`handled_error.concerns_on_rails`** — instrumented for every handled error with `controller` (path), `action`, `code` (the HANDLERS key), `status`, `message` (as rendered), `exception` and `exception_class`.
- **`on_handled_error(key, error, status:, message:)`** — public override point called by the render funnel before the response is rendered. Override to report selectively (`Sentry.capture_exception(error) if key == :record_not_unique`), call `super` to keep the event; the docs show rescuing inside the override so a failing reporter never breaks the 4xx.
- **Exception capture without touching 14 handlers** — the handlers only pass a message along, so the concern overrides `rescue_with_handler(exception, **)` (what ActionController's rescue path calls) to remember the exception for the funnel and clear it after. A handler invoked directly (tests, a subclass) instruments with `exception: nil`. `rescue_from` registration stays `with: <symbol>`, so #42's `handle_errors` matching on `[exception, handler]` is untouched.

## Changelog entry

```
### Added
- **ErrorHandleable**: every handled error instruments `handled_error.concerns_on_rails` (controller,
  action, code, status, message, exception) via the public `on_handled_error(key, error, status:,
  message:)` override point — report some codes to the error tracker, let the rest stay quiet.
```

## Test plan

- [x] `spec/concerns/controllers/error_handleable_spec.rb` — 4 new examples: payload for a rescued error (code/status/action/exception/exception_class, message matches the rendered one, controller key); selective override without `super` (reports one code, no event, rendering intact); direct handler call → `exception: nil`; through the real ActionController stack with the controller path.
- [x] Full suite on the stack: 1282 examples, 0 failures. RuboCop clean.
- [x] README "ErrorHandleable" (Reporting block) and `docs/concerns/error-handleable.md` (method section, reporting example with a safe override and a subscriber).

Merge order: #42 first, then this (GitHub retargets to master automatically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
