### PR TITLE
Lockable, Stateable: open a savepoint so the documented Rollback abort works

### DIFF
--- a/lib/concerns_on_rails/models/lockable.rb
+++ b/lib/concerns_on_rails/models/lockable.rb
@@ -313,7 +313,15 @@ module ConcernsOnRails
       def lockable_write_with_hooks(previous_values)
         completed = false
         begin
-          transaction do
+          # requires_new: a bare `transaction` JOINS an enclosing one rather
+          # than opening a savepoint, and Rails then swallows
+          # ActiveRecord::Rollback without rolling anything back. Inside a
+          # caller's `ApplicationRecord.transaction { user.lock_access! }`,
+          # a hook raising Rollback left the row locked in the database while
+          # the ensure below restored locked_at = nil in memory and this
+          # method returned false — and the idempotency guard in
+          # lock_access! then made every retry a no-op.
+          transaction(requires_new: true) do
             yield
             completed = true
           end

--- a/lib/concerns_on_rails/models/stateable.rb
+++ b/lib/concerns_on_rails/models/stateable.rb
@@ -225,7 +225,12 @@ module ConcernsOnRails
         raise InvalidTransition, "#{self.class.name}: cannot #{event} from '#{self[field]}'" unless from.empty? || from.include?(current)
 
         result = false
-        transaction do
+        # requires_new: a bare `transaction` JOINS an enclosing one instead of
+        # opening a savepoint, so under a caller's transaction Rails swallowed
+        # an ActiveRecord::Rollback from after_transition and rolled nothing
+        # back — the state change committed and this returned true, exactly
+        # opposite to the documented contract above.
+        transaction(requires_new: true) do
           before_transition(event, current, to)
           result = update!(field => to)
           after_transition(event, current, to)

--- a/spec/concerns/models/lockable_spec.rb
+++ b/spec/concerns/models/lockable_spec.rb
@@ -737,4 +737,55 @@ describe ConcernsOnRails::Lockable do
       expect(HookedAccount.unlocked_ids).to eq([a.id])
     end
   end
+
+  describe "ActiveRecord::Rollback from after_lock" do
+    before do
+      class RollbackAccount < TestModel
+        include ConcernsOnRails::Lockable
+
+        self.table_name = "lock_users"
+
+        lockable_by max_attempts: 3
+
+        def after_lock
+          raise ActiveRecord::Rollback
+        end
+      end
+    end
+
+    after { Object.send(:remove_const, :RollbackAccount) if defined?(RollbackAccount) }
+
+    it "rolls the lock back when called standalone" do
+      u = RollbackAccount.create!(email: "a@b.com")
+
+      expect(u.lock_access!).to be(false)
+      expect(u.reload.locked_at).to be_nil
+    end
+
+    # A bare `transaction` JOINS the caller's, so Rails swallowed the Rollback
+    # and committed the lock — while the ensure restored locked_at = nil in
+    # memory and lock_access! returned false. The DB said locked, the model
+    # said unlocked, and the idempotency guard made every retry a no-op.
+    it "rolls the lock back inside an enclosing transaction" do
+      u = RollbackAccount.create!(email: "a@b.com")
+
+      ActiveRecord::Base.transaction { u.lock_access! }
+
+      expect(u.reload.locked_at).to be_nil
+      expect(u.access_locked?).to be(false)
+    end
+
+    it "leaves the caller's own writes in the enclosing transaction intact" do
+      u = RollbackAccount.create!(email: "a@b.com")
+      other = RollbackAccount.create!(email: "c@d.com")
+
+      ActiveRecord::Base.transaction do
+        other.update!(email: "renamed@b.com")
+        u.lock_access!
+      end
+
+      expect(other.reload.email).to eq("renamed@b.com")
+      expect(u.reload.locked_at).to be_nil
+    end
+  end
 end

--- a/spec/concerns/models/stateable_spec.rb
+++ b/spec/concerns/models/stateable_spec.rb
@@ -368,4 +368,55 @@ describe ConcernsOnRails::Stateable do
       expect(ArchivableOrder.transition_all(:archive)).to eq(0)
     end
   end
+
+  describe "ActiveRecord::Rollback from after_transition" do
+    before do
+      class RollbackTicket < TestModel
+        include ConcernsOnRails::Stateable
+
+        self.table_name = "tickets"
+
+        stateable_by :status, states: %i[draft archived], default: :draft,
+                              transitions: { archive: { to: :archived } }
+
+        def after_transition(*)
+          raise ActiveRecord::Rollback
+        end
+      end
+    end
+
+    after { Object.send(:remove_const, :RollbackTicket) if defined?(RollbackTicket) }
+
+    it "rolls the state change back when called standalone" do
+      t = RollbackTicket.create!(title: "t")
+
+      t.archive!
+
+      expect(t.reload.status).to eq("draft")
+    end
+
+    # A bare `transaction` JOINS the caller's, and Rails then swallows
+    # ActiveRecord::Rollback without rolling anything back — the state change
+    # committed, exactly opposite to the documented contract.
+    it "rolls the state change back inside an enclosing transaction" do
+      t = RollbackTicket.create!(title: "t")
+
+      ActiveRecord::Base.transaction { t.archive! }
+
+      expect(t.reload.status).to eq("draft")
+    end
+
+    it "leaves the caller's own writes in the enclosing transaction intact" do
+      t = RollbackTicket.create!(title: "t")
+      other = RollbackTicket.create!(title: "other")
+
+      ActiveRecord::Base.transaction do
+        other.update!(title: "renamed")
+        t.archive!
+      end
+
+      expect(other.reload.title).to eq("renamed")
+      expect(t.reload.status).to eq("draft")
+    end
+  end
 end


### PR DESCRIPTION
Both concerns wrap their hooks and their write in a bare `transaction`, and
both document that a hook raising ActiveRecord::Rollback aborts the change
(lockable.rb "a hook raising ActiveRecord::Rollback is swallowed by
`transaction`, and the caller must see false"; stateable.rb "a raising
after_transition rolls the state change back").

That holds only at the top level. A bare `transaction` JOINS an enclosing
one instead of opening a savepoint, and Rails then swallows the Rollback
without rolling anything back:

    ApplicationRecord.transaction { user.lock_access! }   # after_lock raises Rollback

The lock COMMITTED. Meanwhile `completed` never became true, so the ensure
restored locked_at = nil in memory and lock_access! returned false — the
database said locked, the model said unlocked, the caller saw failure, and
the idempotency guard in lock_access! made every retry a no-op. Stateable
had the mirror image: the state change committed and the event returned
true, exactly opposite to its documented contract.

`transaction(requires_new: true)` in both places. The caller's own writes
in the enclosing transaction are unaffected — covered by a spec each.

Verified the new specs fail (4) against the old code and pass against the
new.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)