### PR TITLE
Encryptable: stop <field>_ciphertext from returning plaintext

### DIFF
--- a/lib/concerns_on_rails/models/encryptable.rb
+++ b/lib/concerns_on_rails/models/encryptable.rb
@@ -271,11 +271,34 @@ module ConcernsOnRails
         end
 
         def encryptable_define_helpers(field)
-          # Raw stored value: the DB ciphertext once persisted (before the type
-          # deserializes it). Useful for migrations, debugging, and asserting no
-          # plaintext is at rest.
-          define_method("#{field}_ciphertext") { read_attribute_before_type_cast(field) }
-          define_method("#{field}_encrypted?") { read_attribute_before_type_cast(field).present? }
+          # The value AT REST — the column's stored content, before the type
+          # deserializes it. Useful for migrations, debugging, and asserting no
+          # plaintext is at rest. nil while the field carries an unsaved change.
+          #
+          # That last clause is the fix: this used to return
+          # read_attribute_before_type_cast unconditionally, and for a column
+          # overridden with `attribute` that is the caller's PLAINTEXT whenever
+          # the value has not round-tripped through the database — a new record,
+          # or any record with a pending assignment (i.e. exactly the state
+          # inside a before_save, a validator, or an error-reporting path). A
+          # reader named `_ciphertext`, documented for "asserting no plaintext
+          # is at rest", handed back the SSN, so `log.info(user.ssn_ciphertext)`
+          # wrote it straight to the log.
+          define_method("#{field}_ciphertext") do
+            next nil if new_record? || public_send("#{field}_changed?")
+
+            read_attribute_before_type_cast(field)
+          end
+
+          # True only when what is stored really is an encryption envelope. The
+          # old `.present?` was true for plaintext too, so the natural guard
+          # `raise unless user.ssn_encrypted?` passed on a record whose column
+          # held the raw value. Note this is honestly false under
+          # `on_missing_key: :passthrough`, where plaintext at rest is the
+          # opted-into behavior.
+          define_method("#{field}_encrypted?") do
+            ConcernsOnRails::Support::Encryptor.envelope?(public_send("#{field}_ciphertext"))
+          end
         end
 
         # find_by_<field> / where_<field> / <field>_fingerprint for equality

--- a/lib/concerns_on_rails/support/encryptor.rb
+++ b/lib/concerns_on_rails/support/encryptor.rb
@@ -85,6 +85,29 @@ module ConcernsOnRails
               "could not decrypt value (wrong key or tampered ciphertext)"
       end
 
+      # True when `value` really is an envelope produced by #encrypt: strict
+      # Base64 decoding to at least header + IV + tag, carrying a version byte
+      # we recognize. Deliberately does NOT check the algorithm byte, so a
+      # future alg (0x11, deterministic) still reads as an envelope.
+      #
+      # Backs Encryptable#<field>_encrypted?, which used a bare `.present?` —
+      # true for plaintext too. Cheap: no key material, no crypto, no KDF.
+      def envelope?(value)
+        return false unless value.is_a?(String)
+
+        # "" for non-Base64 input, which then fails the length check below.
+        raw =
+          begin
+            value.unpack1("m0").to_s
+          rescue ArgumentError
+            ""
+          end
+        return false if raw.bytesize < MIN_ENVELOPE_BYTES
+
+        version, = raw.byteslice(0, HEADER_LEN).unpack(HEADER_FORMAT)
+        version == VERSION_BYTE
+      end
+
       # Deterministic keyed fingerprint (lowercase hex) for equality lookups — a
       # "blind index". The HMAC key is domain-separated from the AES key via
       # BLIND_INDEX_INFO, so the two are cryptographically independent. The same

--- a/spec/concerns/models/encryptable_spec.rb
+++ b/spec/concerns/models/encryptable_spec.rb
@@ -88,6 +88,70 @@ describe ConcernsOnRails::Models::Encryptable do
     end
   end
 
