### PR TITLE
Deprecatable: use getutc so a caller's Time is not mutated

### DIFF
--- a/lib/concerns_on_rails/controllers/deprecatable.rb
+++ b/lib/concerns_on_rails/controllers/deprecatable.rb
@@ -141,8 +141,15 @@ module ConcernsOnRails
           # Module#=== checks the real ancestry, so `when Time` alone would
           # miss it — and Time.current / 1.month.from_now are exactly the
           # values Rails hosts pass.
-          when ActiveSupport::TimeWithZone, Time then value.utc
-          when DateTime then value.to_time.utc
+          # getutc, NOT utc: Time#utc is an alias of #gmtime, which converts the
+          # receiver IN PLACE and returns self. A host passing a frozen
+          # constant (SUNSET = Time.new(...).freeze) got a FrozenError while
+          # the controller class body was still loading — the app would not
+          # boot — and an unfrozen Time was silently rewritten to UTC behind
+          # the caller's back. TimeWithZone#utc is a harmless reader, but
+          # getutc is correct for both, so the branch stays single.
+          when ActiveSupport::TimeWithZone, Time then value.getutc
+          when DateTime then value.to_time.getutc
           when Date then Time.utc(value.year, value.month, value.day)
           when String then parse_deprecation_string(value)
           end

--- a/spec/concerns/controllers/deprecatable_spec.rb
+++ b/spec/concerns/controllers/deprecatable_spec.rb
@@ -524,4 +524,48 @@ describe ConcernsOnRails::Controllers::Deprecatable do
       )
     end
   end
+
+  describe "caller-supplied Time objects are not mutated" do
+    # Time#utc is an alias of #gmtime: it converts the receiver IN PLACE and
+    # returns self. The macro runs while the controller class body loads, so a
+    # frozen constant took the whole app down at boot.
+    let(:tokyo) { Time.new(2026, 12, 31, 0, 0, 0, "+09:00") }
+    let(:announced) { Time.new(2026, 6, 1, 0, 0, 0, "+09:00") }
+
+    it "accepts frozen Times without raising" do
+      sunset = tokyo.freeze
+      from = announced.freeze
+
+      expect do
+        deprecatable_class { deprecate_actions :index, deprecated_at: from, sunset_at: sunset }
+      end.not_to raise_error
+    end
+
+    it "leaves an unfrozen Time's zone alone" do
+      sunset = tokyo
+      from = announced
+      deprecatable_class { deprecate_actions :index, deprecated_at: from, sunset_at: sunset }
+
+      expect(sunset.utc_offset).to eq(9 * 3600)
+      expect(from.utc_offset).to eq(9 * 3600)
+    end
+
+    it "still emits the correct Sunset instant" do
+      sunset = tokyo
+      from = announced
+      c = instance(deprecatable_class { deprecate_actions :index, deprecated_at: from, sunset_at: sunset })
+      c.apply_api_deprecations
+
+      expect(c.response.headers["Sunset"]).to eq(tokyo.getutc.httpdate)
+    end
+
+    it "accepts a frozen DateTime too" do
+      sunset = DateTime.new(2026, 12, 31, 0, 0, 0, "+09:00").freeze
+      from = announced.freeze
+
+      expect do
+        deprecatable_class { deprecate_actions :index, deprecated_at: from, sunset_at: sunset }
+      end.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
`Time#utc` is an alias of `#gmtime`: it converts the receiver IN PLACE and
returns self. parse_deprecation_time called it on the value the host passed
to `deprecate_actions`, which runs while the controller class body loads:

    SUNSET = Time.new(2026, 12, 31, 0, 0, 0, "+09:00").freeze
    deprecate_actions :index, deprecated_at: ANNOUNCED, sunset_at: SUNSET
    # => FrozenError: can't modify frozen Time — at class-load. The app
    #    does not boot.

With an unfrozen Time there is no error, just a silent rewrite: the host's
own object comes back converted to UTC, its zone changed underneath it.

`getutc` instead, on both the Time and DateTime branches.
ActiveSupport::TimeWithZone#utc is a harmless reader rather than gmtime, but
getutc is correct for it too, so the branch stays single.

Verified the new specs fail (3) against the old code and pass against the new.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)