### PR TITLE
Paginatable: window: — first, last and N pages either side of the current page in pagination_meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1494,6 +1494,41 @@ paginate_by style: :jsonapi                                        # ?page[numbe
 paginate_by page_param: %i[paging page], per_page_param: %i[paging per]   # any nested path
 ```
 
+**Page window for a pagination bar**
+
+`window:` adds a `pages:` key to `pagination_meta` — the first page, the last page, and N pages
+either side of the current one, with `:gap` standing in for the runs left out. It is opt-in:
+without `window:` the key is absent entirely. No extra query either way — it is arithmetic over
+the total already counted.
+
+```ruby
+paginate_by per_page: 10, window: 3
+
+pagination_meta
+# => { total: 1000, page: 47, per_page: 10, total_pages: 100,
+#      pages: [1, :gap, 44, 45, 46, 47, 48, 49, 50, :gap, 100] }
+```
+
+Render it straight into a `1 … 44 45 46 [47] 48 49 50 … 100` bar:
+
+```erb
+<% pagination_meta[:pages].each do |page| %>
+  <%= page == :gap ? "…" : link_to(page, url_for(page: page)) %>
+<% end %>
+```
+
+| Situation | `pages:` |
+|-----------|----------|
+| `?page=47` of 100 | `[1, :gap, 44, 45, 46, 47, 48, 49, 50, :gap, 100]` |
+| `?page=2` of 100 | `[1, 2, 3, 4, 5, :gap, 100]` — no leading gap once the window reaches page 1 |
+| `?page=6` of 100 | `[1, 2, 3, 4, 5, 6, 7, 8, 9, :gap, 100]` — a one-page gap is filled, never `1 … 3` |
+| 5 pages total | `[1, 2, 3, 4, 5]` — the window spans everything |
+| empty collection | key absent |
+| `window: 0` | `[1, :gap, 47, :gap, 100]` — first, current and last only |
+
+`?page=` past the last page windows around the last page (as `rel="prev"` already does), and
+`window:` must be a non-negative Integer or `nil`/`false` — validated at declaration.
+
 **Response headers**: `X-Total-Count`, `X-Page`, `X-Per-Page`, `X-Total-Pages`, and an RFC 8288 `Link`
 header with `first` / `prev` / `next` / `last` URLs rebuilt from the current request (other query params
 preserved; `prev`/`next` only when such a page exists; nothing for an empty collection) — the GitHub

--- a/docs/concerns/paginatable.md
+++ b/docs/concerns/paginatable.md
@@ -38,6 +38,7 @@ end
 | `page_param` | Symbol/String or Array | `:page` | Where the page number is read from: a top-level param name, or an Array path into nested params (`%i[page number]` → `?page[number]=2`). Must be a name or a non-empty path of names. |
 | `per_page_param` | Symbol/String or Array | `:per_page` | Same for the page size (`%i[page size]` → `?page[size]=10`). |
 | `style` | `:flat` or `:jsonapi` | `:flat` | Shortcut: `:jsonapi` sets `page_param: %i[page number]` and `per_page_param: %i[page size]` (the JSON:API page-based strategy); `:flat` keeps `page` / `per_page`. Explicit `page_param:`/`per_page_param:` win over the style. |
+| `window` | Integer, `nil` or `false` | `nil` | Half-width of the page window published as `pagination_meta[:pages]` — first, last, and this many pages either side of the current page. `nil`/`false` omit the `pages:` key entirely; `0` is meaningful (first, current, last). A negative or non-Integer value raises `ArgumentError` at declaration. |
 
 **URL params read from `params`**
 
@@ -65,7 +66,23 @@ A `Hash` is rejected with an `ArgumentError` rather than silently paginated as `
 
 **`pagination_meta(collection = nil, total: nil) → Hash`**
 