+  describe "#<field>_ciphertext never exposes plaintext" do
+    let(:klass) { model_class { encryptable :ssn } }
+
+    # read_attribute_before_type_cast on an `attribute`-overridden column is
+    # the caller's PLAINTEXT until the value round-trips through the database.
+    # A reader named _ciphertext returning an SSN — while _encrypted? answered
+    # true — put the value straight into any log line that trusted it.
+    it "returns nil (not the plaintext) for an unsaved new record" do
+      record = klass.new(ssn: "111-22-3333")
+
+      expect(record.ssn_ciphertext).to be_nil
+      expect(record.ssn_encrypted?).to be(false)
+    end
+
+    it "returns nil (not the plaintext) for a persisted record with a pending change" do
+      record = klass.create!(ssn: "111-22-3333").reload
+      record.ssn = "999-88-7777"
+
+      expect(record.ssn_ciphertext).to be_nil
+      expect(record.ssn_encrypted?).to be(false)
+    end
+
+    it "returns the envelope once the change is saved" do
+      record = klass.create!(ssn: "111-22-3333").reload
+      record.update!(ssn: "999-88-7777")
+
+      expect(record.ssn_ciphertext).to be_a(String)
+      expect(record.ssn_ciphertext).not_to include("999-88-7777")
+      expect(record.ssn_encrypted?).to be(true)
+    end
+
+    it "is nil for a persisted record whose value was never set" do
+      record = klass.create!.reload
+
+      expect(record.ssn_ciphertext).to be_nil
+      expect(record.ssn_encrypted?).to be(false)
+    end
+
+    it "reports encrypted? false when the column holds plaintext rather than an envelope" do
+      record = klass.create!(ssn: "111-22-3333")
+      klass.connection.execute(
+        "UPDATE encryptable_records SET ssn = 'not-an-envelope' WHERE id = #{record.id}"
+      )
+
+      expect(klass.find(record.id).ssn_encrypted?).to be(false)
+    end
+  end
+
+  describe "Support::Encryptor.envelope?" do
+    it "recognizes its own output and rejects everything else" do
+      envelope = ConcernsOnRails::Support::Encryptor.encrypt("x", key: "a" * 64)
+
+      expect(ConcernsOnRails::Support::Encryptor.envelope?(envelope)).to be(true)
+      expect(ConcernsOnRails::Support::Encryptor.envelope?("123-45-6789")).to be(false)
+      expect(ConcernsOnRails::Support::Encryptor.envelope?("not base64 !!")).to be(false)
+      expect(ConcernsOnRails::Support::Encryptor.envelope?(["short"].pack("m0"))).to be(false)
+      # valid Base64, right length, but an unknown version byte
+      bogus = [[0xFF].pack("C") + ("\0" * 40)].pack("m0")
+      expect(ConcernsOnRails::Support::Encryptor.envelope?(bogus)).to be(false)
+      expect(ConcernsOnRails::Support::Encryptor.envelope?(nil)).to be(false)
+      expect(ConcernsOnRails::Support::Encryptor.envelope?(42)).to be(false)
+    end
+  end
+
   describe "dirty tracking (on plaintext)" do
     let(:klass) { model_class { encryptable :ssn } }
 


### PR DESCRIPTION
Both readers were `read_attribute_before_type_cast(field)`. On a column
overridden with `attribute`, that is the caller's PLAINTEXT for as long as
the value has not round-tripped through the database:

    r = Patient.new(ssn: "111-22-3333")
    r.ssn_ciphertext   # => "111-22-3333"   <- plaintext
    r.ssn_encrypted?   # => true

    r = Patient.first; r.ssn = "999-88-7777"
    r.ssn_ciphertext   # => "999-88-7777"   <- plaintext

So it was not only new records: ANY pending assignment leaked, which is
exactly the state inside a before_save, a validator, or an error-reporting
path. The docstring sells these for "asserting no plaintext is at rest"
and the name invites logging them, so `log.info(user.ssn_ciphertext)` wrote
the SSN to the log and `raise unless user.ssn_encrypted?` passed anyway.

_ciphertext now means what it says — the value AT REST — and is nil while
the field carries an unsaved change. _encrypted? tests that the stored
value really is an envelope (new Support::Encryptor.envelope?: strict
Base64, minimum length, known version byte, no key material and no crypto)
rather than a bare .present?, which was true for plaintext too. It reads
honestly false under on_missing_key: :passthrough, where plaintext at rest
is the opted-into behavior.

Every pre-existing _ciphertext expectation asserts on a reloaded record, so
all of them still hold, passthrough included.

Verified the new specs fail (3) against the old code and pass against the new.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)