### PR TITLE
WebhookVerifiable: fail closed instead of accepting unverified payloads

### DIFF
--- a/lib/concerns_on_rails/controllers/webhook_verifiable.rb
+++ b/lib/concerns_on_rails/controllers/webhook_verifiable.rb
@@ -178,19 +178,51 @@ module ConcernsOnRails
       # Single funnel for all failure outcomes (override point). Uses
       # Respondable's render_error when available, otherwise the same inline
       # envelope as Throttleable / Idempotentable.
+      #
+      # Fails CLOSED, matching Authorizable#authorization_denied: when there is
+      # nothing to render the rejection into, raise. Returning nil here (the
+      # pre-1.29 behavior) left the before_action chain unhalted, so the action
+      # ran on an unverified — possibly forged — payload.
       def webhook_verification_failed(message:, status:, code:)
-        return unless respond_to?(:response) && response
+        unless webhook_can_render?
+          raise "ConcernsOnRails::Controllers::WebhookVerifiable: rejection for " \
+                "'#{webhook_action_name || '(unknown action)'}' could not be rendered " \
+                "(no response object) — refusing to fail open"
+        end
 
         ConcernsOnRails::Support::ErrorEnvelope.render(self, message: message, status: status, code: code)
       end
 
       private
 
-      def webhook_rule_for_action
-        action = respond_to?(:action_name) ? action_name.to_s : nil
-        return nil unless action
+      # Mirrors the render path in Support::ErrorEnvelope: a render_error
+      # override is enough on its own, so a controller that supplies one but no
+      # response object still rejects properly instead of raising.
+      def webhook_can_render?
+        respond_to?(:render_error, true) || (respond_to?(:response) && response)
+      end
 
-        self.class.webhook_rules.find { |rule| rule[:actions].empty? || rule[:actions].include?(action) }
+      # nil when the action cannot be determined. `action_name` can also be ""
+      # (truthy), which a bare `unless action` guard would let through.
+      def webhook_action_name
+        return nil unless respond_to?(:action_name)
+
+        name = action_name.to_s
+        name.empty? ? nil : name
+      end
+
+      def webhook_rule_for_action
+        rules = self.class.webhook_rules
+        return nil if rules.empty?
+
+        action = webhook_action_name
+        # Fail closed: rules ARE declared but we cannot tell which action this
+        # is, so "no rule applies" is not a conclusion we may draw. Previously
+        # an unresolvable action_name skipped verification entirely and every
+        # webhook was accepted without a signature check.
+        return rules.find { |rule| rule[:actions].empty? } || rules.first if action.nil?
+
+        rules.find { |rule| rule[:actions].empty? || rule[:actions].include?(action) }
       end
 
       def webhook_render_outcome(rule, outcome)

--- a/spec/concerns/controllers/webhook_verifiable_spec.rb
+++ b/spec/concerns/controllers/webhook_verifiable_spec.rb
@@ -518,4 +518,74 @@ describe ConcernsOnRails::Controllers::WebhookVerifiable do
         .to raise_error(ArgumentError, /pins SHA256/)
     end
   end
+
+  describe "#webhook_verification_failed" do
+    # The Authorizable precedent (1.22): a gate that cannot render its own
+    # rejection must raise, never return nil — returning let the action run on
+    # an unverified payload. See authorizable_spec.rb "fails CLOSED".
+    it "fails CLOSED when there is no response object" do
+      klass = verifiable_class { verify_webhook :receive, secret: WH_SECRET, scheme: :github }
+      c = instance(klass, headers: { "X-Hub-Signature-256" => github_sig("wrong", WH_BODY) })
+      c.response = nil
+
+      expect { c.verify_webhook_signature! }.to raise_error(/refusing to fail open/)
+      expect(c.webhook_verified?).to be false
+    end
+
+    it "fails CLOSED when the signature header is missing and there is no response object" do
+      klass = verifiable_class { verify_webhook :receive, secret: WH_SECRET, scheme: :github }
+      c = instance(klass)
+      c.response = nil
+
+      expect { c.verify_webhook_signature! }.to raise_error(/refusing to fail open/)
+    end
+
+    it "still renders when there is no response but a render_error override exists" do
+      klass = verifiable_class do
+        verify_webhook :receive, secret: WH_SECRET, scheme: :github
+
+        def render_error(message:, status:, code: nil, **)
+          @rendered = { message: message, status: status, code: code }
+        end
+      end
+      c = instance(klass, headers: { "X-Hub-Signature-256" => github_sig("wrong", WH_BODY) })
+      c.response = nil
+
+      expect { c.verify_webhook_signature! }.not_to raise_error
+      expect(c.instance_variable_get(:@rendered)).to include(code: "webhook_signature_invalid")
+    end
+  end
+
+  describe "an unresolvable action name" do
+    it "does not skip verification when rules are declared" do
+      klass = verifiable_class { verify_webhook :receive, secret: WH_SECRET, scheme: :github }
+      c = klass.new(params: {})
+      req = WebhookFakeRequest.new({}, WH_BODY)
+      c.define_singleton_method(:request) { req }
+      # No action_name at all — previously webhook_rule_for_action returned nil
+      # and every webhook was accepted without a signature check.
+      c.verify_webhook_signature!
+
+      expect(c.webhook_verified?).to be false
+      expect_failure(c, :unauthorized, "webhook_signature_missing")
+    end
+
+    it "does not skip verification when action_name is blank" do
+      klass = verifiable_class { verify_webhook :receive, secret: WH_SECRET, scheme: :github }
+      c = instance(klass, action: "")
+
+      c.verify_webhook_signature!
+
+      expect(c.webhook_verified?).to be false
+      expect_failure(c, :unauthorized, "webhook_signature_missing")
+    end
+
+    it "still verifies normally when the action IS resolvable and uncovered" do
+      klass = verifiable_class { verify_webhook :receive, secret: WH_SECRET, scheme: :github }
+      c = instance(klass, action: "index")
+
+      expect(c.verify_webhook_signature!).to be_nil
+      expect(c.rendered).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Two ways a forged webhook could reach the action:

1. `webhook_verification_failed` did `return unless respond_to?(:response)
   && response`. With nothing to render into, the before_action returned
   nil, the chain was never halted, and the action ran on an unverified
   payload — `webhook_verified?` stayed false but nothing consulted it.

   This is the defect Authorizable#authorization_denied already fixed in
   1.22 ("returning nil here (the pre-1.22 behavior) let the action run
   unauthorized … refusing to fail open"); it was never carried across to
   the concern guarding inbound webhooks. Now it raises the same way.

   The guard also checked the wrong capability: the render path needs
   `render_error` OR a response, so a controller supplying only a
   render_error override now renders its rejection instead of raising
   (matching Deprecatable's spelling of the same check).

2. `webhook_rule_for_action` returned nil when `action_name` was
   unresolvable, and verification returned immediately — no header read,
   no 401. Rules being declared means "no rule applies" is not a
   conclusion we may draw, so an unresolvable action now falls back to the
   catch-all rule (or the first declared one) and verifies. `action_name`
   can also be "", which is truthy and slipped past the old guard.

A resolvable action that simply is not covered by any rule still passes
through untouched.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)