-Returns `{ total:, page:, per_page:, total_pages: }` **without** applying `LIMIT`/`OFFSET` or slicing — handy for body-based pagination composed with `Respondable`'s `meta:`. Called with no argument after `paginated`, it reuses that call's memoized metadata (no second `COUNT`); pass a relation or collection to compute fresh. Accepts exactly the same inputs as `paginated`; with `total:` the `COUNT` is skipped and the collection may be omitted entirely (`pagination_meta(total: result.total_hits)`).
+Returns `{ total:, page:, per_page:, total_pages: }` (plus `pages:` when `window:` is declared) **without** applying `LIMIT`/`OFFSET` or slicing — handy for body-based pagination composed with `Respondable`'s `meta:`. Called with no argument after `paginated`, it reuses that call's memoized metadata (no second `COUNT`); pass a relation or collection to compute fresh. Accepts exactly the same inputs as `paginated`; with `total:` the `COUNT` is skipped and the collection may be omitted entirely (`pagination_meta(total: result.total_hits)`).
+
+**`pagination_meta[:pages]` — the page window**
+
+Declaring `window: N` adds a `pages:` key: an Array of page numbers with the Symbol `:gap` standing in for each run of pages left out. It is built from the `total` already counted, so it costs no extra query, and it is absent (not `nil`) unless `window:` is declared — `meta.key?(:pages)` is a clean opt-in probe.
+
+The rules, for `window: 3` over 100 pages:
+
+| Current page | `pages:` | Why |
+|---|---|---|
+| `47` | `[1, :gap, 44, 45, 46, 47, 48, 49, 50, :gap, 100]` | first, ±3, last |
+| `2` | `[1, 2, 3, 4, 5, :gap, 100]` | the window already reaches page 1, so no leading gap |
+| `6` | `[1, 2, 3, 4, 5, 6, 7, 8, 9, :gap, 100]` | the gap would hide only page 2 — a `:gap` marker is no narrower than the number it replaces, so the page is emitted instead |
+| `99` | `[1, :gap, 96, 97, 98, 99, 100]` | mirror of `page: 2` |
+| `999` | `[1, :gap, 97, 98, 99, 100]` | a page past the end windows around the last page, matching what `rel="prev"` already does |
+
+With fewer pages than the window spans, every page is listed and no gap appears (`[1, 2, 3, 4, 5]` for 5 pages; `[1]` for one). An empty collection has `total_pages == 0` and gets no `pages:` key at all.
 
 The four `X-*` headers set on `response`:
 
@@ -171,6 +188,8 @@ end
 - **`Link` header is on by default.** Every non-empty paginated response carries `first`/`prev`/`next`/`last` links built from `request.base_url + request.path` and the current query string — behind a proxy, make sure `X-Forwarded-Host`/`-Proto` reach Rails (`config.action_dispatch.trusted_proxies`) or the links will name the internal host. `paginate_by link_header: false` disables it; the `X-*` headers are unaffected.
 - **`Link` is appended, not set.** If Deprecatable (or a CDN hint) already put a `Link` header on the response, the pagination links are appended after it with a comma.
 - **No database columns required.** This is a pure controller concern with no model-layer dependency.
+- **`pages:` is body-only, by design.** The page window is published through `pagination_meta`, never as headers — the current page is already `X-Page`, and a dozen `rel="page"` entries would bloat the `Link` header without telling a client anything it cannot compute from `X-Total-Pages`. Render it in the response body (or a view) instead.
+- **`:gap` is a Symbol, so JSON turns it into a string.** `pages: [1, :gap, 47]` serializes as `[1, "gap", 47]`. Compare against `"gap"` on the client, or map the Symbol to whatever your serializer wants (`nil`, `"…"`) before rendering.
 - **In-memory collections are sliced in Ruby.** The whole collection is already in memory by definition, so `paginated(array)` costs one `to_a` plus an `Array#[]` — there is no lazy path. If the data lives in a table, pass the relation so the database does the work.
 - **Relation detection is duck-typed.** Anything answering `limit` and `offset` takes the SQL path; that includes association proxies and model classes, and keeps a `has_many` collection paginating in the database rather than loading it.
 - **Headers require a live `response` object.** The `set_pagination_headers` method guards with `respond_to?(:response) && response`. In plain unit tests without a real HTTP response object, headers are silently skipped; the return value (the paginated relation) is still correct.

--- a/lib/concerns_on_rails/controllers/paginatable.rb
+++ b/lib/concerns_on_rails/controllers/paginatable.rb
@@ -41,6 +41,9 @@ module ConcernsOnRails
         class_attribute :paginatable_per_page, default: DEFAULT_PER_PAGE
         class_attribute :paginatable_max_per_page, default: DEFAULT_MAX_PER_PAGE
         class_attribute :paginatable_link_header, default: true
