### PR TITLE
Paginatable: bound the requested page and validate the configured page size

### DIFF
--- a/lib/concerns_on_rails/controllers/paginatable.rb
+++ b/lib/concerns_on_rails/controllers/paginatable.rb
@@ -36,6 +36,15 @@ module ConcernsOnRails
       LABEL = "ConcernsOnRails::Controllers::Paginatable".freeze
       DEFAULT_PER_PAGE = 25
       DEFAULT_MAX_PER_PAGE = 200
+      # Upper bound on the requested page. `page` is untrusted input and its
+      # only job is to become `(page - 1) * per_page`, so an unbounded value
+      # produced an offset no backend can take: the relation branch raised
+      # StatementInvalid and Array#[] raised RangeError ("bignum too big to
+      # convert into `long'") — a 500 from `?page=99999999999999999999`.
+      # Clamping keeps the request in range; the page is far past any real
+      # dataset, so it simply comes back empty. Deep pagination at this depth
+      # wants Controllers::CursorPaginatable instead.
+      MAX_PAGE = 1_000_000
 
       included do
         class_attribute :paginatable_per_page, default: DEFAULT_PER_PAGE
@@ -59,8 +68,8 @@ module ConcernsOnRails
         #   paginate_by per_page: 50, max_per_page: 500, link_header: false
         def paginate_by(per_page: DEFAULT_PER_PAGE, max_per_page: DEFAULT_MAX_PER_PAGE, link_header: true,
                         page_param: nil, per_page_param: nil, style: :flat, window: nil)
-          self.paginatable_per_page = per_page.to_i
-          self.paginatable_max_per_page = max_per_page.to_i
+          self.paginatable_per_page = paginatable_page_size!(:per_page, per_page, minimum: 1)
+          self.paginatable_max_per_page = paginatable_page_size!(:max_per_page, max_per_page, minimum: 0)
           self.paginatable_link_header = link_header ? true : false
           self.paginatable_window = paginatable_window!(window)
           defaults = paginatable_style_params!(style)
@@ -77,6 +86,19 @@ module ConcernsOnRails
           when :jsonapi then [%w[page number], %w[page size]]
           else raise ArgumentError, "#{LABEL}: style: must be :flat or :jsonapi (got #{style.inspect})"
           end
+        end
+
+        # per_page must be positive; max_per_page may be 0, which the docs
+        # define as "no cap". A bare `.to_i` let a negative through, and
+        # `LIMIT -1` means NO LIMIT on SQLite and MySQL — so `per_page: -1`
+        # silently serialized the entire table on every request, while
+        # `per_page: 0` made every page permanently empty.
+        def paginatable_page_size!(option, value, minimum:)
+          size = value.to_i
+          return size if size >= minimum
+
+          wording = minimum.positive? ? "a positive integer" : "a non-negative integer"
+          raise ArgumentError, "#{LABEL}: #{option}: must be #{wording} (got #{value.inspect})"
         end
 
         # nil / false disable the window (no `pages:` key). `0` is meaningful:
@@ -206,7 +228,8 @@ module ConcernsOnRails
       # Both readers route through ScalarParam: `?page[]=1` / `?page[x]=1`
       # arrive as Array/Parameters, and calling .to_i on those was a 500.
       def pagination_page
-        [ConcernsOnRails::Support::ScalarParam.to_i(pagination_param(self.class.paginatable_page_param), default: 0), 1].max
+        requested = ConcernsOnRails::Support::ScalarParam.to_i(pagination_param(self.class.paginatable_page_param), default: 0)
+        requested.clamp(1, MAX_PAGE)
       end
 
       def pagination_per_page

--- a/spec/concerns/controllers/paginatable_spec.rb
+++ b/spec/concerns/controllers/paginatable_spec.rb
@@ -530,4 +530,80 @@ describe ConcernsOnRails::Controllers::Paginatable do
       expect(build.call(0).paginatable_window).to eq(0)
     end
   end
