### PR TITLE
Filterable: treat boolean false as a value, not an absent filter

### DIFF
--- a/lib/concerns_on_rails/controllers/filterable.rb
+++ b/lib/concerns_on_rails/controllers/filterable.rb
@@ -42,12 +42,12 @@ module ConcernsOnRails
         end
       end
 
-      # Apply all declared filters to a relation based on params. Blank values
-      # are skipped so unset filters don't narrow the relation.
+      # Apply all declared filters to a relation based on params. Unset values
+      # are skipped so absent filters don't narrow the relation.
       def filtered(relation)
         self.class.filterable_rules.each do |field, options|
           value = params[field]
-          next if value.blank?
+          next if filterable_unset?(value)
 
           relation = apply_filter(relation, field, value, options)
         end
@@ -55,6 +55,19 @@ module ConcernsOnRails
       end
 
       private
+
+      # NOT `value.blank?`: `false.blank?` is true, so a genuine boolean false
+      # read as "filter not supplied" and the relation came back UNFILTERED —
+      # `filter_by :active` could never select the inactive rows. Query strings
+      # were unaffected (they carry the String "false", which is not blank), so
+      # this only bit JSON request bodies, where the value really is `false`.
+      # Everything actually empty — nil, "", "   ", [], {} — is still skipped.
+      def filterable_unset?(value)
+        return false if value == false
+        return true if value.nil?
+
+        value.respond_to?(:blank?) ? value.blank? : false
+      end
 
       def apply_filter(relation, field, value, options)
         if options[:with]

--- a/spec/concerns/controllers/filterable_spec.rb
+++ b/spec/concerns/controllers/filterable_spec.rb
@@ -124,4 +124,50 @@ describe ConcernsOnRails::Controllers::Filterable do
       end.to raise_error(ArgumentError, /pass either :scope or :with, not both/)
     end
   end
+
+  describe "boolean false is a value, not an absent filter" do
+    before do
+      ActiveRecord::Schema.define { add_column :articles, :featured, :boolean }
+      Article.reset_column_information
+      Article.where(title: %w[A B]).update_all(featured: true)
+      Article.where(title: %w[C D]).update_all(featured: false)
+    end
+
+    let(:controller_class) do
+      Class.new(FakeController) do
+        include ConcernsOnRails::Controllers::Filterable
+
+        filter_by :featured
+      end
+    end
+
+    # `false.blank?` is true, so the rule was skipped entirely and the caller
+    # got the UNFILTERED relation — every featured article included. Only JSON
+    # bodies hit this; `?featured=false` carries the String "false".
+    it "filters on a JSON-body boolean false" do
+      titles = controller_class.new(params: { featured: false }).filtered(Article.all).pluck(:title)
+
+      expect(titles).to contain_exactly("C", "D")
+    end
+
+    it "still filters on a boolean true" do
+      titles = controller_class.new(params: { featured: true }).filtered(Article.all).pluck(:title)
+
+      expect(titles).to contain_exactly("A", "B")
+    end
+
+    it "still skips nil, empty strings and empty collections" do
+      [nil, "", "   ", [], {}].each do |unset|
+        titles = controller_class.new(params: { featured: unset }).filtered(Article.all).pluck(:title)
+
+        expect(titles).to contain_exactly("A", "B", "C", "D"), "expected #{unset.inspect} to be skipped"
+      end
+    end
+
+    it "leaves a filter absent from params alone" do
+      titles = controller_class.new(params: {}).filtered(Article.all).pluck(:title)
+
+      expect(titles).to contain_exactly("A", "B", "C", "D")
+    end
+  end
 end


### PR DESCRIPTION
`filtered` skipped a rule on `value.blank?`, and `false.blank?` is true. So
with `filter_by :active`, a request body of

    {"active": false}

skipped the rule entirely and returned the UNFILTERED relation — every
active record included — instead of `where(active: false)`. There was no way
to express the negative side of a boolean filter at all.

Query strings never hit this: `?active=false` carries the String "false",
which is not blank. It only bit JSON APIs, where the value really is the
boolean.

Replaces the blank? check with an explicit unset test: `false` is a value,
nil is unset, and everything genuinely empty (nil, "", "   ", [], {}) is
still skipped, so no existing filter changes behavior.

Verified the new spec fails against the old code and passes against the new.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)