+        # Half-width of the page window in `pagination_meta[:pages]`; nil = no
+        # window, and no `pages:` key at all.
+        class_attribute :paginatable_window, default: nil
         # Where page / per_page are read from — a path of param names (`["page"]`,
         # or `["page", "number"]` for JSON:API's page[number]).
         class_attribute :paginatable_page_param, default: %w[page].freeze
@@ -55,10 +58,11 @@ module ConcernsOnRails
         # Example:
         #   paginate_by per_page: 50, max_per_page: 500, link_header: false
         def paginate_by(per_page: DEFAULT_PER_PAGE, max_per_page: DEFAULT_MAX_PER_PAGE, link_header: true,
-                        page_param: nil, per_page_param: nil, style: :flat)
+                        page_param: nil, per_page_param: nil, style: :flat, window: nil)
           self.paginatable_per_page = per_page.to_i
           self.paginatable_max_per_page = max_per_page.to_i
           self.paginatable_link_header = link_header ? true : false
+          self.paginatable_window = paginatable_window!(window)
           defaults = paginatable_style_params!(style)
           self.paginatable_page_param = paginatable_param_path!(:page_param, page_param || defaults[0])
           self.paginatable_per_page_param = paginatable_param_path!(:per_page_param, per_page_param || defaults[1])
@@ -73,6 +77,15 @@ module ConcernsOnRails
           when :jsonapi then [%w[page number], %w[page size]]
           else raise ArgumentError, "#{LABEL}: style: must be :flat or :jsonapi (got #{style.inspect})"
           end
+        end
+
+        # nil / false disable the window (no `pages:` key). `0` is meaningful:
+        # first, current and last only.
+        def paginatable_window!(value)
+          return nil if value.nil? || value == false
+          return value if value.is_a?(Integer) && !value.negative?
+
+          raise ArgumentError, "#{LABEL}: window: must be a non-negative Integer or nil (got #{value.inspect})"
         end
 
         # A name or a non-empty path of names, normalized to Strings.
@@ -117,8 +130,9 @@ module ConcernsOnRails
             source.limit(per_page).offset(offset)
           end
 
-        @paginatable_meta = { total: total, page: page, per_page: per_page, total_pages: total_pages }
-        set_pagination_headers(**@paginatable_meta)
+        @paginatable_meta =
+          paginatable_windowed(total: total, page: page, per_page: per_page, total_pages: total_pages)
+        set_pagination_headers(total: total, page: page, per_page: per_page, total_pages: total_pages)
         set_pagination_links(page: page, total_pages: total_pages)
         records
       end
@@ -134,12 +148,12 @@ module ConcernsOnRails
 
         total = paginatable_meta_total(collection, total)
         per_page = pagination_per_page
-        {
+        paginatable_windowed(
           total: total,
           page: pagination_page,
           per_page: per_page,
           total_pages: per_page.positive? ? (total.to_f / per_page).ceil : 0
-        }
+        )
       end
 
       private
@@ -226,6 +240,39 @@ module ConcernsOnRails
         path[1...-1].each { |key| node = (node[key] = node[key].is_a?(Hash) ? node[key] : {}) }
         node[path.last] = number
         { path.first.to_sym => nested }
+      end
+
+      # Adds `pages:` to a meta Hash when `window:` is declared, and leaves the
+      # Hash untouched otherwise — the key is absent, never nil, so
+      # `meta.key?(:pages)` is a clean opt-in probe.
+      def paginatable_windowed(meta)
+        pages = paginatable_page_window(meta[:page], meta[:total_pages])
+        pages ? meta.merge(pages: pages) : meta
+      end
+
+      # First, last, and `window` pages either side of the current page, with
+      # :gap standing in for the runs left out — [1, :gap, 46, 47, 48, :gap, 100].
+      # Pure arithmetic over the total already counted: no extra query. A page
+      # past the last one windows around the last page, as `prev` already does.
+      def paginatable_page_window(page, total_pages)
+        window = self.class.paginatable_window
+        return nil if window.nil? || total_pages < 1
+
+        current = page.clamp(1, total_pages)
+        from = [current - window, 1].max
+        to = [current + window, total_pages].min
+        paginatable_insert_gaps(([1, total_pages] + (from..to).to_a).uniq.sort)
+      end
+
+      # A jump of exactly two pages is filled with the page it would have
+      # hidden — "1 2 3", never the wider "1 … 3"; anything longer collapses
+      # into one :gap.
+      def paginatable_insert_gaps(numbers)
+        numbers.each_cons(2).with_object([numbers.first]) do |(previous, current), result|
+          result << (previous + 1) if current - previous == 2
+          result << :gap if current - previous > 2
+          result << current
+        end
       end
 
       def set_pagination_headers(total:, page:, per_page:, total_pages:)

