### PR TITLE
Taggable: drop the inherited ORDER BY from all_tags (PostgreSQL fix)

### DIFF
--- a/lib/concerns_on_rails/models/taggable.rb
+++ b/lib/concerns_on_rails/models/taggable.rb
@@ -75,8 +75,17 @@ module ConcernsOnRails
         # All distinct tags currently stored across the table, sorted.
         # distinct + NULL filter dedupe DB-side, so identical tag strings ship
         # over the wire once instead of once per row.
+        #
+        # reorder(nil) drops any inherited ORDER BY: PostgreSQL rejects
+        # SELECT DISTINCT ordered by a column outside the select list ("for
+        # SELECT DISTINCT, ORDER BY expressions must appear in select list"),
+        # and Models::Sortable installs exactly such a default_scope — so
+        # Taggable + Sortable raised on Postgres while passing on SQLite,
+        # which permits it. The ordering is meaningless here anyway: the
+        # result is sorted in Ruby below.
         def all_tags
           where.not(taggable_field => nil)
+               .reorder(nil)
                .distinct
                .pluck(taggable_field)
                .flat_map { |raw| taggable_split(raw) }

--- a/spec/concerns/models/taggable_spec.rb
+++ b/spec/concerns/models/taggable_spec.rb
@@ -171,6 +171,51 @@ describe ConcernsOnRails::Taggable do
       TagArticle.create!(title: "b", tag_list: "ruby, go")
       expect(TagArticle.all_tags).to eq(%w[go rails ruby])
     end
+
+    context "when the model carries an ordering default_scope" do
+      # SELECT DISTINCT with an ORDER BY on a column that is not in the select
+      # list is a hard error on PostgreSQL ("for SELECT DISTINCT, ORDER BY
+      # expressions must appear in select list"). SQLite permits it, which is
+      # why CI never caught this — and Models::Sortable installs exactly such
+      # a default_scope, so Taggable + Sortable was broken on Postgres.
+      before do
+        class OrderedTagArticle < TestModel
+          include ConcernsOnRails::Taggable
+
+          self.table_name = "tag_articles"
+
+          taggable_by :tags
+          default_scope { order(:title) }
+        end
+      end
+
+      after { Object.send(:remove_const, :OrderedTagArticle) if defined?(OrderedTagArticle) }
+
+      def captured_sql
+        queries = []
+        sub = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+          queries << payload[:sql]
+        end
+        yield
+        queries
+      ensure
+        ActiveSupport::Notifications.unsubscribe(sub)
+      end
+
+      it "does not carry the ORDER BY into the DISTINCT query" do
+        distinct = captured_sql { OrderedTagArticle.all_tags }.grep(/DISTINCT/)
+
+        expect(distinct).not_to be_empty
+        expect(distinct.first).not_to include("ORDER BY")
+      end
+
+      it "still returns the sorted unique tags" do
+        OrderedTagArticle.create!(title: "a", tag_list: "ruby, rails")
+        OrderedTagArticle.create!(title: "b", tag_list: "ruby, go")
+
+        expect(OrderedTagArticle.all_tags).to eq(%w[go rails ruby])
+      end
+    end
   end
 
   context "with downcase: true" do


### PR DESCRIPTION
`all_tags` built `where.not(field => nil).distinct.pluck(field)`. With any
ordering default_scope in play that emits

    SELECT DISTINCT "articles"."tags" FROM "articles"
      WHERE "tags" IS NOT NULL ORDER BY "articles"."position" ASC

which PostgreSQL rejects outright: "for SELECT DISTINCT, ORDER BY
expressions must appear in select list". SQLite permits it, and SQLite is
the only adapter CI runs — so the suite stayed green.

This is not a hypothetical pairing: Models::Sortable installs exactly such
a default_scope, so Taggable + Sortable on one model was broken on
Postgres. Sortable's own comment already warns that a sticky ordering
default_scope "breaks .last, distinct.pluck, window queries etc." — the
fix simply never reached the gem's own distinct.pluck.

reorder(nil) before .distinct. The ordering was meaningless here anyway:
the tags are sorted in Ruby afterwards. This is the only .distinct in
lib/, so the fix is complete.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)