### PR TITLE
Aliasable spec: accept the Rails 8.1 join-alias SQL (unblocks the Rails 8.1 bumps)

### DIFF
--- a/spec/concerns/models/aliasable_spec.rb
+++ b/spec/concerns/models/aliasable_spec.rb
@@ -266,8 +266,10 @@ describe ConcernsOnRails::Aliasable do
   describe "query side" do
     it "joins(:alias) joins the source table, aliased when the where-hash references the alias" do
       expect(Author.joins(:works).to_sql).to include('INNER JOIN "books"')
+      # Rails <= 8.0 renders the table alias as `"books" "works"`; Rails 8.1
+      # renders it as `"books" AS "works"`. Both are the same join.
       expect(Author.joins(:works).where(works: { title: "X" }).to_sql)
-        .to include('INNER JOIN "books" "works"')
+        .to match(/INNER JOIN "books" (?:AS )?"works"/)
     end
 
     it "joins(:alias).where(alias: {...}) finds matching rows" do


### PR DESCRIPTION
## Why

The suite is red on Rails 8.1 because of a single literal SQL assertion.

Rails 8.1 renders a table alias as `INNER JOIN "books" AS "works"`. Rails 8.0 and
earlier rendered it as `INNER JOIN "books" "works"`. Same join, different spelling.
One Aliasable example asserted the older spelling with `include`, so it fails on 8.1
while the concern itself is perfectly fine.

## What

Match both spellings with a regex.

## Verification

| Rails | Result |
| --- | --- |
| 7.1.6 (lockfile) | 1360 examples, 0 failures |
| 8.1.3.1 | 1360 examples, 0 failures |

RuboCop clean on both.

## Impact

This is the **only** failure on Rails 8.1, so it unblocks the two dependabot PRs that
bump the Rails component gems to 8.1.3.1: #39 (activerecord) and #37 (actionpack).
Both are red today solely because of this example. Merge this first, then rerun them.

## Changelog entry

### Fixed

- **Aliasable (specs)** — the join-alias SQL assertion now accepts both the
  Rails 8.1 `AS`-qualified table alias and the older unqualified form, so the suite
  passes on Rails 8.1. No library change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)