--- a/spec/concerns/controllers/paginatable_spec.rb
+++ b/spec/concerns/controllers/paginatable_spec.rb
@@ -450,4 +450,84 @@ describe ConcernsOnRails::Controllers::Paginatable do
       expect(result.header("Link")).to include(%(<http://example.org/?p=3&limit=10>; rel="next"))
     end
   end
+
+  describe "window:" do
+    # `total:` drives total_pages without materializing thousands of rows:
+    # total 1000 / per_page 10 => 100 pages.
+    def meta(window:, page:, total:, per_page: 10)
+      klass = Class.new(FakeController) do
+        include ConcernsOnRails::Controllers::Paginatable
+      end
+      klass.paginate_by(window: window)
+      klass.new(params: { page: page, per_page: per_page }).pagination_meta(total: total)
+    end
+
+    it "returns first, last and a window of pages either side of the current page" do
+      expect(meta(window: 3, page: 47, total: 1000)[:pages])
+        .to eq([1, :gap, 44, 45, 46, 47, 48, 49, 50, :gap, 100])
+    end
+
+    it "omits the leading gap when the window reaches the first page" do
+      expect(meta(window: 3, page: 2, total: 1000)[:pages]).to eq([1, 2, 3, 4, 5, :gap, 100])
+    end
+
+    it "fills a one-page gap rather than hiding a single page behind an ellipsis" do
+      expect(meta(window: 3, page: 6, total: 1000)[:pages]).to eq([1, 2, 3, 4, 5, 6, 7, 8, 9, :gap, 100])
+    end
+
+    it "omits the trailing gap when the window reaches the last page" do
+      expect(meta(window: 3, page: 99, total: 1000)[:pages]).to eq([1, :gap, 96, 97, 98, 99, 100])
+    end
+
+    it "lists every page when the window spans the whole collection" do
+      expect(meta(window: 3, page: 3, total: 50)[:pages]).to eq([1, 2, 3, 4, 5])
+      expect(meta(window: 3, page: 1, total: 4)[:pages]).to eq([1])
+    end
+
+    it "clamps a page past the last page into the window" do
+      expect(meta(window: 2, page: 999, total: 1000)[:pages]).to eq([1, :gap, 98, 99, 100])
+    end
+
+    it "keeps only first, current and last with window: 0" do
+      expect(meta(window: 0, page: 47, total: 1000)[:pages]).to eq([1, :gap, 47, :gap, 100])
+    end
+
+    it "omits pages: entirely for an empty collection" do
+      expect(meta(window: 3, page: 1, total: 0)).not_to have_key(:pages)
+    end
+
+    it "omits pages: entirely when window: is not declared" do
+      controller = controller_class.new(params: { page: 2, per_page: 10 })
+      controller.paginated(Widget.order(:id))
+      expect(controller.pagination_meta).not_to have_key(:pages)
+      expect(controller.pagination_meta(total: 1000)).not_to have_key(:pages)
+    end
+
+    it "includes pages: in the meta memoized by paginated" do
+      klass = Class.new(FakeController) do
+        include ConcernsOnRails::Controllers::Paginatable
+      end
+      klass.paginate_by(window: 0, per_page: 5)
+      controller = klass.new(params: { page: 5 })
+      controller.paginated(Widget.order(:id)) # 50 widgets / 5 => 10 pages
+      expect(controller.pagination_meta[:pages]).to eq([1, :gap, 5, :gap, 10])
+      expect(controller.response.headers["X-Total-Pages"]).to eq("10")
+    end
+
+    it "validates window: at declaration" do
+      build = lambda do |window|
+        Class.new(FakeController) do
+          include ConcernsOnRails::Controllers::Paginatable
+
+          paginate_by(window: window)
+        end
+      end
+      expect { build.call(-1) }.to raise_error(ArgumentError, /window: must be a non-negative Integer/)
+      expect { build.call("3") }.to raise_error(ArgumentError, /window: must be a non-negative Integer/)
+      expect { build.call(2.5) }.to raise_error(ArgumentError, /window: must be a non-negative Integer/)
+      expect(build.call(nil).paginatable_window).to be_nil
+      expect(build.call(false).paginatable_window).to be_nil
+      expect(build.call(0).paginatable_window).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Off `master` (post-1.28.0), not stacked. `pagination_meta` returns four scalars and the `Link` header carries `first`/`prev`/`next`/`last`, so a client gets page 1, page N and the current page's immediate neighbours — but nothing that can render the ordinary pagination bar `1 … 44 45 46 [47] 48 49 50 … 100`. Computing it client-side means reimplementing the window (and its edge cases) in every consumer.

- **`paginate_by window: 3`** adds a `pages:` key to `pagination_meta`: the first page, the last page, and N pages either side of the current one, with the Symbol `:gap` standing in for each run left out — `[1, :gap, 44, 45, 46, 47, 48, 49, 50, :gap, 100]`. Renders straight into a bar with no client-side arithmetic.
- **Opt-in, so nothing changes shape on upgrade.** Without `window:` the key is absent entirely (not `nil`), so no existing consumer's meta Hash or serialized response body grows a key, and `meta.key?(:pages)` is a clean probe. `window:` is validated at declaration — a non-negative Integer, or `nil`/`false` to disable; `0` is meaningful (first, current and last only).
- **No extra query on either path.** The window is pure arithmetic over the `total` already counted, merged into both the meta `paginated` memoizes and the fresh `pagination_meta` one, so the single-COUNT-per-request guarantee from 1.22 holds.
- **A jump of exactly two pages is filled with the page it would have hidden** — `1 2 3`, never the wider `1 … 3` — since a gap marker is no narrower than the single number it replaces. A `?page=` past the last page windows around the last page, matching what `rel="prev"` already does.
- **`pages:` is body-only by design.** `set_pagination_headers` no longer splats the meta Hash (that splat raised `unknown keyword: :pages` once the Hash grew a key — caught by the new spec): the current page is already `X-Page`, and a dozen `rel="page"` entries would bloat the `Link` header with nothing a client cannot compute from `X-Total-Pages`. Headers and Link rels are byte-for-byte unchanged.

Deliberately not done: nothing added to CursorPaginatable, which has no page numbers by design.

## Changelog entry

```
### Added
- **Paginatable**: `paginate_by window: 3` publishes a page window as `pagination_meta[:pages]` —
  first, last and N pages either side of the current page, with `:gap` for the runs left out
  (`[1, :gap, 46, 47, 48, :gap, 100]`) — enough to render a pagination bar from the meta Hash.
  Opt-in (the key is absent without `window:`), computed from the total already counted (no extra
  query), one-page gaps filled rather than elided, and a page past the end windows around the last
  page. Headers and Link rels unchanged.
```

## Test plan

- [x] `spec/concerns/controllers/paginatable_spec.rb` — 10 new examples: the `?page=47` window; leading- and trailing-gap suppression at the edges; the one-page gap fill; a window spanning the whole collection (and a single page); a `?page=` past the end clamped into the window; `window: 0`; the empty collection and the undeclared-`window:` case both omitting the key; `pages:` present in the meta memoized by `paginated`; and six declaration-time validation cases.
- [x] Full suite: **1314 examples, 0 failures**, 98.37% line coverage. `rubocop lib spec` clean (124 files, no offenses).
- [x] Every table row written into README and `docs/concerns/paginatable.md` was executed against the implementation rather than reasoned about — all 8 rows plus both new gotchas (`:gap` serializing as `"gap"`, empty collection omitting the key).
- [x] README "Paginatable" (new page-window subsection with the ERB snippet and the behaviour table) and `docs/concerns/paginatable.md` (`window` option row, `pagination_meta` return shape, a rules table, two gotchas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