+
+  describe "an out-of-range page (untrusted input)" do
+    # `?page=99999999999999999999` produced offset 2499999999999999999950,
+    # which raised StatementInvalid on a relation and RangeError ("bignum too
+    # big to convert into `long'") on an Array — an unauthenticated 500 on
+    # every index action. per_page was capped; page was not.
+    let(:huge) { "99999999999999999999" }
+
+    it "does not blow up on a relation" do
+      controller = controller_class.new(params: { page: huge })
+
+      expect { controller.paginated(Widget.all).to_a }.not_to raise_error
+    end
+
+    it "does not blow up on an in-memory collection" do
+      controller = controller_class.new(params: { page: huge })
+
+      expect { controller.paginated((1..50).to_a) }.not_to raise_error
+    end
+
+    it "clamps to the maximum page and reports it in the meta and headers" do
+      controller = controller_class.new(params: { page: huge })
+      controller.paginated(Widget.all).to_a
+
+      max = ConcernsOnRails::Controllers::Paginatable::MAX_PAGE
+      expect(controller.pagination_meta[:page]).to eq(max)
+      expect(controller.response.headers["X-Page"]).to eq(max.to_s)
+    end
+
+    it "returns an empty page past the end rather than wrapping to page 1" do
+      controller = controller_class.new(params: { page: huge })
+
+      expect(controller.paginated(Widget.all).to_a).to be_empty
+    end
+
+    it "leaves ordinary pages untouched" do
+      controller = controller_class.new(params: { page: 2 })
+
+      expect(controller.paginated(Widget.all).to_a.size).to eq(25)
+      expect(controller.pagination_meta[:page]).to eq(2)
+    end
+  end
+
+  describe "paginate_by validation" do
+    def declare(**opts)
+      expect do
+        Class.new(FakeController) do
+          include ConcernsOnRails::Controllers::Paginatable
+
+          paginate_by(**opts)
+        end
+      end
+    end
+
+    # `LIMIT -1` means NO LIMIT on SQLite/MySQL, so a negative per_page
+    # silently serialized the whole table on every request.
+    it "rejects a negative per_page" do
+      declare(per_page: -1).to raise_error(ArgumentError, /per_page: must be a positive integer/)
+    end
+
+    it "rejects a zero per_page" do
+      declare(per_page: 0).to raise_error(ArgumentError, /per_page: must be a positive integer/)
+    end
+
+    it "rejects a negative max_per_page" do
+      declare(max_per_page: -5).to raise_error(ArgumentError, /max_per_page: must be a non-negative integer/)
+    end
+
+    it "allows max_per_page: 0 (documented as 'no cap')" do
+      declare(max_per_page: 0).not_to raise_error
+    end
+
+    it "allows ordinary values" do
+      declare(per_page: 10, max_per_page: 100).not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
Two unrelated holes in size/offset handling, both traced to a bare `.to_i`.

1. `pagination_page` clamped only the bottom (`[…, 1].max`), so `page` —
   untrusted input whose only job is to become `(page - 1) * per_page` —
   was unbounded. `?page=99999999999999999999` produced offset
   2499999999999999999950 and an unauthenticated 500 on every index
   action: ActiveRecord::StatementInvalid on the relation branch, and
   `RangeError: bignum too big to convert into 'long'` from Array#[] on
   the in-memory branch. `per_page` was already capped; `page` was not.

   Now clamped to MAX_PAGE (1_000_000). That is far past any real
   offset-paginated dataset, so the page simply comes back empty rather
   than wrapping to page 1 — and anything that deep wants
   CursorPaginatable instead.

2. `paginate_by` validated `window:`, `style:` and the param paths but
   ran `per_page:`/`max_per_page:` through a bare `.to_i`. `LIMIT -1`
   means NO LIMIT on SQLite and MySQL, so `paginate_by per_page: -1`
   silently serialized the entire table on every request, and
   `per_page: 0` made every page permanently empty. Both now raise at
   declaration time, matching how the other options are handled.
   `max_per_page: 0` is still accepted — the docs define it as "no cap".

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)