### PR TITLE
Aliasable: stop double-counting an aliased belongs_to counter_cache

### DIFF
--- a/lib/concerns_on_rails/models/aliasable.rb
+++ b/lib/concerns_on_rails/models/aliasable.rb
@@ -274,6 +274,15 @@ module ConcernsOnRails
         #     polymorphic).
         def aliasable_copy_options(src)
           opts = src.options.dup
+          # The SOURCE reflection already owns the counter. Carrying the option
+          # onto the copy makes ActiveRecord::CounterCache count it twice: it
+          # iterates _reflections and calls association(name) for each
+          # counter-cached one, and the #association override below maps the
+          # alias back to the SAME association object, so increment_counters
+          # fires once per name with no dedup guard. The parent's count came
+          # out doubled on create and doubled on destroy — drifting
+          # permanently negative once rows predating the alias were removed.
+          opts.delete(:counter_cache)
           if opts[:through]
             opts[:source] ||= aliasable_through_source_name(src)
           else

--- a/spec/concerns/models/aliasable_spec.rb
+++ b/spec/concerns/models/aliasable_spec.rb
@@ -785,4 +785,58 @@ describe ConcernsOnRails::Aliasable do
       end.to raise_error(ArgumentError, /'penman_id' is already a column/)
     end
   end
+
+  describe "counter_cache: on an aliased belongs_to" do
+    before do
+      ActiveRecord::Schema.define do
+        add_column :authors, :books_count, :integer, default: 0
+      end
+      # Author was defined (and its columns cached) by the outer before(:each).
+      Author.reset_column_information
+
+      class TrackedBook < TestModel
+        include ConcernsOnRails::Aliasable
+
+        self.table_name = "books"
+
+        belongs_to :author, counter_cache: :books_count
+        alias_association :writer, :author
+      end
+    end
+
+    # The renamed reflection copy used to keep :counter_cache, and because
+    # #association maps both names to the SAME BelongsToAssociation,
+    # each_counter_cached_associations incremented the parent twice per row.
+    it "increments the parent counter exactly once per create" do
+      author = Author.create!(name: "A")
+
+      TrackedBook.create!(title: "one", author: author)
+
+      expect(author.reload.books_count).to eq(1)
+    end
+
+    it "decrements exactly once per destroy" do
+      author = Author.create!(name: "A")
+      book = TrackedBook.create!(title: "one", author: author)
+
+      book.destroy
+
+      expect(author.reload.books_count).to eq(0)
+    end
+
+    it "keeps the counter correct across several rows" do
+      author = Author.create!(name: "A")
+      3.times { |i| TrackedBook.create!(title: "b#{i}", author: author) }
+
+      expect(author.reload.books_count).to eq(3)
+    end
+
+    it "still reads and writes through the alias" do
+      author = Author.create!(name: "A")
+      book = TrackedBook.create!(title: "one", writer: author)
+
+      expect(book.writer).to eq(author)
+      expect(author.reload.books_count).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
`alias_association :writer, :author` over `belongs_to :author,
counter_cache: :books_count` incremented the parent twice per row:

    author = Author.create!
    TrackedBook.create!(author: author)
    author.reload.books_count    # => 2, want 1

`aliasable_copy_options` copied the source reflection's options verbatim,
so `:counter_cache` survived onto the renamed copy. ActiveRecord::
CounterCache iterates `_reflections` and calls `association(name)` for
every counter-cached one, and the `#association` override maps the alias
back to the SAME BelongsToAssociation — so `increment_counters` fired
once per name, with no dedup guard.

Destroy doubled too, which hid the bug in aggregate (+2/-2 nets to zero),
but any row created before the alias was declared decrements by 2 and
takes the counter permanently negative.

The source reflection already owns the counter, so the copy simply drops
the option. Reads and writes through the alias are unaffected.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)