### PR TITLE
Stateable: transition_all no longer skips NULL-state rows

### DIFF
--- a/lib/concerns_on_rails/models/stateable.rb
+++ b/lib/concerns_on_rails/models/stateable.rb
@@ -113,7 +113,15 @@ module ConcernsOnRails
           method_base = stateable_method_name(name)
 
           eligible = from.empty? ? all : all.where(field => from)
-          eligible = eligible.where.not(field => to)
+          # NULL-safe: `where.not(field => to)` compiles to `NOT (state = 'x')`,
+          # which SQL three-valued logic evaluates to NULL — never TRUE — for a
+          # NULL state, so those rows were silently dropped from the batch and
+          # from the returned count. They ARE eligible: a transition with no
+          # `from:` is documented as allowed from any state, `may_<event>?`
+          # returns true for them, and `record.<event>!` on the same row
+          # succeeds. A NULL state is reachable through an imported row,
+          # insert_all, or the documented `create!(status: nil)`.
+          eligible = eligible.where(arel_table[field].not_eq(to).or(arel_table[field].eq(nil)))
 
           ConcernsOnRails::Support::BatchOps.run(
             eligible,

--- a/spec/concerns/models/stateable_spec.rb
+++ b/spec/concerns/models/stateable_spec.rb
@@ -367,5 +367,40 @@ describe ConcernsOnRails::Stateable do
       expect(ArchivableOrder.transition_all(:archive)).to eq(2)
       expect(ArchivableOrder.transition_all(:archive)).to eq(0)
     end
+
+    # `where.not(status: "archived")` compiles to NOT (status = 'archived'),
+    # which is NULL — never TRUE — for a NULL state, so those rows were
+    # silently skipped and left out of the count, even though may_archive? is
+    # true for them and record.archive! on the same row works.
+    context "with NULL-state rows and a transition declared without :from" do
+      before do
+        stub_const("NullableOrder", Class.new(TestModel) do
+          self.table_name = "batch_orders"
+          include ConcernsOnRails::Stateable
+
+          stateable_by :status, states: %i[draft archived],
+                                transitions: { archive: { to: :archived } }
+        end)
+        NullableOrder.create!(status: "draft")
+        NullableOrder.insert_all([{ status: nil }]) # legacy / imported row
+      end
+
+      it "includes them in the batch" do
+        expect(NullableOrder.transition_all(:archive)).to eq(2)
+        expect(NullableOrder.where(status: "archived").count).to eq(2)
+      end
+
+      it "agrees with the per-record path, which already accepted them" do
+        null_row = NullableOrder.find_by(status: nil)
+
+        expect(null_row.may_archive?).to be(true)
+      end
+
+      it "is still idempotent afterwards" do
+        NullableOrder.transition_all(:archive)
+
+        expect(NullableOrder.transition_all(:archive)).to eq(0)
+      end
+    end
   end
 end


### PR DESCRIPTION
For a transition declared without `from:` — documented as "allowed from any
state" — the eligibility filter was

    eligible.where.not(field => to)

which compiles to `NOT (status = 'archived')`. Under SQL three-valued logic
that is NULL, never TRUE, for a row whose state column is NULL, so those
rows were silently excluded from the batch AND from the returned count.

They are genuinely eligible: `may_archive?` returns true for them and
`record.archive!` on the same row succeeds. The batch verb and the
per-record path disagreed. A NULL state is reachable through an imported or
legacy row, insert_all, or `create!(status: nil)` — which stateable.rb
explicitly documents as keeping the explicit nil.

Now `status <> 'archived' OR status IS NULL`, via Arel so it stays portable.
Idempotency is unchanged: once archived, the rows stop matching.

Verified the new spec fails against the old code and passes against the new.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)